### PR TITLE
feat: generalize atomic-write across persistence stores + schema versioning

### DIFF
--- a/backend/src/__tests__/workspace-store.test.ts
+++ b/backend/src/__tests__/workspace-store.test.ts
@@ -336,10 +336,11 @@ describe('WorkspaceStore', () => {
                 store.deleteWorkspace(dir);
             }
 
-            // Read the raw config to check the internal limit
+            // Read the raw config to check the internal limit.
+            // File is now a versioned envelope: { schemaVersion, data: { ... } }
             const configPath = join(testBaseDir, 'workspace-config.json');
             const configData = JSON.parse(readFileSync(configPath, 'utf-8'));
-            expect(configData.recentWorkspaces.length).toBeLessThanOrEqual(10);
+            expect(configData.data.recentWorkspaces.length).toBeLessThanOrEqual(10);
         });
     });
 

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -1,13 +1,17 @@
 /**
  * Config Store - Manages application configuration (MCP servers, CLI switches)
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { BackendType } from './backends/types.js';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+/** Schema version for config.json. Bump when the AppConfig shape changes. */
+const CONFIG_SCHEMA_VERSION = 1;
 
 export interface MCPServerConfig {
     name: string;
@@ -152,59 +156,58 @@ export class ConfigStore {
         this.config = this.loadConfig();
     }
 
+    /** Apply defaults to a partial config. Used after load to guarantee every field. */
+    private normalize(loaded: Partial<AppConfig>): AppConfig {
+        return {
+            // Use defaults if mcpServers is undefined or empty array
+            mcpServers: (loaded.mcpServers && loaded.mcpServers.length > 0) ? loaded.mcpServers : DEFAULT_MCP_SERVERS,
+            skipPermissions: loaded.skipPermissions ?? false,
+            rules: loaded.rules ?? '',
+            supervisorEnabled: loaded.supervisorEnabled ?? false,
+            supervisorSystemPrompt: loaded.supervisorSystemPrompt ?? DEFAULT_SUPERVISOR_PROMPT,
+            autoFocusOnInput: loaded.autoFocusOnInput ?? false,
+            apiMode: loaded.apiMode ?? 'default',
+            customAnthropicApiKey: loaded.customAnthropicApiKey,
+            deepgramApiKey: loaded.deepgramApiKey,
+            backend: loaded.backend ?? 'claude-code',
+            opencodePort: loaded.opencodePort ?? 4096,
+            useLearnings: loaded.useLearnings ?? false,
+            claudeCodeSwitches: {
+                ...DEFAULT_CLAUDE_CODE_SWITCHES,
+                ...(loaded.claudeCodeSwitches || {})
+            },
+            hyperspaceProxy: loaded.hyperspaceProxy ?? DEFAULT_HYPERSPACE_PROXY,
+            aiCoreCredentials: loaded.aiCoreCredentials,
+            enabledPlugins: loaded.enabledPlugins ?? [],
+            claudiaMcpServerEnabled: loaded.claudiaMcpServerEnabled ?? true
+        };
+    }
+
+    private defaultConfig(): AppConfig {
+        return this.normalize({});
+    }
+
     private loadConfig(): AppConfig {
         try {
-            if (existsSync(this.configFile)) {
-                const data = readFileSync(this.configFile, 'utf-8');
-                const loaded = JSON.parse(data) as Partial<AppConfig>;
-                return {
-                    // Use defaults if mcpServers is undefined or empty array
-                    mcpServers: (loaded.mcpServers && loaded.mcpServers.length > 0) ? loaded.mcpServers : DEFAULT_MCP_SERVERS,
-                    skipPermissions: loaded.skipPermissions ?? false,
-                    rules: loaded.rules ?? '',
-                    supervisorEnabled: loaded.supervisorEnabled ?? false,
-                    supervisorSystemPrompt: loaded.supervisorSystemPrompt ?? DEFAULT_SUPERVISOR_PROMPT,
-                    autoFocusOnInput: loaded.autoFocusOnInput ?? false,
-                    apiMode: loaded.apiMode ?? 'default',
-                    customAnthropicApiKey: loaded.customAnthropicApiKey,
-                    deepgramApiKey: loaded.deepgramApiKey,
-                    backend: loaded.backend ?? 'claude-code',
-                    opencodePort: loaded.opencodePort ?? 4096,
-                    useLearnings: loaded.useLearnings ?? false,
-                    claudeCodeSwitches: {
-                        ...DEFAULT_CLAUDE_CODE_SWITCHES,
-                        ...(loaded.claudeCodeSwitches || {})
-                    },
-                    hyperspaceProxy: loaded.hyperspaceProxy ?? DEFAULT_HYPERSPACE_PROXY,
-                    aiCoreCredentials: loaded.aiCoreCredentials,
-                    enabledPlugins: loaded.enabledPlugins ?? [],
-                    claudiaMcpServerEnabled: loaded.claudiaMcpServerEnabled ?? true
-                };
-            }
+            // loadVersioned handles: missing file → defaultData; legacy unversioned
+            // file → legacyLoader; future versioned files → migrations (none yet).
+            // We run normalize() over the result so newly-added fields always have
+            // a default, regardless of the on-disk version.
+            const data = loadVersioned<Partial<AppConfig>>(this.configFile, {
+                currentVersion: CONFIG_SCHEMA_VERSION,
+                defaultData: this.defaultConfig(),
+                legacyLoader: (raw) => raw as Partial<AppConfig>,
+            });
+            return this.normalize(data);
         } catch (error) {
             console.error('[ConfigStore] Error loading config:', error);
+            return this.defaultConfig();
         }
-        return {
-            mcpServers: [...DEFAULT_MCP_SERVERS],
-            skipPermissions: false,
-            rules: '',
-            supervisorEnabled: false,
-            supervisorSystemPrompt: DEFAULT_SUPERVISOR_PROMPT,
-            autoFocusOnInput: false,
-            apiMode: 'default',
-            backend: 'claude-code',
-            opencodePort: 4096,
-            useLearnings: false,
-            claudeCodeSwitches: { ...DEFAULT_CLAUDE_CODE_SWITCHES },
-            hyperspaceProxy: { ...DEFAULT_HYPERSPACE_PROXY },
-            enabledPlugins: [],
-            claudiaMcpServerEnabled: true
-        };
     }
 
     private saveConfig(): void {
         try {
-            writeFileSync(this.configFile, JSON.stringify(this.config, null, 2), 'utf-8');
+            saveVersioned(this.configFile, this.config, CONFIG_SCHEMA_VERSION);
             console.log('[ConfigStore] Config saved to', this.configFile);
         } catch (error) {
             console.error('[ConfigStore] Error saving config:', error);

--- a/backend/src/cron-scheduler.ts
+++ b/backend/src/cron-scheduler.ts
@@ -15,10 +15,11 @@
 
 import { EventEmitter } from 'events';
 import { ScheduledTask } from '@claudia/shared';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createLogger } from './logger.js';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
 
 const logger = createLogger('[CronScheduler]');
 
@@ -30,6 +31,9 @@ const MAX_SCHEDULED_TASKS_PER_TASK = 50;
 const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 const CHECK_INTERVAL_MS = 1000; // Check every second
 const PERSISTENCE_PATH = join(__dirname, '..', 'scheduled-tasks.json');
+
+/** Schema version for scheduled-tasks.json. Bump when ScheduledTask shape changes. */
+const CRON_SCHEMA_VERSION = 1;
 
 /**
  * Generate an 8-character random ID for scheduled tasks
@@ -610,7 +614,7 @@ export class CronScheduler extends EventEmitter {
     private save(): void {
         try {
             const data = Array.from(this.scheduledTasks.values());
-            writeFileSync(PERSISTENCE_PATH, JSON.stringify(data, null, 2), 'utf8');
+            saveVersioned(PERSISTENCE_PATH, data, CRON_SCHEMA_VERSION);
             logger.debug('Saved scheduled tasks', { count: data.length });
         } catch (error) {
             logger.error('Failed to save scheduled tasks', { error });
@@ -624,8 +628,12 @@ export class CronScheduler extends EventEmitter {
         try {
             if (!existsSync(PERSISTENCE_PATH)) return;
 
-            const raw = readFileSync(PERSISTENCE_PATH, 'utf8');
-            const data: ScheduledTask[] = JSON.parse(raw);
+            const data = loadVersioned<ScheduledTask[]>(PERSISTENCE_PATH, {
+                currentVersion: CRON_SCHEMA_VERSION,
+                defaultData: [],
+                // Legacy format was a bare ScheduledTask[] — pass through.
+                legacyLoader: (raw) => (Array.isArray(raw) ? (raw as ScheduledTask[]) : []),
+            });
 
             for (const task of data) {
                 try {

--- a/backend/src/learnings-store.ts
+++ b/backend/src/learnings-store.ts
@@ -5,14 +5,18 @@
  * Stores learnings with title, content, and embeddings for semantic search.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { ConfigStore } from './config-store.js';
 import { PORTS } from '@claudia/shared';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+/** Schema version for learnings.json. Bump when LearningsData shape changes. */
+const LEARNINGS_SCHEMA_VERSION = 1;
 
 /**
  * A single learning entry
@@ -70,14 +74,17 @@ export class LearningsStore {
 
     private loadData(): LearningsData {
         try {
-            if (existsSync(this.storagePath)) {
-                const raw = readFileSync(this.storagePath, 'utf-8');
-                return JSON.parse(raw);
-            }
+            return loadVersioned<LearningsData>(this.storagePath, {
+                currentVersion: LEARNINGS_SCHEMA_VERSION,
+                defaultData: { learnings: [], version: 1 },
+                // Legacy format (pre-envelope) was already { learnings, version }.
+                // Pass through unchanged.
+                legacyLoader: (raw) => (raw as LearningsData) ?? { learnings: [], version: 1 },
+            });
         } catch (error) {
             console.error('[LearningsStore] Failed to load data:', error);
+            return { learnings: [], version: 1 };
         }
-        return { learnings: [], version: 1 };
     }
 
     private saveData(): void {
@@ -86,7 +93,7 @@ export class LearningsStore {
             if (!existsSync(dir)) {
                 mkdirSync(dir, { recursive: true });
             }
-            writeFileSync(this.storagePath, JSON.stringify(this.data, null, 2));
+            saveVersioned(this.storagePath, this.data, LEARNINGS_SCHEMA_VERSION);
         } catch (error) {
             console.error('[LearningsStore] Failed to save data:', error);
         }

--- a/backend/src/task-persistence.ts
+++ b/backend/src/task-persistence.ts
@@ -5,9 +5,14 @@
  * Manages task history files and archived task storage.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, statSync, openSync, readSync, closeSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, unlinkSync, statSync, openSync, readSync, closeSync } from 'fs';
 import { dirname, join } from 'path';
 import { TaskState, TaskGitState } from '@claudia/shared';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
+
+/** Schema version for tasks.json. Bump when TaskPersistence shape changes. */
+const TASKS_SCHEMA_VERSION = 1;
 
 /**
  * Persisted task data (no process, just metadata)
@@ -132,8 +137,19 @@ export class TaskPersistenceManager {
                 return result;
             }
 
-            const data = readFileSync(this.persistencePath, 'utf-8');
-            const persistence = JSON.parse(data) as { tasks: PersistedTask[]; archivedTasks?: any[] };
+            const persistence = loadVersioned<{ tasks: PersistedTask[]; archivedTasks?: any[] }>(
+                this.persistencePath,
+                {
+                    currentVersion: TASKS_SCHEMA_VERSION,
+                    defaultData: { tasks: [], archivedTasks: [] },
+                    // Legacy format was the raw TaskPersistence object; pass through.
+                    legacyLoader: (raw) =>
+                        (raw as { tasks: PersistedTask[]; archivedTasks?: any[] }) ?? {
+                            tasks: [],
+                            archivedTasks: [],
+                        },
+                }
+            );
             console.log(`[TaskPersistence] Loading ${persistence.tasks.length} persisted tasks`);
 
             this.ensureHistoryDir();
@@ -143,7 +159,7 @@ export class TaskPersistenceManager {
                 // MIGRATION: If task has outputHistory string, move it to file
                 if (persisted.outputHistory && typeof persisted.outputHistory === 'string') {
                     try {
-                        writeFileSync(this.getTaskHistoryPath(persisted.id), persisted.outputHistory);
+                        atomicWriteFileSync(this.getTaskHistoryPath(persisted.id), persisted.outputHistory);
                         if (process.env.DEBUG_TASKS) {
                             console.log(`[TaskPersistence] Migrated history for task ${persisted.id} to file`);
                         }
@@ -168,7 +184,7 @@ export class TaskPersistenceManager {
                     if (archived.outputHistory && typeof archived.outputHistory === 'string') {
                         this.ensureArchivedHistoryDir();
                         try {
-                            writeFileSync(this.getArchivedHistoryPath(archived.id), archived.outputHistory);
+                            atomicWriteFileSync(this.getArchivedHistoryPath(archived.id), archived.outputHistory);
                             result.migratedCount++;
                         } catch (e) {
                             console.error(`[TaskPersistence] Failed to migrate history for ${archived.id}:`, e);
@@ -221,7 +237,7 @@ export class TaskPersistenceManager {
                 mkdirSync(dir, { recursive: true });
             }
 
-            writeFileSync(this.persistencePath, JSON.stringify(persistence, null, 2));
+            saveVersioned(this.persistencePath, persistence, TASKS_SCHEMA_VERSION);
             console.log(`[TaskPersistence] Saved ${tasks.length} tasks, ${archivedTasks.length} archived (metadata only)`);
         } catch (error) {
             console.error('[TaskPersistence] Failed to save tasks:', error);
@@ -264,7 +280,7 @@ export class TaskPersistenceManager {
 
             if (parts.length > 0 || !existsSync(historyPath)) {
                 const fullHistory = Buffer.concat(parts);
-                writeFileSync(historyPath, fullHistory.toString('base64'));
+                atomicWriteFileSync(historyPath, fullHistory.toString('base64'));
             }
         } catch (e) {
             console.error(`[TaskPersistence] Failed to save history for task ${taskId}:`, e);
@@ -326,7 +342,7 @@ export class TaskPersistenceManager {
     saveArchivedHistory(taskId: string, base64Content: string): void {
         this.ensureArchivedHistoryDir();
         try {
-            writeFileSync(this.getArchivedHistoryPath(taskId), base64Content);
+            atomicWriteFileSync(this.getArchivedHistoryPath(taskId), base64Content);
         } catch (e) {
             console.error(`[TaskPersistence] Failed to save archived history for ${taskId}:`, e);
         }

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -3,9 +3,10 @@ import { EventEmitter } from 'events';
 import { Task, TaskState, TaskGitState, WaitingInputType, BackendType, PORTS } from '@claudia/shared';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, appendFileSync, statSync, openSync, readSync, closeSync, renameSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, appendFileSync, statSync, openSync, readSync, closeSync } from 'fs';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { ConfigStore, ClaudeCodeSwitches } from './config-store.js';
 import { captureGitStateBefore, captureGitStateAfter, revertTaskChanges } from './git-utils.js';
 import { sanitizePrompt } from './validation.js';
@@ -558,7 +559,7 @@ export class TaskSpawner extends EventEmitter {
             // Write .mcp.json
             const workspaceMcpFile = `${workspaceId}/.mcp.json`;
             try {
-                writeFileSync(workspaceMcpFile, mcpConfigJson);
+                atomicWriteFileSync(workspaceMcpFile, mcpConfigJson);
                 logger.info('Synced .mcp.json', { workspaceId });
             } catch (err) {
                 logger.error('Failed to write .mcp.json', { workspaceId, error: err });
@@ -571,7 +572,7 @@ export class TaskSpawner extends EventEmitter {
                 if (!existsSync(claudeSettingsDir)) {
                     mkdirSync(claudeSettingsDir, { recursive: true });
                 }
-                writeFileSync(claudeSettingsFile, JSON.stringify(settingsContent, null, 2));
+                atomicWriteFileSync(claudeSettingsFile, JSON.stringify(settingsContent, null, 2));
                 logger.info('Synced settings.local.json', { workspaceId });
             } catch (err) {
                 logger.error('Failed to write settings.local.json', { workspaceId, error: err });
@@ -935,7 +936,7 @@ export class TaskSpawner extends EventEmitter {
                                 `[TaskSpawner] Main file is ${mainState} but backup has ${bakTotal} tasks — ` +
                                 `restoring from ${bakPath}`
                             );
-                            writeFileSync(this.persistencePath, bakRaw);
+                            atomicWriteFileSync(this.persistencePath, bakRaw);
                         }
                     } catch (_e) {
                         // Backup also corrupt; fall through to normal load.
@@ -973,7 +974,7 @@ export class TaskSpawner extends EventEmitter {
                             if (contentToWrite.includes('\x1b') || contentToWrite.includes(' ')) {
                                 contentToWrite = Buffer.from(contentToWrite, 'utf8').toString('base64');
                             }
-                            writeFileSync(this.getTaskHistoryPath(persisted.id), contentToWrite);
+                            atomicWriteFileSync(this.getTaskHistoryPath(persisted.id), contentToWrite);
                             if (process.env.DEBUG_TASKS) {
                                 console.log(`[TaskSpawner] Migrated history for task ${persisted.id} to file`);
                             }
@@ -1014,7 +1015,7 @@ export class TaskSpawner extends EventEmitter {
                                 if (contentToWrite.includes('\x1b') || contentToWrite.includes(' ')) {
                                     contentToWrite = Buffer.from(contentToWrite, 'utf8').toString('base64');
                                 }
-                                writeFileSync(this.getArchivedHistoryPath(archived.id), contentToWrite);
+                                atomicWriteFileSync(this.getArchivedHistoryPath(archived.id), contentToWrite);
                                 migratedCount++;
                             } catch (e) {
                                 console.error(`[TaskSpawner] Failed to migrate history for ${archived.id}:`, e);
@@ -1096,17 +1097,20 @@ export class TaskSpawner extends EventEmitter {
                             buffers.push(...task.outputHistory);
                         }
                         const fullHistory = Buffer.concat(buffers);
-                        writeFileSync(historyPath, fullHistory.toString('utf8'));
+                        atomicWriteFileSync(historyPath, fullHistory.toString('utf8'));
                         task.savedBufferCount = task.outputHistory.length;
                     } else if (!existsSync(historyPath)) {
                         // New file — write current output as raw text
                         if (task.outputHistory.length > 0) {
                             const fullHistory = Buffer.concat(task.outputHistory);
-                            writeFileSync(historyPath, fullHistory.toString('utf8'));
+                            atomicWriteFileSync(historyPath, fullHistory.toString('utf8'));
                             task.savedBufferCount = task.outputHistory.length;
                         }
                     } else if (task.savedBufferCount < task.outputHistory.length) {
                         // File exists — incrementally append only NEW buffers (O(new) not O(total))
+                        // appendFileSync is kept (not replaced with atomicWriteFileSync) because
+                        // an append is not a full-file replacement; the tmp+rename atomic write
+                        // semantics don't apply to incremental appends.
                         const newBuffers = task.outputHistory.slice(task.savedBufferCount);
                         if (newBuffers.length > 0) {
                             const newData = Buffer.concat(newBuffers).toString('utf8');
@@ -1185,28 +1189,15 @@ export class TaskSpawner extends EventEmitter {
                 }
             }
 
-            // Atomic write: write to a temp file then rename. This ensures tasks.json
-            // is never left in a partial state if the process dies mid-write.
-            // Per-process unique tmp name so concurrent backend instances (e.g. two
-            // tsx watch processes from a stale dev server) don't race on the same .tmp.
-            const tmpPath = `${this.persistencePath}.${process.pid}.tmp`;
-            const bakPath = this.persistencePath + '.bak';
-            writeFileSync(tmpPath, JSON.stringify(persistence, null, 2));
-            try {
-                // Keep a backup of the previous good save before replacing.
-                if (existsSync(this.persistencePath)) {
-                    try {
-                        renameSync(this.persistencePath, bakPath);
-                    } catch (_e) {
-                        // Backup is best-effort; continue with the rename.
-                    }
-                }
-                renameSync(tmpPath, this.persistencePath);
-            } catch (renameErr) {
-                // Clean up our tmp file on failure so we don't leave junk behind.
-                try { if (existsSync(tmpPath)) unlinkSync(tmpPath); } catch (_e) { /* ignore */ }
-                throw renameErr;
-            }
+            // Atomic write with .bak rollover: write to a per-pid temp file, rename the
+            // current file to tasks.json.bak, then rename the temp file into place.
+            // The previous good save is recoverable from .bak if a future load hits
+            // an empty/corrupt main file.
+            atomicWriteFileSync(
+                this.persistencePath,
+                JSON.stringify(persistence, null, 2),
+                { backup: true }
+            );
 
             // Update our tracked modification time after successful save (PR #37 multi-instance guard)
             const newStats = statSync(this.persistencePath);
@@ -1991,7 +1982,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
             // Write to temp file for --mcp-config
             const mcpConfigFile = join(tmpdir(), `claudia-mcp-${id}.json`);
-            writeFileSync(mcpConfigFile, mcpConfigJson);
+            atomicWriteFileSync(mcpConfigFile, mcpConfigJson);
             logger.info(`MCP config written to: ${mcpConfigFile}`);
             logger.debug(`MCP config contents: ${mcpConfigJson}`);
             claudeArgs.push('--mcp-config', mcpConfigFile);
@@ -3071,7 +3062,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                 if (!existsSync(historyDir)) {
                     mkdirSync(historyDir, { recursive: true });
                 }
-                writeFileSync(this.getArchivedHistoryPath(taskId), historyBase64);
+                atomicWriteFileSync(this.getArchivedHistoryPath(taskId), historyBase64);
                 console.log(`[TaskSpawner] Saved archived task history to disk: ${historySize} bytes`);
             } catch (e) {
                 console.error(`[TaskSpawner] Failed to save archived history:`, e);
@@ -3124,7 +3115,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                     if (!existsSync(historyDir)) {
                         mkdirSync(historyDir, { recursive: true });
                     }
-                    writeFileSync(this.getArchivedHistoryPath(taskId), disconnected.outputHistory);
+                    atomicWriteFileSync(this.getArchivedHistoryPath(taskId), disconnected.outputHistory);
                     const historySize = Math.floor(disconnected.outputHistory.length * 0.75);
                     console.log(`[TaskSpawner] Saved disconnected task history to disk: ${historySize} bytes`);
                 } catch (e) {
@@ -3433,7 +3424,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             if (mcpResult) {
                 const mcpConfigJson = JSON.stringify({ mcpServers: mcpResult.mcpConfig }, null, 2);
                 const mcpConfigFile = join(tmpdir(), `claudia-mcp-${taskId}-reconnect.json`);
-                writeFileSync(mcpConfigFile, mcpConfigJson);
+                atomicWriteFileSync(mcpConfigFile, mcpConfigJson);
                 claudeArgs.push('--mcp-config', mcpConfigFile);
                 console.log(`[TaskSpawner] Added ${mcpResult.enabledMcpServers.length} MCP server(s) for reconnection via ${mcpConfigFile}`);
             }

--- a/backend/src/utils/atomic-write.ts
+++ b/backend/src/utils/atomic-write.ts
@@ -1,0 +1,82 @@
+/**
+ * Atomic file write utility.
+ *
+ * Writes to a per-process temporary file first, then renames to the target.
+ * `renameSync` is atomic on POSIX and near-atomic on Windows NTFS, so a
+ * crash mid-write cannot leave the target file in a partial/empty state.
+ *
+ * Optional `.bak` rollover gives callers a one-step recovery point: the
+ * previous good file is renamed to `{filePath}.bak` before the new file
+ * takes its place.
+ */
+
+import { writeFileSync, renameSync, unlinkSync, mkdirSync, existsSync } from 'fs';
+import { dirname } from 'path';
+
+export interface AtomicWriteOptions {
+    /** Text encoding for string payloads. Defaults to 'utf-8'. Ignored for Buffer. */
+    encoding?: BufferEncoding;
+    /**
+     * If true, rename the existing target file to `{filePath}.bak` before placing
+     * the new file. Gives callers a rolling one-step backup for recovery.
+     * Default: false.
+     */
+    backup?: boolean;
+}
+
+/**
+ * Atomically write data to a file.
+ *
+ * Writes to `{filePath}.{pid}.tmp` first, then renames to the target path.
+ * If the write or rename fails, the original file remains intact and the
+ * temp file is cleaned up.
+ *
+ * The per-process tmp filename prevents concurrent backend instances
+ * (e.g. two `tsx watch` processes from a stale dev server) from racing
+ * on the same staging file.
+ */
+export function atomicWriteFileSync(
+    filePath: string,
+    data: string | Buffer,
+    options?: AtomicWriteOptions
+): void {
+    const { encoding, backup = false } = options ?? {};
+
+    const tmpPath = `${filePath}.${process.pid}.tmp`;
+    const bakPath = `${filePath}.bak`;
+    const dir = dirname(filePath);
+
+    // Ensure parent directory exists
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    try {
+        // Write to temp file
+        if (typeof data === 'string') {
+            writeFileSync(tmpPath, data, encoding ?? 'utf-8');
+        } else {
+            writeFileSync(tmpPath, data);
+        }
+
+        // Optional: keep a backup of the previous good file before replacing.
+        if (backup && existsSync(filePath)) {
+            try {
+                renameSync(filePath, bakPath);
+            } catch {
+                // Backup is best-effort; continue with the rename.
+            }
+        }
+
+        // Atomic rename (POSIX) / near-atomic (NTFS)
+        renameSync(tmpPath, filePath);
+    } catch (error) {
+        // Clean up our tmp file on failure so we don't leave junk behind.
+        try {
+            if (existsSync(tmpPath)) unlinkSync(tmpPath);
+        } catch {
+            // Ignore cleanup errors
+        }
+        throw error;
+    }
+}

--- a/backend/src/utils/schema-version.ts
+++ b/backend/src/utils/schema-version.ts
@@ -1,0 +1,110 @@
+/**
+ * Schema versioning utility for JSON persistence files.
+ *
+ * Wraps data in a versioned envelope: `{ schemaVersion: N, data: ... }` so
+ * stores can evolve their on-disk shape without breaking existing files.
+ * A legacy (unversioned) file is treated as version 0 and can be passed
+ * through `legacyLoader` to normalize into the v0 shape before migrations run.
+ *
+ * Writes go through `atomicWriteFileSync` so a crash mid-save can't corrupt
+ * the file.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { atomicWriteFileSync } from './atomic-write.js';
+
+/** Versioned file envelope. */
+export interface VersionedFile<T> {
+    schemaVersion: number;
+    data: T;
+}
+
+/** A migration function that transforms data from version N to N+1. */
+export type Migration<T = unknown> = (data: T) => T;
+
+export interface LoadVersionedOptions<T> {
+    /** Current schema version for this file type. */
+    currentVersion: number;
+    /**
+     * Ordered migrations: `migrations[0]` upgrades v0→v1, `migrations[1]`
+     * upgrades v1→v2, etc.
+     */
+    migrations?: Migration[];
+    /** Default data if file doesn't exist or can't be parsed. */
+    defaultData: T;
+    /**
+     * Legacy loader: if the file exists but has no `schemaVersion` field,
+     * this function extracts the data from the raw parsed JSON. Return the
+     * data in the shape expected by version 0 (pre-versioning).
+     */
+    legacyLoader?: (raw: unknown) => T;
+}
+
+/**
+ * Load a versioned JSON file, running migrations if needed.
+ *
+ * - If the file doesn't exist: returns `defaultData`.
+ * - If the file parses but has no `schemaVersion`: treats it as v0 and
+ *   uses `legacyLoader` to normalize.
+ * - Runs migrations sequentially from the file's version to `currentVersion`.
+ * - Persists the migrated form so the next load is fast.
+ */
+export function loadVersioned<T>(filePath: string, options: LoadVersionedOptions<T>): T {
+    const { currentVersion, migrations = [], defaultData, legacyLoader } = options;
+
+    if (!existsSync(filePath)) {
+        return defaultData;
+    }
+
+    let raw: unknown;
+    try {
+        const content = readFileSync(filePath, 'utf-8');
+        raw = JSON.parse(content);
+    } catch (error) {
+        console.error(`[SchemaVersion] Failed to parse ${filePath}:`, error);
+        return defaultData;
+    }
+
+    let fileVersion: number;
+    let data: T;
+
+    if (raw && typeof raw === 'object' && 'schemaVersion' in raw) {
+        const versioned = raw as VersionedFile<T>;
+        fileVersion = versioned.schemaVersion;
+        data = versioned.data;
+    } else {
+        // Legacy (unversioned) file.
+        fileVersion = 0;
+        data = legacyLoader ? legacyLoader(raw) : (raw as T);
+    }
+
+    if (fileVersion < currentVersion) {
+        for (let v = fileVersion; v < currentVersion; v++) {
+            const migration = migrations[v];
+            if (migration) {
+                try {
+                    data = migration(data) as T;
+                    console.log(`[SchemaVersion] Migrated ${filePath} from v${v} to v${v + 1}`);
+                } catch (error) {
+                    console.error(`[SchemaVersion] Migration v${v}→v${v + 1} failed for ${filePath}:`, error);
+                    // Return what we have so far rather than losing everything.
+                    break;
+                }
+            }
+        }
+
+        saveVersioned(filePath, data, currentVersion);
+        console.log(`[SchemaVersion] Saved migrated ${filePath} at v${currentVersion}`);
+    }
+
+    return data;
+}
+
+/** Save data to a versioned JSON file using atomic writes. */
+export function saveVersioned<T>(filePath: string, data: T, version: number): void {
+    const envelope: VersionedFile<T> = {
+        schemaVersion: version,
+        data,
+    };
+    atomicWriteFileSync(filePath, JSON.stringify(envelope, null, 2));
+}

--- a/backend/src/workspace-store.ts
+++ b/backend/src/workspace-store.ts
@@ -2,14 +2,18 @@
  * Workspace Store - Manages workspace directories
  * Workspaces are simply folder paths - the name comes from the folder name
  */
-import { readFileSync, writeFileSync, existsSync, statSync, mkdirSync } from 'fs';
+import { existsSync, statSync, mkdirSync } from 'fs';
 import { join, dirname, resolve, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { Workspace, RecentWorkspace, WorkspaceReference } from '@claudia/shared';
 import { randomUUID } from 'crypto';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+/** Schema version for workspace-config.json. Bump when WorkspaceConfig shape changes. */
+const WORKSPACE_SCHEMA_VERSION = 1;
 
 // Re-export for convenience
 export type { RecentWorkspace };
@@ -50,31 +54,31 @@ export class WorkspaceStore {
 
     private loadConfig(): WorkspaceConfig {
         try {
-            if (existsSync(this.workspaceFile)) {
-                const data = readFileSync(this.workspaceFile, 'utf-8');
-                const loaded = JSON.parse(data) as WorkspaceConfig;
+            const loaded = loadVersioned<WorkspaceConfig>(this.workspaceFile, {
+                currentVersion: WORKSPACE_SCHEMA_VERSION,
+                defaultData: { ...DEFAULT_CONFIG },
+                // Legacy unversioned format was the raw WorkspaceConfig.
+                legacyLoader: (raw) => (raw as WorkspaceConfig) ?? { ...DEFAULT_CONFIG },
+            });
 
-                // Filter out workspaces that no longer exist
-                loaded.workspaces = (loaded.workspaces || []).filter(w =>
-                    existsSync(w.id)
-                );
+            // Filter out workspaces that no longer exist.
+            loaded.workspaces = (loaded.workspaces || []).filter(w => existsSync(w.id));
 
-                // Initialize recentWorkspaces if not present
-                if (!loaded.recentWorkspaces) {
-                    loaded.recentWorkspaces = [];
-                }
-
-                return loaded;
+            // Initialize recentWorkspaces if not present.
+            if (!loaded.recentWorkspaces) {
+                loaded.recentWorkspaces = [];
             }
+
+            return loaded;
         } catch (error) {
             console.error('[WorkspaceStore] Error loading config:', error);
+            return { ...DEFAULT_CONFIG };
         }
-        return { ...DEFAULT_CONFIG };
     }
 
     private saveConfig(): void {
         try {
-            writeFileSync(this.workspaceFile, JSON.stringify(this.config, null, 2), 'utf-8');
+            saveVersioned(this.workspaceFile, this.config, WORKSPACE_SCHEMA_VERSION);
             console.log('[WorkspaceStore] Config saved to', this.workspaceFile);
         } catch (error) {
             console.error('[WorkspaceStore] Error saving config:', error);


### PR DESCRIPTION
## Summary

Generalizes the per-pid atomic-write pattern that upstream added to `task-spawner.ts` into a shared utility, applies it to every JSON persistence store, and introduces a schema-version envelope so future on-disk shape changes can migrate forward without breaking existing files.

This is purely a persistence-layer hardening. No UI, no API, no new features. Existing files continue to load without any migration step from the user.

## Why

Upstream [#37](https://github.com/extropolis/claudia/pull/37) hardened `tasks.json` against crash-corruption with per-pid temp files, atomic rename, and `.bak` rollover — but only inline, only for that one file. Every other persistence store (`config.json`, `learnings.json`, `scheduled-tasks.json`, `workspace-config.json`, task-history files, archived histories, MCP config scratch files) still used bare `writeFileSync` and could leave partial/empty JSON on disk if the process died mid-write.

This PR extends the same crash-safety guarantees to all of them, without duplicating the implementation.

## Changes

### New utilities

- **`backend/src/utils/atomic-write.ts`** — shared `atomicWriteFileSync()` that owns the per-pid tmp + rename pattern, with an optional `{ backup: true }` flag for one-step `.bak` rollover. Upstream's inline code in `task-spawner.ts` is refactored to call into this.
- **`backend/src/utils/schema-version.ts`** — `{ schemaVersion: N, data: ... }` envelope with `loadVersioned()` + `saveVersioned()`. Supports a `legacyLoader` for files written before the envelope existed (unversioned files are treated as v0 and normalized on first load). Migration functions run sequentially from file version → current version.

### Applied to every persistence store

| File | What changed |
|---|---|
| `task-spawner.ts` | Inline atomic-write block → shared util call. All 13 other `writeFileSync` sites (task history, archived history, MCP configs, workspace `.mcp.json`, `settings.local.json`) → `atomicWriteFileSync`. `appendFileSync` left alone — incremental appends aren't full-file replacements, so tmp+rename doesn't apply. |
| `config-store.ts` | `saveConfig` → `saveVersioned(v1)`. `loadConfig` → `loadVersioned(v1)` with a `legacyLoader` that accepts the current unversioned shape. The per-field default logic is extracted into a `normalize()` helper so newly-added fields always pick up defaults, regardless of the file's on-disk version. |
| `learnings-store.ts` | Same pattern — `loadVersioned` / `saveVersioned` with a legacyLoader that passes through the existing `{ learnings, version }` shape. |
| `cron-scheduler.ts` | Same pattern — legacyLoader accepts the bare `ScheduledTask[]` array. The post-load `isPaused` default and cron-parse loop is unchanged. |
| `workspace-store.ts` | Same pattern. Post-load cleanup (filtering workspaces whose folder no longer exists, defaulting `recentWorkspaces` to `[]`) is preserved. |
| `task-persistence.ts` | Same pattern. Currently unused (no imports) but kept in sync so a future wire-up inherits the same semantics. |

## Design notes

- **Per-process tmp filename** (`${path}.${pid}.tmp`) — matches upstream's #37 pattern so two backend instances (e.g. a stale `tsx watch` + a fresh one) can't race on the same staging file.
- **Optional `.bak` rollover** — only `tasks.json` uses `{ backup: true }` since it's the one-of-a-kind state file. History files, MCP scratch configs, and per-store JSON don't need it.
- **No behavior change on first load** — every store ships with a `legacyLoader` that treats the current on-disk shape as v0 and passes it through unchanged. The first save after this PR rewrites the file in the versioned envelope. No migration step for users.
- **`appendFileSync` preserved** — upstream #38 added an incremental append path for task history that avoids re-encoding the whole file on every tick. That optimization stays; atomic semantics only apply to full-file writes.

## Explicitly out of scope

The following live on a separate branch and are not part of this PR:
- Task recovery from orphaned history files + `/api/tasks/recover` endpoint (a new feature, not persistence hardening)
- `tasks.json.prev` rolling backup (redundant with upstream's `.bak`)
- Session-ID pre-generation via `crypto.randomUUID()` + `--session-id` (not persistence; separate concern)
- Bundled bug fixes (base64 tail-read alignment, duplicate `HyperspaceProxyConfig` interface, `updateConfig()` simplification) — will follow as a separate PR after this lands

## Test plan

- [ ] Start the server with an existing `config.json`, `learnings.json`, `scheduled-tasks.json`, `workspace-config.json` from before this PR → they load cleanly, no data loss, no errors in logs
- [ ] Save any config from the UI (toggle a setting) → file is rewritten in `{ schemaVersion: 1, data: ... }` envelope; restart server → settings load correctly
- [ ] Verify `tasks.json.${pid}.tmp` appears briefly during a save and is gone after (no stale tmp files left behind)
- [ ] Kill the server mid-save (`kill -9`) → `tasks.json` is either the old good copy or the new good copy, never partial; `tasks.json.bak` holds the previous save
- [ ] Run two backend instances concurrently (stale `tsx watch`) → neither crashes with ENOENT on tmp rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)