### PR TITLE
fix: stop rewriting full history for active reconnected tasks + atomic writes

### DIFF
--- a/backend/src/backends/claude-code-backend.ts
+++ b/backend/src/backends/claude-code-backend.ts
@@ -9,6 +9,7 @@ import { execSync } from 'child_process';
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { randomBytes } from 'crypto';
 import { TaskState, WaitingInputType, TaskGitState } from '@claudia/shared';
 import {
     CodeBackend,
@@ -178,7 +179,7 @@ export class ClaudeCodeBackend extends EventEmitter implements CodeBackend {
     }
 
     async createTask(config: TaskConfig, environment: TaskEnvironment): Promise<BackendTask> {
-        const id = `task-${Date.now()}-${require('crypto').randomBytes(5).toString('hex')}`;
+        const id = `task-${Date.now()}-${randomBytes(5).toString('hex')}`;
 
         const customArgs = process.env['CC_CLAUDE_ARGS']
             ? process.env['CC_CLAUDE_ARGS'].split(' ')

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -638,6 +638,23 @@ export class TaskSpawner extends EventEmitter {
     }
 
     /**
+     * Atomically write history to disk via a per-process temp file + rename.
+     * Mirrors the pattern used for tasks.json so a crash mid-write can't leave
+     * a truncated history file. Per-process tmp name avoids races between
+     * concurrent backend instances.
+     */
+    private atomicWriteHistorySync(historyPath: string, data: string): void {
+        const tmpPath = `${historyPath}.${process.pid}.tmp`;
+        writeFileSync(tmpPath, data);
+        try {
+            renameSync(tmpPath, historyPath);
+        } catch (e) {
+            try { if (existsSync(tmpPath)) unlinkSync(tmpPath); } catch (_e) { /* ignore */ }
+            throw e;
+        }
+    }
+
+    /**
      * Get the directory for task histories
      */
     private getHistoryDir(): string {
@@ -1089,20 +1106,23 @@ export class TaskSpawner extends EventEmitter {
                 // on EVERY save. With 15+ tasks and 112MB of history, this caused OOM crashes.
                 const historyPath = this.getTaskHistoryPath(task.id);
                 try {
-                    if (task.previousHistory) {
-                        // First save after reconnect — write base + current output as raw text
+                    if (task.previousHistory && !existsSync(historyPath)) {
+                        // Legacy/first-seed: previousHistory came from in-memory/tasks.json
+                        // and no on-disk file exists yet. Seed the file once; subsequent saves
+                        // fall through to the incremental-append branch below. Keep previousHistory
+                        // in memory (UI fallback, archive) — it will be dropped by setTaskActive.
                         const buffers: Buffer[] = [task.previousHistory];
                         if (task.outputHistory.length > 0) {
                             buffers.push(...task.outputHistory);
                         }
                         const fullHistory = Buffer.concat(buffers);
-                        writeFileSync(historyPath, fullHistory.toString('utf8'));
+                        this.atomicWriteHistorySync(historyPath, fullHistory.toString('utf8'));
                         task.savedBufferCount = task.outputHistory.length;
                     } else if (!existsSync(historyPath)) {
                         // New file — write current output as raw text
                         if (task.outputHistory.length > 0) {
                             const fullHistory = Buffer.concat(task.outputHistory);
-                            writeFileSync(historyPath, fullHistory.toString('utf8'));
+                            this.atomicWriteHistorySync(historyPath, fullHistory.toString('utf8'));
                             task.savedBufferCount = task.outputHistory.length;
                         }
                     } else if (task.savedBufferCount < task.outputHistory.length) {


### PR DESCRIPTION
## Summary

Follow-up to #38 / #39. Three issues surfaced during review of the OOM-fix and security changes:

1. **The O(new) history-save claim from #38 is defeated for actively-viewed reconnected tasks.** When a reconnected task is the one the user is looking at, `task.previousHistory` stays set indefinitely — `setTaskActive`'s clearing loop explicitly skips the active task. So `saveTasks()` keeps falling into the full-rewrite branch and writes `previousHistory + outputHistory` on every tick. For an 11MB history that's an 11MB `Buffer.concat` + `writeFileSync` every save interval — exactly what the fix was supposed to eliminate.

   The fix: the full-rewrite branch only needs to run when there's no on-disk history file yet (legacy upgrades where history lived in `tasks.json`). On a normal reconnect, `previousHistory` was loaded **from** the file, so the file already contains those bytes. Gating branch 1 on `!existsSync(historyPath)` lets the normal reconnect path fall straight through to the incremental-append branch. `previousHistory` stays in memory (UI fallback, archive), and `setTaskActive` keeps clearing it on the normal schedule.

2. **History writes weren't atomic.** `tasks.json` already uses the `.{pid}.tmp` + `renameSync` pattern; history files used bare `writeFileSync`. A crash or power loss mid-write would leave the file truncated. Added a small `atomicWriteHistorySync` helper and used it at the two full-rewrite sites. `appendFileSync` is unchanged (atomic appends would require a full rewrite — not worth it).

3. **`backend/src/backends/claude-code-backend.ts` used `require('crypto')` inside an ESM module.** Works under `tsx` via CommonJS interop but would throw `ReferenceError` on a strict ESM runtime, and is inconsistent with `task-spawner.ts` which correctly imports `randomBytes`. Moved to a top-level import.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Backend auto-reloaded and task list endpoint still works (55 tasks loaded)
- [x] No leftover `.tmp` files in `task-histories/` after restart
- [ ] After a reconnect to an active task, confirm history file is not rewritten on every save (watch `stat -f %z` / `%m` on the history file)
- [ ] Kill -9 the server mid-save and confirm history file is either the old content or the new content, never a truncated mix

🤖 Generated with [Claude Code](https://claude.com/claude-code)