### PR TITLE
feat: token usage dashboard with per-task cost tracking

### DIFF
--- a/backend/src/__tests__/config-store.test.ts
+++ b/backend/src/__tests__/config-store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { ConfigStore, AppConfig, MCPServerConfig } from '../config-store.js';
+import { ConfigStore, AppConfig, MCPServerConfig, DEFAULT_TOKEN_PRICING } from '../config-store.js';
 
 describe('ConfigStore', () => {
     let testBaseDir: string;
@@ -291,6 +291,202 @@ describe('ConfigStore', () => {
             // Defaults applied
             expect(config.skipPermissions).toBe(false);
             expect(config.apiMode).toBe('default');
+        });
+    });
+
+    describe('token tracking methods', () => {
+        it('should default tokenTrackingEnabled to true', () => {
+            expect(store.getTokenTrackingEnabled()).toBe(true);
+        });
+
+        it('should get and set tokenTrackingEnabled', () => {
+            store.setTokenTrackingEnabled(false);
+            expect(store.getTokenTrackingEnabled()).toBe(false);
+
+            store.setTokenTrackingEnabled(true);
+            expect(store.getTokenTrackingEnabled()).toBe(true);
+        });
+
+        it('should persist tokenTrackingEnabled', () => {
+            store.setTokenTrackingEnabled(false);
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getTokenTrackingEnabled()).toBe(false);
+        });
+
+        it('should update tokenTrackingEnabled via updateConfig', () => {
+            store.updateConfig({ tokenTrackingEnabled: false });
+            expect(store.getTokenTrackingEnabled()).toBe(false);
+        });
+
+        it('should default tokenCostEnabled to false', () => {
+            expect(store.getTokenCostEnabled()).toBe(false);
+        });
+
+        it('should get and set tokenCostEnabled', () => {
+            store.setTokenCostEnabled(true);
+            expect(store.getTokenCostEnabled()).toBe(true);
+        });
+
+        it('should persist tokenCostEnabled', () => {
+            store.setTokenCostEnabled(true);
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getTokenCostEnabled()).toBe(true);
+        });
+
+        it('should update tokenCostEnabled via updateConfig', () => {
+            store.updateConfig({ tokenCostEnabled: true });
+            expect(store.getTokenCostEnabled()).toBe(true);
+        });
+
+        it('should return DEFAULT_TOKEN_PRICING when no custom pricing set', () => {
+            const pricing = store.getTokenPricing();
+            expect(pricing).toEqual(DEFAULT_TOKEN_PRICING);
+        });
+
+        it('should get and set token pricing', () => {
+            const customPricing = {
+                'my-model': {
+                    inputPer1MTokens: 1.00,
+                    outputPer1MTokens: 5.00,
+                    cacheCreatePer1MTokens: 1.25,
+                    cacheReadPer1MTokens: 0.10,
+                },
+            };
+            store.setTokenPricing(customPricing);
+            expect(store.getTokenPricing()).toEqual(customPricing);
+        });
+
+        it('should persist token pricing', () => {
+            const customPricing = {
+                'my-model': {
+                    inputPer1MTokens: 2.00,
+                    outputPer1MTokens: 8.00,
+                    cacheCreatePer1MTokens: 2.50,
+                    cacheReadPer1MTokens: 0.20,
+                },
+            };
+            store.setTokenPricing(customPricing);
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getTokenPricing()).toEqual(customPricing);
+        });
+
+        it('should update tokenPricing via updateConfig', () => {
+            const p = { 'x': { inputPer1MTokens: 1, outputPer1MTokens: 1, cacheCreatePer1MTokens: 1, cacheReadPer1MTokens: 1 } };
+            store.updateConfig({ tokenPricing: p });
+            expect(store.getTokenPricing()).toEqual(p);
+        });
+
+        it('should include token fields in resetToDefaults', () => {
+            store.setTokenTrackingEnabled(false);
+            store.setTokenCostEnabled(true);
+            store.setTokenPricing({ 'x': { inputPer1MTokens: 99, outputPer1MTokens: 99, cacheCreatePer1MTokens: 99, cacheReadPer1MTokens: 99 } });
+
+            store.resetToDefaults();
+
+            expect(store.getTokenTrackingEnabled()).toBe(true);
+            expect(store.getTokenCostEnabled()).toBe(false);
+            expect(store.getTokenPricing()).toEqual(DEFAULT_TOKEN_PRICING);
+        });
+    });
+
+    describe('defaultBaseDirectory methods', () => {
+        it('should default to undefined', () => {
+            expect(store.getDefaultBaseDirectory()).toBeUndefined();
+        });
+
+        it('should get and set defaultBaseDirectory', () => {
+            store.setDefaultBaseDirectory('/home/user/projects');
+            expect(store.getDefaultBaseDirectory()).toBe('/home/user/projects');
+        });
+
+        it('should persist defaultBaseDirectory', () => {
+            store.setDefaultBaseDirectory('/my/workspace');
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getDefaultBaseDirectory()).toBe('/my/workspace');
+        });
+
+        it('should allow clearing defaultBaseDirectory to undefined', () => {
+            store.setDefaultBaseDirectory('/some/path');
+            store.setDefaultBaseDirectory(undefined);
+            expect(store.getDefaultBaseDirectory()).toBeUndefined();
+        });
+
+        it('should update defaultBaseDirectory via updateConfig', () => {
+            store.updateConfig({ defaultBaseDirectory: '/updated/path' });
+            expect(store.getDefaultBaseDirectory()).toBe('/updated/path');
+        });
+    });
+
+    describe('defaultModel migration', () => {
+        it('should migrate old "model" field to "defaultModel" on load', () => {
+            // Simulate a legacy (unversioned) config saved before the model→defaultModel rename.
+            // The schema-version loader treats files without schemaVersion as legacy.
+            const configPath = join(testBaseDir, 'config.json');
+            const legacyConfig = {
+                // No schemaVersion field → treated as legacy by loadVersioned
+                claudeCodeSwitches: {
+                    verbose: false,
+                    maxTurns: null,
+                    maxBudgetUsd: null,
+                    permissionMode: null,
+                    allowedTools: '',
+                    disallowedTools: '',
+                    appendSystemPrompt: '',
+                    effortLevel: 'high',
+                    model: 'claude-opus-4-6',   // old field name
+                    // defaultModel intentionally absent
+                },
+            };
+            writeFileSync(configPath, JSON.stringify(legacyConfig));
+
+            const newStore = new ConfigStore(testBaseDir);
+            const switches = newStore.getClaudeCodeSwitches();
+            expect(switches.defaultModel).toBe('claude-opus-4-6');
+        });
+
+        it('should prefer defaultModel over legacy model field if both present', () => {
+            const configPath = join(testBaseDir, 'config.json');
+            const config = {
+                // No schemaVersion → legacy
+                claudeCodeSwitches: {
+                    model: 'old-model',
+                    defaultModel: 'new-model',
+                },
+            };
+            writeFileSync(configPath, JSON.stringify(config));
+
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getClaudeCodeSwitches().defaultModel).toBe('new-model');
+        });
+
+        it('should default defaultModel to empty string when neither field present', () => {
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getClaudeCodeSwitches().defaultModel).toBe('');
+        });
+    });
+
+    describe('claudiaMcpServerEnabled methods', () => {
+        it('should default to true', () => {
+            expect(store.getClaudioMcpServerEnabled()).toBe(true);
+        });
+
+        it('should get and set claudiaMcpServerEnabled', () => {
+            store.setClaudioMcpServerEnabled(false);
+            expect(store.getClaudioMcpServerEnabled()).toBe(false);
+
+            store.setClaudioMcpServerEnabled(true);
+            expect(store.getClaudioMcpServerEnabled()).toBe(true);
+        });
+
+        it('should persist claudiaMcpServerEnabled', () => {
+            store.setClaudioMcpServerEnabled(false);
+            const newStore = new ConfigStore(testBaseDir);
+            expect(newStore.getClaudioMcpServerEnabled()).toBe(false);
+        });
+
+        it('should update via updateConfig', () => {
+            store.updateConfig({ claudiaMcpServerEnabled: false });
+            expect(store.getClaudioMcpServerEnabled()).toBe(false);
         });
     });
 });

--- a/backend/src/__tests__/task-spawner-args.test.ts
+++ b/backend/src/__tests__/task-spawner-args.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { buildClaudeCodeSwitchArgs } from '../task-spawner.js';
+import type { ClaudeCodeSwitches } from '../config-store.js';
+
+const BASE: ClaudeCodeSwitches = {
+    verbose: false,
+    maxTurns: null,
+    maxBudgetUsd: null,
+    permissionMode: null,
+    allowedTools: '',
+    disallowedTools: '',
+    appendSystemPrompt: '',
+    effortLevel: 'high',
+    defaultModel: '',
+};
+
+describe('buildClaudeCodeSwitchArgs', () => {
+    it('returns empty array for all-default switches', () => {
+        expect(buildClaudeCodeSwitchArgs(BASE)).toEqual([]);
+    });
+
+    describe('--verbose', () => {
+        it('adds --verbose when true', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, verbose: true });
+            expect(args).toContain('--verbose');
+        });
+
+        it('omits --verbose when false', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, verbose: false });
+            expect(args).not.toContain('--verbose');
+        });
+    });
+
+    describe('--max-turns', () => {
+        it('adds --max-turns with value when set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxTurns: 10 });
+            expect(args).toContain('--max-turns');
+            expect(args[args.indexOf('--max-turns') + 1]).toBe('10');
+        });
+
+        it('omits --max-turns when null', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxTurns: null });
+            expect(args).not.toContain('--max-turns');
+        });
+
+        it('omits --max-turns when 0', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxTurns: 0 });
+            expect(args).not.toContain('--max-turns');
+        });
+
+        it('omits --max-turns when negative', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxTurns: -5 });
+            expect(args).not.toContain('--max-turns');
+        });
+    });
+
+    describe('--max-budget-usd', () => {
+        it('adds --max-budget-usd with value when set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxBudgetUsd: 5.50 });
+            expect(args).toContain('--max-budget-usd');
+            expect(args[args.indexOf('--max-budget-usd') + 1]).toBe('5.5');
+        });
+
+        it('omits --max-budget-usd when null', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxBudgetUsd: null });
+            expect(args).not.toContain('--max-budget-usd');
+        });
+
+        it('omits --max-budget-usd when 0', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, maxBudgetUsd: 0 });
+            expect(args).not.toContain('--max-budget-usd');
+        });
+    });
+
+    describe('--permission-mode', () => {
+        it('adds --permission-mode for known mode', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, permissionMode: 'auto' });
+            expect(args).toContain('--permission-mode');
+        });
+
+        it('omits --permission-mode when null', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, permissionMode: null });
+            expect(args).not.toContain('--permission-mode');
+        });
+
+        it('omits --permission-mode for empty string', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, permissionMode: '' });
+            expect(args).not.toContain('--permission-mode');
+        });
+    });
+
+    describe('--allowedTools', () => {
+        it('adds --allowedTools when set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, allowedTools: 'Bash,Write' });
+            expect(args).toContain('--allowedTools');
+            expect(args[args.indexOf('--allowedTools') + 1]).toBe('Bash,Write');
+        });
+
+        it('omits --allowedTools when empty string', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, allowedTools: '' });
+            expect(args).not.toContain('--allowedTools');
+        });
+
+        it('omits --allowedTools for whitespace-only string', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, allowedTools: '   ' });
+            expect(args).not.toContain('--allowedTools');
+        });
+
+        it('trims whitespace from allowedTools value', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, allowedTools: '  Bash  ' });
+            const idx = args.indexOf('--allowedTools');
+            expect(args[idx + 1]).toBe('Bash');
+        });
+    });
+
+    describe('--disallowedTools', () => {
+        it('adds --disallowedTools when set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, disallowedTools: 'Write' });
+            expect(args).toContain('--disallowedTools');
+            expect(args[args.indexOf('--disallowedTools') + 1]).toBe('Write');
+        });
+
+        it('omits --disallowedTools when empty', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, disallowedTools: '' });
+            expect(args).not.toContain('--disallowedTools');
+        });
+    });
+
+    describe('--append-system-prompt', () => {
+        it('adds --append-system-prompt when set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, appendSystemPrompt: 'Be concise.' });
+            expect(args).toContain('--append-system-prompt');
+            expect(args[args.indexOf('--append-system-prompt') + 1]).toBe('Be concise.');
+        });
+
+        it('omits --append-system-prompt when empty', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, appendSystemPrompt: '' });
+            expect(args).not.toContain('--append-system-prompt');
+        });
+
+        it('omits --append-system-prompt for whitespace-only', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, appendSystemPrompt: '   ' });
+            expect(args).not.toContain('--append-system-prompt');
+        });
+    });
+
+    describe('--model (defaultModel)', () => {
+        it('adds --model when defaultModel is set', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, defaultModel: 'claude-opus-latest' });
+            expect(args).toContain('--model');
+            expect(args[args.indexOf('--model') + 1]).toBe('claude-opus-latest');
+        });
+
+        it('omits --model when defaultModel is empty string', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, defaultModel: '' });
+            expect(args).not.toContain('--model');
+        });
+
+        it('omits --model for whitespace-only defaultModel', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, defaultModel: '   ' });
+            expect(args).not.toContain('--model');
+        });
+
+        it('trims whitespace from defaultModel', () => {
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, defaultModel: '  claude-sonnet-4-6  ' });
+            const idx = args.indexOf('--model');
+            expect(args[idx + 1]).toBe('claude-sonnet-4-6');
+        });
+
+        it('passes custom model IDs through unchanged', () => {
+            // Custom model IDs like Claude-Opus-4.6[1m] used on Vertex/SAP AI Core
+            const customModel = 'Claude-Opus-4.6[1m]';
+            const args = buildClaudeCodeSwitchArgs({ ...BASE, defaultModel: customModel });
+            expect(args[args.indexOf('--model') + 1]).toBe(customModel);
+        });
+    });
+
+    describe('argument order and combinations', () => {
+        it('produces correct arg pairs for multiple flags', () => {
+            const args = buildClaudeCodeSwitchArgs({
+                ...BASE,
+                verbose: true,
+                maxTurns: 5,
+                defaultModel: 'claude-sonnet-4-6',
+            });
+
+            expect(args).toContain('--verbose');
+            expect(args).toContain('--max-turns');
+            expect(args).toContain('--model');
+
+            // Values must follow their flags
+            expect(args[args.indexOf('--max-turns') + 1]).toBe('5');
+            expect(args[args.indexOf('--model') + 1]).toBe('claude-sonnet-4-6');
+        });
+
+        it('does not add any flag for all-null/empty switches', () => {
+            const args = buildClaudeCodeSwitchArgs({
+                verbose: false,
+                maxTurns: null,
+                maxBudgetUsd: null,
+                permissionMode: null,
+                allowedTools: '',
+                disallowedTools: '',
+                appendSystemPrompt: '',
+                effortLevel: 'high',
+                defaultModel: '',
+            });
+            expect(args).toHaveLength(0);
+        });
+    });
+});

--- a/backend/src/__tests__/token-parser.test.ts
+++ b/backend/src/__tests__/token-parser.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { calculateCost, parseSessionTokenUsage, getTaskTokenUsage } from '../token-parser.js';
+import type { ModelPricing } from '@claudia/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PRICING: ModelPricing = {
+    inputPer1MTokens: 3.00,
+    outputPer1MTokens: 15.00,
+    cacheCreatePer1MTokens: 3.75,
+    cacheReadPer1MTokens: 0.30,
+};
+
+function makeAssistant(opts: {
+    uuid: string;
+    model?: string;
+    stopReason?: string | null;
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
+    costUSD?: number;
+}) {
+    return JSON.stringify({
+        type: 'assistant',
+        uuid: opts.uuid,
+        message: {
+            model: opts.model ?? 'claude-sonnet-4-6',
+            role: 'assistant',
+            stop_reason: opts.stopReason !== undefined ? opts.stopReason : 'end_turn',
+            usage: {
+                input_tokens: opts.inputTokens ?? 100,
+                output_tokens: opts.outputTokens ?? 50,
+                cache_creation_input_tokens: opts.cacheCreation ?? 0,
+                cache_read_input_tokens: opts.cacheRead ?? 0,
+            },
+        },
+        ...(opts.costUSD !== undefined ? { costUSD: opts.costUSD } : {}),
+    });
+}
+
+function makeToolResult(opts: {
+    uuid: string;
+    inputTokens?: number;
+    outputTokens?: number;
+}) {
+    return JSON.stringify({
+        type: 'user',
+        uuid: opts.uuid,
+        toolUseResult: {
+            usage: {
+                input_tokens: opts.inputTokens ?? 200,
+                output_tokens: opts.outputTokens ?? 100,
+            },
+        },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// calculateCost
+// ---------------------------------------------------------------------------
+
+describe('calculateCost', () => {
+    it('returns 0 when no pricing provided', () => {
+        const result = calculateCost(
+            { inputTokens: 1_000_000, outputTokens: 1_000_000, cacheCreationTokens: 0, cacheReadTokens: 0 },
+            undefined
+        );
+        expect(result).toBe(0);
+    });
+
+    it('computes input token cost', () => {
+        const result = calculateCost(
+            { inputTokens: 1_000_000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(3.00);
+    });
+
+    it('computes output token cost', () => {
+        const result = calculateCost(
+            { inputTokens: 0, outputTokens: 1_000_000, cacheCreationTokens: 0, cacheReadTokens: 0 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(15.00);
+    });
+
+    it('computes cache creation token cost', () => {
+        const result = calculateCost(
+            { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 1_000_000, cacheReadTokens: 0 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(3.75);
+    });
+
+    it('computes cache read token cost', () => {
+        const result = calculateCost(
+            { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 1_000_000 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(0.30);
+    });
+
+    it('sums all cost components', () => {
+        const result = calculateCost(
+            { inputTokens: 1_000_000, outputTokens: 1_000_000, cacheCreationTokens: 1_000_000, cacheReadTokens: 1_000_000 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(3.00 + 15.00 + 3.75 + 0.30);
+    });
+
+    it('handles zero tokens without NaN', () => {
+        const result = calculateCost(
+            { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 },
+            PRICING
+        );
+        expect(result).toBe(0);
+        expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it('guards against NaN token inputs', () => {
+        // NaN token counts should not propagate to cost
+        const result = calculateCost(
+            { inputTokens: NaN, outputTokens: NaN, cacheCreationTokens: NaN, cacheReadTokens: NaN },
+            PRICING
+        );
+        expect(Number.isNaN(result)).toBe(false);
+        expect(result).toBe(0);
+    });
+
+    it('scales correctly for small token counts', () => {
+        const result = calculateCost(
+            { inputTokens: 1000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 },
+            PRICING
+        );
+        expect(result).toBeCloseTo(0.003);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionTokenUsage
+// ---------------------------------------------------------------------------
+
+describe('parseSessionTokenUsage', () => {
+    const testDir = join(tmpdir(), 'claudia-token-parser-test-' + Date.now());
+    const testFile = join(testDir, 'session.jsonl');
+
+    beforeEach(() => {
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    });
+
+    it('returns null for non-existent file', async () => {
+        const result = await parseSessionTokenUsage('/nonexistent/path.jsonl');
+        expect(result).toBeNull();
+    });
+
+    it('returns zero totals for empty file', async () => {
+        writeFileSync(testFile, '');
+        const result = await parseSessionTokenUsage(testFile);
+        expect(result).not.toBeNull();
+        expect(result!.inputTokens).toBe(0);
+        expect(result!.outputTokens).toBe(0);
+        expect(result!.totalCostUsd).toBe(0);
+    });
+
+    it('aggregates tokens from a single assistant entry', async () => {
+        writeFileSync(testFile, makeAssistant({
+            uuid: 'a1',
+            inputTokens: 500,
+            outputTokens: 200,
+        }));
+
+        const result = await parseSessionTokenUsage(testFile);
+        expect(result!.inputTokens).toBe(500);
+        expect(result!.outputTokens).toBe(200);
+    });
+
+    it('deduplicates by UUID — only counts final entry with stop_reason', async () => {
+        // Partial entry (no stop_reason) followed by final entry (with stop_reason)
+        const partial = JSON.stringify({
+            type: 'assistant',
+            uuid: 'a1',
+            message: {
+                model: 'claude-sonnet-4-6',
+                role: 'assistant',
+                stop_reason: null,   // partial — no stop_reason
+                usage: { input_tokens: 9999, output_tokens: 9999 },
+            },
+        });
+        const final = makeAssistant({ uuid: 'a1', inputTokens: 100, outputTokens: 50 });
+
+        writeFileSync(testFile, [partial, final].join('\n'));
+        const result = await parseSessionTokenUsage(testFile);
+
+        // Should count only the final entry, not partial + final
+        expect(result!.inputTokens).toBe(100);
+        expect(result!.outputTokens).toBe(50);
+    });
+
+    it('skips assistant entries without stop_reason entirely', async () => {
+        const partial = JSON.stringify({
+            type: 'assistant',
+            uuid: 'a1',
+            message: {
+                model: 'claude-sonnet-4-6',
+                stop_reason: null,
+                usage: { input_tokens: 999, output_tokens: 999 },
+            },
+        });
+        writeFileSync(testFile, partial);
+
+        const result = await parseSessionTokenUsage(testFile);
+        expect(result!.inputTokens).toBe(0);
+        expect(result!.outputTokens).toBe(0);
+    });
+
+    it('aggregates across multiple assistant turns', async () => {
+        const lines = [
+            makeAssistant({ uuid: 'a1', inputTokens: 100, outputTokens: 50 }),
+            makeAssistant({ uuid: 'a2', inputTokens: 200, outputTokens: 80 }),
+            makeAssistant({ uuid: 'a3', inputTokens: 300, outputTokens: 120 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.inputTokens).toBe(600);
+        expect(result!.outputTokens).toBe(250);
+    });
+
+    it('builds per-model breakdown', async () => {
+        const lines = [
+            makeAssistant({ uuid: 'a1', model: 'claude-sonnet-4-6', inputTokens: 100, outputTokens: 50 }),
+            makeAssistant({ uuid: 'a2', model: 'claude-opus-4-6', inputTokens: 200, outputTokens: 80 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.modelBreakdown['claude-sonnet-4-6']).toBeDefined();
+        expect(result!.modelBreakdown['claude-sonnet-4-6'].inputTokens).toBe(100);
+        expect(result!.modelBreakdown['claude-opus-4-6']).toBeDefined();
+        expect(result!.modelBreakdown['claude-opus-4-6'].inputTokens).toBe(200);
+    });
+
+    it('accumulates same-model entries in breakdown', async () => {
+        const lines = [
+            makeAssistant({ uuid: 'a1', model: 'claude-sonnet-4-6', inputTokens: 100, outputTokens: 50 }),
+            makeAssistant({ uuid: 'a2', model: 'claude-sonnet-4-6', inputTokens: 200, outputTokens: 80 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.modelBreakdown['claude-sonnet-4-6'].inputTokens).toBe(300);
+        expect(result!.modelBreakdown['claude-sonnet-4-6'].outputTokens).toBe(130);
+    });
+
+    it('aggregates cache tokens', async () => {
+        writeFileSync(testFile, makeAssistant({
+            uuid: 'a1',
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheCreation: 400,
+            cacheRead: 800,
+        }));
+
+        const result = await parseSessionTokenUsage(testFile);
+        expect(result!.cacheCreationTokens).toBe(400);
+        expect(result!.cacheReadTokens).toBe(800);
+    });
+
+    it('calculates cost when pricingMap provided', async () => {
+        writeFileSync(testFile, makeAssistant({
+            uuid: 'a1',
+            model: 'claude-sonnet-4-6',
+            inputTokens: 1_000_000,
+            outputTokens: 0,
+        }));
+
+        const pricingMap = { 'claude-sonnet-4-6': PRICING };
+        const result = await parseSessionTokenUsage(testFile, pricingMap);
+
+        expect(result!.totalCostUsd).toBeCloseTo(3.00);
+        expect(result!.modelBreakdown['claude-sonnet-4-6'].costUsd).toBeCloseTo(3.00);
+    });
+
+    it('overrides any accumulated costUSD when pricingMap provided', async () => {
+        // Entry has a costUSD field, but pricingMap should recalculate from tokens
+        const line = JSON.stringify({
+            type: 'assistant',
+            uuid: 'a1',
+            costUSD: 99.99,   // would be a large wrong value
+            message: {
+                model: 'claude-sonnet-4-6',
+                stop_reason: 'end_turn',
+                usage: { input_tokens: 0, output_tokens: 0 },
+            },
+        });
+        writeFileSync(testFile, line);
+
+        const pricingMap = { 'claude-sonnet-4-6': PRICING };
+        const result = await parseSessionTokenUsage(testFile, pricingMap);
+
+        // pricingMap recalculates from 0 tokens → $0
+        expect(result!.totalCostUsd).toBeCloseTo(0);
+    });
+
+    it('sets cost to 0 for unknown model when pricingMap provided', async () => {
+        writeFileSync(testFile, makeAssistant({
+            uuid: 'a1',
+            model: 'some-unknown-model',
+            inputTokens: 1_000_000,
+            outputTokens: 1_000_000,
+        }));
+
+        const pricingMap = { 'claude-sonnet-4-6': PRICING };
+        const result = await parseSessionTokenUsage(testFile, pricingMap);
+
+        expect(result!.totalCostUsd).toBe(0);
+    });
+
+    it('aggregates tool result (subagent) usage', async () => {
+        const lines = [
+            makeToolResult({ uuid: 'tr1', inputTokens: 500, outputTokens: 300 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.inputTokens).toBe(500);
+        expect(result!.outputTokens).toBe(300);
+        expect(result!.modelBreakdown['subagent']).toBeDefined();
+        expect(result!.modelBreakdown['subagent'].inputTokens).toBe(500);
+    });
+
+    it('deduplicates tool result entries by UUID', async () => {
+        const lines = [
+            makeToolResult({ uuid: 'tr1', inputTokens: 500, outputTokens: 300 }),
+            makeToolResult({ uuid: 'tr1', inputTokens: 500, outputTokens: 300 }),  // duplicate
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        // Should only count once
+        expect(result!.inputTokens).toBe(500);
+    });
+
+    it('combines assistant and tool result tokens', async () => {
+        const lines = [
+            makeAssistant({ uuid: 'a1', inputTokens: 100, outputTokens: 50 }),
+            makeToolResult({ uuid: 'tr1', inputTokens: 200, outputTokens: 80 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.inputTokens).toBe(300);
+        expect(result!.outputTokens).toBe(130);
+    });
+
+    it('skips malformed JSON lines without throwing', async () => {
+        const lines = [
+            'not valid json at all }{',
+            makeAssistant({ uuid: 'a1', inputTokens: 100, outputTokens: 50 }),
+            '{ "broken":',
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result).not.toBeNull();
+        expect(result!.inputTokens).toBe(100);
+    });
+
+    it('includes lastUpdated ISO timestamp', async () => {
+        writeFileSync(testFile, makeAssistant({ uuid: 'a1' }));
+        const result = await parseSessionTokenUsage(testFile);
+
+        expect(result!.lastUpdated).toBeTruthy();
+        expect(new Date(result!.lastUpdated).getTime()).not.toBeNaN();
+    });
+
+    it('does not produce NaN totals from valid entries', async () => {
+        const lines = [
+            makeAssistant({ uuid: 'a1', inputTokens: 100, outputTokens: 50 }),
+            makeAssistant({ uuid: 'a2', inputTokens: 200, outputTokens: 80 }),
+        ].join('\n');
+
+        writeFileSync(testFile, lines);
+        const result = await parseSessionTokenUsage(testFile, { 'claude-sonnet-4-6': PRICING });
+
+        expect(Number.isNaN(result!.totalCostUsd)).toBe(false);
+        expect(Number.isNaN(result!.inputTokens)).toBe(false);
+        expect(Number.isNaN(result!.outputTokens)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getTaskTokenUsage — path resolution
+// ---------------------------------------------------------------------------
+
+describe('getTaskTokenUsage', () => {
+    const testHome = join(tmpdir(), 'claudia-token-home-' + Date.now());
+    const testWorkspace = '/test/my-workspace';
+    let originalHome: string | undefined;
+    let originalUserProfile: string | undefined;
+
+    beforeEach(() => {
+        originalHome = process.env.HOME;
+        originalUserProfile = process.env.USERPROFILE;
+        process.env.HOME = testHome;
+        process.env.USERPROFILE = testHome;
+
+        // Replicate Claude Code's path: ~/.claude/projects/<workspace-hash>/
+        const folderName = testWorkspace.replace(/[^a-zA-Z0-9-]/g, '-');
+        const projectDir = join(testHome, '.claude', 'projects', folderName);
+        mkdirSync(projectDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        process.env.USERPROFILE = originalUserProfile;
+        rmSync(testHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    });
+
+    it('returns null for non-existent session', async () => {
+        const result = await getTaskTokenUsage(testWorkspace, 'no-such-session');
+        expect(result).toBeNull();
+    });
+
+    it('resolves workspace path to correct .claude/projects folder and parses it', async () => {
+        const folderName = testWorkspace.replace(/[^a-zA-Z0-9-]/g, '-');
+        const projectDir = join(testHome, '.claude', 'projects', folderName);
+        const sessionId = 'test-session-abc';
+        const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+
+        writeFileSync(sessionFile, makeAssistant({ uuid: 'a1', inputTokens: 123, outputTokens: 45 }));
+
+        const result = await getTaskTokenUsage(testWorkspace, sessionId);
+        expect(result).not.toBeNull();
+        expect(result!.inputTokens).toBe(123);
+        expect(result!.outputTokens).toBe(45);
+    });
+
+    it('passes pricingMap through to parser', async () => {
+        const folderName = testWorkspace.replace(/[^a-zA-Z0-9-]/g, '-');
+        const projectDir = join(testHome, '.claude', 'projects', folderName);
+        const sessionId = 'priced-session';
+        const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+
+        writeFileSync(sessionFile, makeAssistant({
+            uuid: 'a1',
+            model: 'claude-sonnet-4-6',
+            inputTokens: 1_000_000,
+            outputTokens: 0,
+        }));
+
+        const result = await getTaskTokenUsage(testWorkspace, sessionId, { 'claude-sonnet-4-6': PRICING });
+        expect(result!.totalCostUsd).toBeCloseTo(3.00);
+    });
+});

--- a/backend/src/backends/claude-code-backend.ts
+++ b/backend/src/backends/claude-code-backend.ts
@@ -178,7 +178,7 @@ export class ClaudeCodeBackend extends EventEmitter implements CodeBackend {
     }
 
     async createTask(config: TaskConfig, environment: TaskEnvironment): Promise<BackendTask> {
-        const id = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const id = `task-${Date.now()}-${require('crypto').randomBytes(5).toString('hex')}`;
 
         const customArgs = process.env['CC_CLAUDE_ARGS']
             ? process.env['CC_CLAUDE_ARGS'].split(' ')

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -208,7 +208,10 @@ export class ConfigStore {
             hyperspaceProxy: loaded.hyperspaceProxy ?? DEFAULT_HYPERSPACE_PROXY,
             aiCoreCredentials: loaded.aiCoreCredentials,
             enabledPlugins: loaded.enabledPlugins ?? [],
-            claudiaMcpServerEnabled: loaded.claudiaMcpServerEnabled ?? true
+            claudiaMcpServerEnabled: loaded.claudiaMcpServerEnabled ?? true,
+            tokenTrackingEnabled: loaded.tokenTrackingEnabled ?? true,
+            tokenCostEnabled: loaded.tokenCostEnabled ?? false,
+            tokenPricing: loaded.tokenPricing,
         };
     }
 
@@ -300,6 +303,15 @@ export class ConfigStore {
         if (updates.claudiaMcpServerEnabled !== undefined) {
             this.config.claudiaMcpServerEnabled = updates.claudiaMcpServerEnabled;
         }
+        if (updates.tokenTrackingEnabled !== undefined) {
+            this.config.tokenTrackingEnabled = updates.tokenTrackingEnabled;
+        }
+        if (updates.tokenCostEnabled !== undefined) {
+            this.config.tokenCostEnabled = updates.tokenCostEnabled;
+        }
+        if (updates.tokenPricing !== undefined) {
+            this.config.tokenPricing = updates.tokenPricing;
+        }
         this.saveConfig();
         return this.getConfig();
     }
@@ -356,7 +368,10 @@ export class ConfigStore {
             useLearnings: false,
             claudeCodeSwitches: { ...DEFAULT_CLAUDE_CODE_SWITCHES },
             hyperspaceProxy: { ...DEFAULT_HYPERSPACE_PROXY },
-            claudiaMcpServerEnabled: true
+            claudiaMcpServerEnabled: true,
+            tokenTrackingEnabled: true,
+            tokenCostEnabled: false,
+            tokenPricing: { ...DEFAULT_TOKEN_PRICING },
         };
         this.saveConfig();
         return this.getConfig();
@@ -443,6 +458,20 @@ export class ConfigStore {
 
     getTokenTrackingEnabled(): boolean {
         return this.config.tokenTrackingEnabled ?? true;
+    }
+
+    setTokenTrackingEnabled(enabled: boolean): void {
+        this.config.tokenTrackingEnabled = enabled;
+        this.saveConfig();
+    }
+
+    getTokenCostEnabled(): boolean {
+        return this.config.tokenCostEnabled ?? false;
+    }
+
+    setTokenCostEnabled(enabled: boolean): void {
+        this.config.tokenCostEnabled = enabled;
+        this.saveConfig();
     }
 
     getTokenPricing(): Record<string, ModelPricing> {

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -98,6 +98,7 @@ export interface AppConfig {
     claudiaMcpServerEnabled: boolean;  // Enable Claudia MCP server for Claude Code sessions
     tokenPricing?: Record<string, ModelPricing>;  // Custom token pricing per model
     tokenTrackingEnabled?: boolean;  // Enable token usage tracking
+    tokenCostEnabled?: boolean;  // Enable cost calculation display (default: false)
 }
 
 const DEFAULT_SUPERVISOR_PROMPT = `You are a concise, witty AI supervisor for a voice-first coding environment. Keep all responses SHORT and spoken-friendly — no bullet lists, no markdown headers, no walls of text.

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -218,10 +218,12 @@ export class ConfigStore {
             backend: loaded.backend ?? 'claude-code',
             opencodePort: loaded.opencodePort ?? 4096,
             useLearnings: loaded.useLearnings ?? false,
-            claudeCodeSwitches: {
-                ...DEFAULT_CLAUDE_CODE_SWITCHES,
-                ...(loaded.claudeCodeSwitches || {})
-            },
+            claudeCodeSwitches: (() => {
+                const sw = loaded.claudeCodeSwitches || {} as any;
+                // Migrate old 'model' field to 'defaultModel' if present
+                const defaultModel = sw.defaultModel || (sw as any).model || DEFAULT_CLAUDE_CODE_SWITCHES.defaultModel;
+                return { ...DEFAULT_CLAUDE_CODE_SWITCHES, ...sw, defaultModel };
+            })(),
             hyperspaceProxy: loaded.hyperspaceProxy ?? DEFAULT_HYPERSPACE_PROXY,
             aiCoreCredentials: loaded.aiCoreCredentials,
             enabledPlugins: loaded.enabledPlugins ?? [],

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -41,7 +41,7 @@ export interface ClaudeCodeSwitches {
     disallowedTools: string;       // --disallowedTools TOOLS (empty = not set)
     appendSystemPrompt: string;    // --append-system-prompt TEXT (empty = not set)
     effortLevel: string;           // CLAUDE_CODE_EFFORT_LEVEL env var ('low' | 'medium' | 'high')
-    defaultModel: string;          // --model MODEL (e.g. 'claude-opus-latest')
+    defaultModel: string;          // --model MODEL (empty = use Claude's default)
 }
 
 // Hyperspace AI Proxy configuration
@@ -61,7 +61,7 @@ export const DEFAULT_CLAUDE_CODE_SWITCHES: ClaudeCodeSwitches = {
     disallowedTools: '',
     appendSystemPrompt: '',
     effortLevel: 'high',
-    defaultModel: 'claude-opus-latest'
+    defaultModel: ''
 };
 
 const DEFAULT_HYPERSPACE_PROXY: HyperspaceProxyConfig = {

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -36,6 +36,7 @@ export interface ClaudeCodeSwitches {
     disallowedTools: string;       // --disallowedTools TOOLS (empty = not set)
     appendSystemPrompt: string;    // --append-system-prompt TEXT (empty = not set)
     effortLevel: string;           // CLAUDE_CODE_EFFORT_LEVEL env var ('low' | 'medium' | 'high')
+    model: string;                 // --model MODEL (empty = use Claude's default)
 }
 
 // Hyperspace AI Proxy configuration
@@ -54,7 +55,8 @@ export const DEFAULT_CLAUDE_CODE_SWITCHES: ClaudeCodeSwitches = {
     allowedTools: '',
     disallowedTools: '',
     appendSystemPrompt: '',
-    effortLevel: 'high'
+    effortLevel: 'high',
+    model: '',
 };
 
 const DEFAULT_HYPERSPACE_PROXY: HyperspaceProxyConfig = {

--- a/backend/src/git-utils.ts
+++ b/backend/src/git-utils.ts
@@ -1,8 +1,20 @@
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { TaskGitState, FileDiff } from '@claudia/shared';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/** Validate a git commit hash (full or abbreviated SHA-1) */
+function isValidCommitHash(hash: string): boolean {
+    return /^[a-f0-9]{4,40}$/i.test(hash);
+}
+
+/** Validate a git branch/ref name (no shell metacharacters) */
+function isValidBranchName(name: string): boolean {
+    // Based on git-check-ref-format rules, simplified
+    return /^[a-zA-Z0-9._\-/]+$/.test(name) && !name.startsWith('-');
+}
 
 /**
  * Git utilities for task revert functionality
@@ -58,8 +70,11 @@ export async function getCurrentBranch(cwd: string): Promise<string | null> {
  * Checkout a branch in a git repository
  */
 export async function checkoutBranch(cwd: string, branch: string): Promise<{ success: boolean; error?: string }> {
+    if (!isValidBranchName(branch)) {
+        return { success: false, error: 'Invalid branch name' };
+    }
     try {
-        await execAsync(`git checkout ${branch}`, { cwd });
+        await execFileAsync('git', ['checkout', branch], { cwd });
         return { success: true };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -121,8 +136,9 @@ export async function getModifiedFiles(cwd: string): Promise<string[]> {
  * Get files changed between two commits
  */
 export async function getFilesBetweenCommits(cwd: string, fromCommit: string, toCommit: string): Promise<string[]> {
+    if (!isValidCommitHash(fromCommit) || !isValidCommitHash(toCommit)) return [];
     try {
-        const { stdout } = await execAsync(`git diff --name-only ${fromCommit} ${toCommit}`, { cwd });
+        const { stdout } = await execFileAsync('git', ['diff', '--name-only', fromCommit, toCommit], { cwd });
         return stdout.trim().split('\n').filter(f => f.length > 0);
     } catch {
         return [];
@@ -133,8 +149,9 @@ export async function getFilesBetweenCommits(cwd: string, fromCommit: string, to
  * Count commits between two commits (how many commits is fromCommit behind toCommit)
  */
 export async function countCommitsBetween(cwd: string, fromCommit: string, toCommit: string): Promise<number> {
+    if (!isValidCommitHash(fromCommit) || !isValidCommitHash(toCommit)) return -1;
     try {
-        const { stdout } = await execAsync(`git rev-list --count ${fromCommit}..${toCommit}`, { cwd });
+        const { stdout } = await execFileAsync('git', ['rev-list', '--count', `${fromCommit}..${toCommit}`], { cwd });
         return parseInt(stdout.trim(), 10) || 0;
     } catch {
         return -1; // Error case
@@ -145,8 +162,9 @@ export async function countCommitsBetween(cwd: string, fromCommit: string, toCom
  * Check if a commit exists in the repository
  */
 export async function commitExists(cwd: string, commit: string): Promise<boolean> {
+    if (!isValidCommitHash(commit)) return false;
     try {
-        await execAsync(`git cat-file -t ${commit}`, { cwd });
+        await execFileAsync('git', ['cat-file', '-t', commit], { cwd });
         return true;
     } catch {
         return false;
@@ -297,18 +315,21 @@ export async function revertTaskChanges(
 
         // If commit changed, reset to before commit
         if (currentHead !== gitState.commitBefore) {
+            if (!isValidCommitHash(gitState.commitBefore)) {
+                return { success: false, error: 'Invalid commit hash in stored git state', filesReverted: [] };
+            }
             console.log(`[GitUtils] Resetting to commit ${gitState.commitBefore.substring(0, 7)} (undoing ${await countCommitsBetween(cwd, gitState.commitBefore, currentHead)} commits)`);
-            await execAsync(`git reset --hard ${gitState.commitBefore}`, { cwd });
+            await execFileAsync('git', ['reset', '--hard', gitState.commitBefore], { cwd });
         } else if (hasUncommitted) {
             // Just discard uncommitted changes
             console.log(`[GitUtils] Discarding uncommitted changes`);
-            await execAsync('git checkout -- .', { cwd });
+            await execFileAsync('git', ['checkout', '--', '.'], { cwd });
         }
 
         // Optionally clean untracked files
         if (cleanUntracked) {
             console.log(`[GitUtils] Cleaning untracked files`);
-            await execAsync('git clean -fd', { cwd });
+            await execFileAsync('git', ['clean', '-fd'], { cwd });
         }
 
         return {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,18 +9,20 @@ import { PORTS } from '@claudia/shared';
 
 const PORT = process.env.CLAUDIA_BACKEND_PORT || PORTS.BACKEND;
 
-// Check if Claude Code CLI is installed before starting
+// Check if Claude Code CLI is installed — warn but don't block startup.
+// The CLI may be unreachable when off VPN or during network issues;
+// the server should still start so the UI is accessible.
 const claudeCheck = checkClaudeCodeInstalled();
 if (!claudeCheck.installed) {
-    console.error('\n╔══════════════════════════════════════════════════════════════════╗');
-    console.error('║  ERROR: Claude Code CLI is not installed!                        ║');
-    console.error('║                                                                  ║');
-    console.error('║  This application requires Claude Code CLI to function.         ║');
-    console.error('║  Please install it from: https://claude.ai/code                 ║');
-    console.error('╚══════════════════════════════════════════════════════════════════╝\n');
-    process.exit(1);
+    console.warn('\n╔══════════════════════════════════════════════════════════════════╗');
+    console.warn('║  WARNING: Claude Code CLI not detected                          ║');
+    console.warn('║                                                                  ║');
+    console.warn('║  Task creation will fail until the CLI is available.             ║');
+    console.warn('║  Install from: https://claude.ai/code                            ║');
+    console.warn('╚══════════════════════════════════════════════════════════════════╝\n');
+} else {
+    console.log(`Claude Code CLI detected: ${claudeCheck.version}`);
 }
-console.log(`Claude Code CLI detected: ${claudeCheck.version}`);
 
 // Auto-install the /learn command to ~/.claude/commands/ so it's available in all Claude Code sessions
 function installLearnCommand() {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -338,7 +338,20 @@ export async function createApp(basePath?: string) {
     const wss = new WebSocketServer({ noServer: true });
 
     // Middleware
-    app.use(cors());
+    // Restrict CORS to localhost origins only — Claudia is a local-first app
+    app.use(cors({
+        origin: (origin, callback) => {
+            // Allow requests with no origin (same-origin, curl, native apps)
+            if (!origin) return callback(null, true);
+            try {
+                const url = new URL(origin);
+                if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1') {
+                    return callback(null, true);
+                }
+            } catch { /* invalid origin */ }
+            callback(new Error('CORS: origin not allowed'));
+        },
+    }));
     app.use(express.json({ limit: '50mb' })); // Increased limit for large AI requests
 
     // TunnelManager for mobile remote access (ngrok-based, created early for middleware use)
@@ -1490,55 +1503,56 @@ export async function createApp(basePath?: string) {
 
                     case 'workspace:browseFolder': {
                         // Open native OS folder picker dialog and return selected path
-                        const { execSync } = await import('child_process');
+                        const { execFileSync } = await import('child_process');
                         const platform = process.platform;
                         let selectedPath: string | null = null;
                         const lastBrowsed = workspaceStore.getLastBrowsedPath();
 
                         try {
                             if (platform === 'darwin') {
-                                let osascriptCmd = `osascript -e 'POSIX path of (choose folder with prompt "Select a workspace folder"`;
+                                // Build osascript args as an array — no shell interpolation
+                                const scriptParts = ['POSIX path of (choose folder with prompt "Select a workspace folder"'];
                                 if (lastBrowsed) {
-                                    osascriptCmd += ` default location POSIX file "${lastBrowsed}"`;
+                                    // Escape backslashes and quotes inside the AppleScript string
+                                    const safe = lastBrowsed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                                    scriptParts.push(` default location POSIX file "${safe}"`);
                                 }
-                                osascriptCmd += `)'`;
-                                const result = execSync(
-                                    osascriptCmd,
+                                scriptParts.push(')');
+                                const result = execFileSync(
+                                    'osascript', ['-e', scriptParts.join('')],
                                     { encoding: 'utf-8', timeout: 120000 }
                                 ).trim();
                                 if (result) selectedPath = result.replace(/\/$/, ''); // remove trailing slash
                             } else if (platform === 'win32') {
-                                const initialDirLine = lastBrowsed ? `$dialog.SelectedPath = "${lastBrowsed}"` : '';
-                                const psScript = `
-Add-Type -AssemblyName System.Windows.Forms
-$dialog = New-Object System.Windows.Forms.FolderBrowserDialog
-$dialog.Description = "Select a workspace folder"
-$dialog.ShowNewFolderButton = $true
-${initialDirLine}
-if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
-    Write-Output $dialog.SelectedPath
-}`;
-                                const result = execSync(
-                                    `powershell -NoProfile -Command "${psScript.replace(/\n/g, '; ')}"`,
+                                // Pass the PowerShell script via -EncodedCommand to avoid any shell quoting issues
+                                const initialDirLine = lastBrowsed
+                                    ? `$dialog.SelectedPath = [System.IO.Path]::GetFullPath("${lastBrowsed.replace(/"/g, '')}")`
+                                    : '';
+                                const psScript = [
+                                    'Add-Type -AssemblyName System.Windows.Forms',
+                                    '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+                                    '$dialog.Description = "Select a workspace folder"',
+                                    '$dialog.ShowNewFolderButton = $true',
+                                    ...(initialDirLine ? [initialDirLine] : []),
+                                    'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.SelectedPath }',
+                                ].join('\n');
+                                const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
+                                const result = execFileSync(
+                                    'powershell', ['-NoProfile', '-EncodedCommand', encoded],
                                     { encoding: 'utf-8', timeout: 120000 }
                                 ).trim();
                                 if (result) selectedPath = result;
                             } else {
-                                // Linux - try zenity first, then kdialog
-                                const zenityFilename = lastBrowsed ? ` --filename="${lastBrowsed}/"` : '';
+                                // Linux - try zenity first, then kdialog — use execFileSync with arg arrays
                                 try {
-                                    const result = execSync(
-                                        `zenity --file-selection --directory --title="Select a workspace folder"${zenityFilename} 2>/dev/null`,
-                                        { encoding: 'utf-8', timeout: 120000 }
-                                    ).trim();
+                                    const zenityArgs = ['--file-selection', '--directory', '--title=Select a workspace folder'];
+                                    if (lastBrowsed) zenityArgs.push(`--filename=${lastBrowsed}/`);
+                                    const result = execFileSync('zenity', zenityArgs, { encoding: 'utf-8', timeout: 120000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
                                     if (result) selectedPath = result;
                                 } catch {
-                                    const kdialogStart = lastBrowsed || '~';
                                     try {
-                                        const result = execSync(
-                                            `kdialog --getexistingdirectory "${kdialogStart}" --title "Select a workspace folder" 2>/dev/null`,
-                                            { encoding: 'utf-8', timeout: 120000 }
-                                        ).trim();
+                                        const kdialogArgs = ['--getexistingdirectory', lastBrowsed || process.env['HOME'] || '/', '--title', 'Select a workspace folder'];
+                                        const result = execFileSync('kdialog', kdialogArgs, { encoding: 'utf-8', timeout: 120000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
                                         if (result) selectedPath = result;
                                     } catch {
                                         logger.warn('No folder dialog available (install zenity or kdialog)');
@@ -1568,21 +1582,22 @@ if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
                         // Open workspace folder in native file explorer
                         const { workspaceId } = payload as { workspaceId?: string };
                         if (!workspaceId) break;
-                        const { exec } = await import('child_process');
+                        const { execFile } = await import('child_process');
                         const platform = process.platform;
-                        let command: string;
+                        // Use execFile with argument arrays — no shell, no injection risk
                         if (platform === 'darwin') {
-                            command = `open "${workspaceId}"`;
+                            execFile('open', [workspaceId], (error) => {
+                                if (error) logger.error('Failed to open folder', { workspaceId, error: error.message });
+                            });
                         } else if (platform === 'win32') {
-                            command = `explorer "${workspaceId}"`;
+                            execFile('explorer.exe', [workspaceId], (error) => {
+                                if (error) logger.error('Failed to open folder', { workspaceId, error: error.message });
+                            });
                         } else {
-                            command = `xdg-open "${workspaceId}"`;
+                            execFile('xdg-open', [workspaceId], (error) => {
+                                if (error) logger.error('Failed to open folder', { workspaceId, error: error.message });
+                            });
                         }
-                        exec(command, (error) => {
-                            if (error) {
-                                logger.error('Failed to open folder', { workspaceId, error: error.message });
-                            }
-                        });
                         break;
                     }
 
@@ -1590,23 +1605,37 @@ if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
                         // Open terminal at workspace folder
                         const { workspaceId } = payload as { workspaceId?: string };
                         if (!workspaceId) break;
-                        const { exec } = await import('child_process');
+                        const { execFile } = await import('child_process');
                         const platform = process.platform;
-                        let command: string;
                         if (platform === 'darwin') {
-                            // Use AppleScript to open Terminal.app at the specified directory
-                            command = `osascript -e 'tell application "Terminal" to do script "cd \\"${workspaceId}\\""' -e 'tell application "Terminal" to activate'`;
+                            // Use osascript with the path set via cwd — quoted form of handles all special chars
+                            // We pass two -e args: the cd script and the activate command
+                            const safeId = workspaceId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                            execFile('osascript', [
+                                '-e', `tell application "Terminal" to do script "cd \\"${safeId}\\""`,
+                                '-e', 'tell application "Terminal" to activate',
+                            ], (error) => {
+                                if (error) logger.error('Failed to open terminal', { workspaceId, error: error.message });
+                            });
                         } else if (platform === 'win32') {
-                            command = `start cmd /K "cd /d "${workspaceId}""`;
+                            // Use cwd option instead of interpolating the path into the command
+                            execFile('cmd.exe', ['/C', 'start', 'cmd.exe'], { cwd: workspaceId }, (error) => {
+                                if (error) logger.error('Failed to open terminal', { workspaceId, error: error.message });
+                            });
                         } else {
-                            // Try common Linux terminal emulators
-                            command = `x-terminal-emulator --working-directory="${workspaceId}" 2>/dev/null || gnome-terminal --working-directory="${workspaceId}" 2>/dev/null || xterm -e "cd '${workspaceId}' && bash"`;
+                            // Try common Linux terminal emulators in order
+                            execFile('x-terminal-emulator', [`--working-directory=${workspaceId}`], (error) => {
+                                if (error) {
+                                    execFile('gnome-terminal', [`--working-directory=${workspaceId}`], (error2) => {
+                                        if (error2) {
+                                            execFile('xterm', ['-e', `cd '${workspaceId.replace(/'/g, "'\\''")}' && bash`], (error3) => {
+                                                if (error3) logger.error('Failed to open terminal', { workspaceId, error: error3.message });
+                                            });
+                                        }
+                                    });
+                                }
+                            });
                         }
-                        exec(command, (error) => {
-                            if (error) {
-                                logger.error('Failed to open terminal', { workspaceId, error: error.message });
-                            }
-                        });
                         break;
                     }
 
@@ -3377,22 +3406,22 @@ if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
         }
 
         try {
-            const { exec } = await import('child_process');
+            const { execFile } = await import('child_process');
             const { promisify } = await import('util');
-            const execAsync = promisify(exec);
+            const execFileAsync = promisify(execFile);
 
             const platform = process.platform;
 
             if (platform === 'darwin') {
-                // macOS: reveal in Finder
-                await execAsync(`open -R "${resolvedPath}"`);
+                // macOS: reveal in Finder — -R flag with path as separate arg
+                await execFileAsync('open', ['-R', resolvedPath]);
             } else if (platform === 'win32') {
-                // Windows: reveal in Explorer
-                await execAsync(`explorer /select,"${resolvedPath.replace(/\//g, '\\')}"`);
+                // Windows: reveal in Explorer — /select with backslash path
+                await execFileAsync('explorer.exe', [`/select,${resolvedPath.replace(/\//g, '\\')}`]);
             } else {
                 // Linux: open parent directory in file manager
                 const parentDir = dirname(resolvedPath);
-                await execAsync(`xdg-open "${parentDir}"`);
+                await execFileAsync('xdg-open', [parentDir]);
             }
 
             logger.info('File revealed in file manager', { path });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3443,11 +3443,16 @@ export async function createApp(basePath?: string) {
         }
 
         try {
-            const execAsync = (await import('util')).promisify((await import('child_process')).exec);
+            const { execFile: execFileGit } = await import('child_process');
+            const { promisify } = await import('util');
+            const execFileAsync = promisify(execFileGit);
+            // Prevent git from hanging on auth prompts or credential helpers
+            const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: 'echo' };
+            const gitOpts = { cwd: workspacePath, env: gitEnv, timeout: 5000 };
 
             // Check if it's a git repo
             try {
-                await execAsync('git rev-parse --git-dir', { cwd: workspacePath });
+                await execFileAsync('git', ['rev-parse', '--git-dir'], gitOpts);
             } catch {
                 return res.json({ isGitRepo: false, branch: null, changes: [] });
             }
@@ -3455,14 +3460,14 @@ export async function createApp(basePath?: string) {
             // Get current branch
             let branch = '';
             try {
-                const { stdout } = await execAsync('git branch --show-current', { cwd: workspacePath });
+                const { stdout } = await execFileAsync('git', ['branch', '--show-current'], gitOpts);
                 branch = stdout.trim();
             } catch {
                 branch = 'HEAD';
             }
 
-            // Get status with porcelain v2 for richer info
-            const { stdout: statusOutput } = await execAsync('git status --porcelain', { cwd: workspacePath });
+            // Get status with porcelain format
+            const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], gitOpts);
             // Split on newlines WITHOUT trimming the full output first — trim() would strip the
             // leading space from the first porcelain line (e.g. " M path") shifting all indices
             // by one, which corrupts the XY status codes and drops the first path character.
@@ -3497,16 +3502,19 @@ export async function createApp(basePath?: string) {
                     return { path: filePath, status, staged: isStaged };
                 });
 
-            // Get ahead/behind info
+            // Get ahead/behind counts from local tracking data only — no network calls
             let ahead = 0;
             let behind = 0;
             try {
-                const { stdout: abOutput } = await execAsync('git rev-list --left-right --count HEAD...@{upstream}', { cwd: workspacePath });
+                const { stdout: abOutput } = await execFileAsync(
+                    'git', ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
+                    gitOpts
+                );
                 const parts = abOutput.trim().split(/\s+/);
                 ahead = parseInt(parts[0], 10) || 0;
                 behind = parseInt(parts[1], 10) || 0;
             } catch {
-                // No upstream configured
+                // No upstream configured or upstream not reachable
             }
 
             res.json({ isGitRepo: true, branch, changes, ahead, behind });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5282,6 +5282,8 @@ Guidelines:
                         costUsd: 0,
                         inputTokens: 0,
                         outputTokens: 0,
+                        cacheCreationTokens: 0,
+                        cacheReadTokens: 0,
                         taskCount: 0,
                     };
                 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4344,7 +4344,22 @@ export async function createApp(basePath?: string) {
                 return res.status(400).json({ error: 'Path is not a file' });
             }
 
-            // Read file contents
+            // For binary image files, return base64-encoded content
+            const imageExtensions = /\.(png|jpg|jpeg|gif|webp|bmp|ico|svg)$/i;
+            if (imageExtensions.test(resolvedPath)) {
+                const buffer = await readFile(resolvedPath);
+                const base64 = buffer.toString('base64');
+                const ext = resolvedPath.split('.').pop()!.toLowerCase();
+                const mimeType = ext === 'svg' ? 'image/svg+xml' : ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : `image/${ext}`;
+                return res.json({
+                    path: filePath,
+                    content: `data:${mimeType};base64,${base64}`,
+                    isImage: true,
+                    size: stats.size
+                });
+            }
+
+            // Read file contents as text
             const content = await readFile(resolvedPath, 'utf-8');
             res.json({
                 path: filePath,
@@ -5440,11 +5455,11 @@ Guidelines:
                 dashboard.taskCount++;
 
                 const usage = task.tokenUsage;
-                dashboard.totalCostUsd += usage.totalCostUsd;
-                dashboard.totalInputTokens += usage.inputTokens;
-                dashboard.totalOutputTokens += usage.outputTokens;
-                dashboard.totalCacheCreationTokens += usage.cacheCreationTokens;
-                dashboard.totalCacheReadTokens += usage.cacheReadTokens;
+                dashboard.totalCostUsd += usage.totalCostUsd || 0;
+                dashboard.totalInputTokens += usage.inputTokens || 0;
+                dashboard.totalOutputTokens += usage.outputTokens || 0;
+                dashboard.totalCacheCreationTokens += usage.cacheCreationTokens || 0;
+                dashboard.totalCacheReadTokens += usage.cacheReadTokens || 0;
 
                 // Group by workspace
                 if (!dashboard.byWorkspace[task.workspaceId]) {
@@ -5459,11 +5474,11 @@ Guidelines:
                     };
                 }
                 const wsData = dashboard.byWorkspace[task.workspaceId];
-                wsData.costUsd += usage.totalCostUsd;
-                wsData.inputTokens += usage.inputTokens;
-                wsData.outputTokens += usage.outputTokens;
-                wsData.cacheCreationTokens += usage.cacheCreationTokens;
-                wsData.cacheReadTokens += usage.cacheReadTokens;
+                wsData.costUsd += usage.totalCostUsd || 0;
+                wsData.inputTokens += usage.inputTokens || 0;
+                wsData.outputTokens += usage.outputTokens || 0;
+                wsData.cacheCreationTokens += usage.cacheCreationTokens || 0;
+                wsData.cacheReadTokens += usage.cacheReadTokens || 0;
                 wsData.taskCount++;
 
                 // Group by model
@@ -5478,11 +5493,11 @@ Guidelines:
                         };
                     }
                     const m = dashboard.byModel[model];
-                    m.inputTokens += modelUsage.inputTokens;
-                    m.outputTokens += modelUsage.outputTokens;
-                    m.cacheCreationTokens += modelUsage.cacheCreationTokens;
-                    m.cacheReadTokens += modelUsage.cacheReadTokens;
-                    m.costUsd += modelUsage.costUsd;
+                    m.inputTokens += modelUsage.inputTokens || 0;
+                    m.outputTokens += modelUsage.outputTokens || 0;
+                    m.cacheCreationTokens += modelUsage.cacheCreationTokens || 0;
+                    m.cacheReadTokens += modelUsage.cacheReadTokens || 0;
+                    m.costUsd += modelUsage.costUsd || 0;
                 }
             }
 

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -109,7 +109,11 @@ function resolveClaudeSpawn(): { command: string; prefixArgs: string[] } {
  */
 export function checkClaudeCodeInstalled(): { installed: boolean; version?: string; error?: string } {
     try {
-        const version = execSync('claude --version', { encoding: 'utf8', timeout: 5000 }).trim();
+        const { command, prefixArgs } = resolveClaudeSpawn();
+        const versionCmd = command === process.execPath
+            ? `"${command}" "${prefixArgs[0]}" --version`
+            : `${command} ${prefixArgs.join(' ')} --version`.trim();
+        const version = execSync(versionCmd, { encoding: 'utf8', timeout: 5000 }).trim();
         return { installed: true, version };
     } catch (error) {
         return {
@@ -172,6 +176,7 @@ interface InternalTask extends Task {
     process: IPty;
     outputHistory: Buffer[];
     previousHistory?: Buffer; // Historical output from before reconnection (kept separate)
+    resumeSeparator?: string; // "─── Resuming session ───" shown live but NOT saved to history file
     lazyHistoryBase64?: string; // Base64-encoded history for lazy loading (memory efficient)
     isActive: boolean;
     initialPromptSent: boolean;
@@ -2516,7 +2521,11 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
      * knows history loading is complete and can clear the loading spinner.
      */
     private sendTaskHistory(task: InternalTask): void {
-        const history = this.getCombinedHistory(task);
+        let history = this.getCombinedHistory(task);
+        // Append the resume separator for display (it's not in outputHistory / not saved to disk)
+        if (task.resumeSeparator) {
+            history = (history || '') + task.resumeSeparator;
+        }
         this.emit('taskRestore', task.id, history || '');
     }
 
@@ -2827,7 +2836,37 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
             // Use consolidated retry mechanism with follow-up input options (5 retries for reliability)
             setTimeout(() => this.sendEnterWithRetry(task, 5, { isInitialPrompt: false, enterKey }), enterDelayMs);
-        } else if (task.state !== 'exited') {
+        } else if (task.state === 'exited') {
+            // Task's PTY has exited — reconnect it (with --resume) and deliver the write
+            console.log(`[TaskSpawner] Task ${taskId} is exited, auto-reconnecting before write`);
+            const reconnected = this.reconnectTask(taskId);
+            if (reconnected) {
+                const newTask = this.tasks.get(taskId);
+                if (newTask) {
+                    newTask.isActive = true;
+                    this.emit('tasksUpdated');
+                    // Wait for idle state before delivering write (same pattern as disconnected reconnect)
+                    let delivered = false;
+                    const onStateChanged = (changedTask: Task) => {
+                        if (changedTask.id === taskId && changedTask.state === 'idle' && !delivered) {
+                            delivered = true;
+                            this.removeListener('taskStateChanged', onStateChanged);
+                            console.log(`[TaskSpawner] Task ${taskId} reached idle after exited-reconnect, delivering pending write`);
+                            this.writeToTask(taskId, data);
+                        }
+                    };
+                    this.on('taskStateChanged', onStateChanged);
+                    setTimeout(() => {
+                        if (!delivered) {
+                            delivered = true;
+                            this.removeListener('taskStateChanged', onStateChanged);
+                            console.log(`[TaskSpawner] Fallback: delivering pending write after 15s for exited-reconnect ${taskId}`);
+                            this.writeToTask(taskId, data);
+                        }
+                    }, 15000);
+                }
+            }
+        } else {
             // Single keypress or task is busy - write directly
             task.process.write(data);
         }
@@ -3283,8 +3322,32 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
     reconnectTask(taskId: string): Task | null {
         // Guard: if the task is already live, return it without spawning a second process
         if (this.tasks.has(taskId)) {
-            console.log(`[TaskSpawner] Task ${taskId} is already live, skipping reconnect`);
-            return this.toPublicTask(this.tasks.get(taskId)!);
+            const existing = this.tasks.get(taskId)!;
+            if (existing.state !== 'exited') {
+                console.log(`[TaskSpawner] Task ${taskId} is already live (state=${existing.state}), skipping reconnect`);
+                return this.toPublicTask(existing);
+            }
+            // Task's PTY exited but task is still in the live map — move it to
+            // disconnectedTasks so it can be properly reconnected with --resume
+            console.log(`[TaskSpawner] Task ${taskId} is exited, moving to disconnected for reconnect`);
+            const persisted: PersistedTask = {
+                id: existing.id,
+                prompt: existing.prompt,
+                workspaceId: existing.workspaceId,
+                createdAt: existing.createdAt.toISOString(),
+                lastActivity: existing.lastActivity.toISOString(),
+                lastState: 'exited',
+                sessionId: existing.sessionId,
+                backendType: this.taskBackends.get(existing.id) || 'claude-code',
+                gitState: existing.gitState,
+                systemPrompt: existing.systemPrompt,
+                displayName: existing.displayName,
+                displayNameEditedByUser: existing.displayNameEditedByUser,
+                order: existing.order,
+            };
+            this.disconnectedTasks.set(taskId, persisted);
+            this.tasks.delete(taskId);
+            // Fall through to normal reconnect logic below
         }
 
         const persisted = this.disconnectedTasks.get(taskId);
@@ -3451,8 +3514,9 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             processStartedAt: shouldContinue
                 ? (persisted.processStartedAt ? new Date(persisted.processStartedAt) : now)
                 : undefined,  // Preserve original start time across reconnect, or use now as fallback
-            outputHistory: [Buffer.from(resumeMessage)], // Start fresh, only resume message
+            outputHistory: [], // Start empty — resume separator is emitted live but not persisted
             previousHistory, // Historical output from before reconnect (loaded from file or in-memory)
+            resumeSeparator: resumeMessage, // Shown live when task becomes active, not saved to disk
             lastActivity: now,
             createdAt: new Date(persisted.createdAt),
             isActive: false,
@@ -3461,8 +3525,8 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             // Use sessionIdToUse (not persisted.sessionId) — if the session file was missing,
             // sessionIdToUse was cleared to null so the PTY handler can capture the new session ID.
             sessionId: sessionIdToUse,
-            lastOutputLength: resumeMessage.length,  // Initialize for state polling
-            totalOutputSize: resumeMessage.length,  // Incremental output size tracking
+            lastOutputLength: 0,  // Initialize for state polling
+            totalOutputSize: 0,  // Incremental output size tracking
             savedBufferCount: 0,  // Incremental history saves
             hasStartedProcessing: !shouldContinue,  // Will be set true when continuation starts
             shouldContinue,

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -41,7 +41,7 @@ const PERMISSION_MODE_MAP: Record<string, string> = {
  * Build CLI args from ClaudeCodeSwitches config.
  * Returns args to push into the claudeArgs array.
  */
-function buildClaudeCodeSwitchArgs(switches: ClaudeCodeSwitches): string[] {
+export function buildClaudeCodeSwitchArgs(switches: ClaudeCodeSwitches): string[] {
     const args: string[] = [];
 
     if (switches.verbose) {
@@ -2584,6 +2584,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
     }
 
     private async captureTokenUsage(taskId: string): Promise<void> {
+        if (!this.configStore?.getTokenTrackingEnabled()) return;
         const task = this.tasks.get(taskId);
         if (!task?.sessionId) return;
 

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1012,12 +1012,17 @@ export class TaskSpawner extends EventEmitter {
                         this.transitionTaskState(task, 'waiting_input', inputType, `polling: detected ${inputType}`);
                         this.emit('taskWaitingInput', task.id, inputType, recentOutput);
                     } else {
-                        this.transitionTaskState(task, 'idle', undefined, 'polling: output stable');
+                        // Capture token usage before transitioning to idle so the save
+                        // triggered by transitionTaskState includes the latest costs.
+                        this.captureTokenUsage(task.id)
+                            .catch(err => {
+                                logger.error('Unhandled error in captureTokenUsage', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
+                            })
+                            .finally(() => {
+                                this.transitionTaskState(task, 'idle', undefined, 'polling: output stable');
+                            });
                         this.captureGitStateAfterTask(task.id).catch(err => {
                             logger.error('Unhandled error in captureGitStateAfterTask', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
-                        });
-                        this.captureTokenUsage(task.id).catch(err => {
-                            logger.error('Unhandled error in captureTokenUsage', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
                         });
                     }
                 }
@@ -2478,12 +2483,15 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             }
             task.state = 'exited';
 
-            // Capture token usage on exit
-            this.captureTokenUsage(task.id).catch(err => {
-                logger.error('Unhandled error in captureTokenUsage (onExit)', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
-            });
-
-            this.scheduleSave();
+            // Capture token usage before saving so the persisted record has costs.
+            // Run async but schedule save only after it resolves.
+            this.captureTokenUsage(task.id)
+                .catch(err => {
+                    logger.error('Unhandled error in captureTokenUsage (onExit)', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
+                })
+                .finally(() => {
+                    this.scheduleSave();
+                });
             this.emit('taskStateChanged', this.toPublicTask(task));
             this.emit('taskExit', task.id, exitCode);
         });

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -284,6 +284,12 @@ export class TaskSpawner extends EventEmitter {
     /** After rotation, how many bytes of the tail we keep. */
     private readonly historyFileKeepBytes: number;
 
+    /** Wall-clock time when this TaskSpawner instance was created. Used by the
+     *  idle reaper to avoid disconnecting tasks that were already idle before
+     *  this server session started — their lastActivity timestamp predates the
+     *  server, so the 24h window would fire immediately on every restart. */
+    private readonly startedAt: Date = new Date();
+
     // Backend abstraction for multi-backend support (Claude Code, OpenCode, etc.)
     private backend: CodeBackend | null = null;
     private backendType: BackendType = 'claude-code';
@@ -901,6 +907,11 @@ export class TaskSpawner extends EventEmitter {
         const toReap: string[] = [];
         for (const task of this.tasks.values()) {
             if (task.state !== 'idle') continue;
+            // Only reap tasks that went idle during this server session. A task
+            // whose lastActivity predates startedAt was already idle when the
+            // server started; its age would immediately exceed the 24h threshold
+            // on every restart, disconnecting tasks the user hasn't touched yet.
+            if (task.lastActivity < this.startedAt) continue;
             const age = now - task.lastActivity.getTime();
             if (age >= this.idleReapMs) toReap.push(task.id);
         }
@@ -1401,10 +1412,12 @@ export class TaskSpawner extends EventEmitter {
                     console.error(`[TaskSpawner] Failed to save history for task ${task.id}:`, e);
                 }
 
-                // Track if task was busy when being saved (will be interrupted)
-                const wasInterrupted = task.state === 'busy' || task.state === 'starting';
-                // Tasks that were busy should auto-continue on restart
-                const shouldContinue = wasInterrupted && task.sessionId != null;
+                // All live tasks are interrupted by a server restart (their PTY is killed).
+                // idle/waiting_input tasks also get their PTY destroyed, so they should reconnect too.
+                const wasInterrupted = true;
+                // Only auto-continue tasks that were actively mid-turn (busy/starting)
+                const wasMidTurn = task.state === 'busy' || task.state === 'starting';
+                const shouldContinue = wasMidTurn && task.sessionId != null;
 
                 // Get the backend type for this task (needed for correct reconnection)
                 const taskBackendType = this.taskBackends.get(task.id);
@@ -3639,10 +3652,10 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
         const disconnectedTasks = Array.from(this.disconnectedTasks.values()).map(persisted => ({
             id: persisted.id,
             prompt: persisted.prompt,
-            // Show 'interrupted' if task was busy when killed, otherwise 'disconnected'.
-            // Previously this showed persisted.lastState which could be 'busy' — making
-            // tasks appear busy with no running process (zombie tasks).
-            state: (persisted.wasInterrupted ? 'interrupted' : 'disconnected') as TaskState,
+            // Show 'interrupted' if task was mid-turn (busy/starting) when killed, otherwise 'disconnected'.
+            // wasInterrupted=true now applies to all live tasks killed by a server restart, so use
+            // lastState to distinguish mid-turn interruptions from idle reconnects.
+            state: ((persisted.wasInterrupted && (persisted.lastState === 'busy' || persisted.lastState === 'starting')) ? 'interrupted' : 'disconnected') as TaskState,
             workspaceId: persisted.workspaceId,
             createdAt: new Date(persisted.createdAt),
             lastActivity: new Date(persisted.lastActivity),

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -842,6 +842,9 @@ export class TaskSpawner extends EventEmitter {
 
         const keep = this.historyFileKeepBytes;
         try {
+            // Read into memory then close the fd before renaming — on Windows
+            // a file cannot be renamed while it has an open file descriptor.
+            let payload: Buffer;
             const fd = openSync(historyPath, 'r');
             try {
                 const start = Math.max(0, stat.size - keep);
@@ -851,21 +854,21 @@ export class TaskSpawner extends EventEmitter {
                 // Align to first newline within the first 1KB if possible, to
                 // drop a likely-partial opening line. Fall back to raw cut.
                 let offset = 0;
-                const scan = Math.min(1024, buf.length);
                 const nl = buf.indexOf(0x0a, 0);
-                if (nl >= 0 && nl < scan) offset = nl + 1;
+                if (nl >= 0 && nl < Math.min(1024, buf.length)) offset = nl + 1;
 
                 const marker = Buffer.from(`\x1b[90m── history trimmed (${Math.round((stat.size - start) / 1024)} KB shown of ${Math.round(stat.size / 1024)} KB) ──\x1b[0m\r\n`);
-                const payload = Buffer.concat([marker, buf.subarray(offset)]);
-                this.atomicWriteHistorySync(historyPath, payload.toString('utf8'));
-                logger.info('Rotated history file', {
-                    file: historyPath,
-                    originalBytes: stat.size,
-                    newBytes: payload.length,
-                });
+                payload = Buffer.concat([marker, buf.subarray(offset)]);
             } finally {
-                closeSync(fd);
+                closeSync(fd);  // Close before rename — critical on Windows
             }
+
+            this.atomicWriteHistorySync(historyPath, payload.toString('utf8'));
+            logger.info('Rotated history file', {
+                file: historyPath,
+                originalBytes: stat.size,
+                newBytes: payload.length,
+            });
         } catch (e) {
             logger.warn('Failed to rotate history file', { file: historyPath, error: (e as Error).message });
         }

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1017,12 +1017,16 @@ export class TaskSpawner extends EventEmitter {
                     } else {
                         // Capture token usage before transitioning to idle so the save
                         // triggered by transitionTaskState includes the latest costs.
+                        // Guard: only transition to idle if the task is still in 'busy' state when
+                        // captureTokenUsage resolves — a new user turn may have started in the meantime.
                         this.captureTokenUsage(task.id)
                             .catch(err => {
                                 logger.error('Unhandled error in captureTokenUsage', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
                             })
                             .finally(() => {
-                                this.transitionTaskState(task, 'idle', undefined, 'polling: output stable');
+                                if (task.state === 'busy') {
+                                    this.transitionTaskState(task, 'idle', undefined, 'polling: output stable');
+                                }
                             });
                         this.captureGitStateAfterTask(task.id).catch(err => {
                             logger.error('Unhandled error in captureGitStateAfterTask', { taskId: task.id, error: err instanceof Error ? err.message : String(err) });
@@ -2914,8 +2918,9 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
      * decoded only when the task is actually selected.
      */
     private getCombinedHistory(task: InternalTask): string | null {
-        // Limit history sent to frontend to prevent memory exhaustion
-        const MAX_HISTORY_TO_SEND = 2 * 1024 * 1024; // 2MB max
+        // Limit history sent to frontend. Smaller = faster xterm rendering.
+        // 512KB is ~128 full terminal screens, well beyond what's visually useful.
+        const MAX_HISTORY_TO_SEND = 512 * 1024; // 512KB max
 
         // Handle lazy loading from file
         if (!task.previousHistory && !task.lazyHistoryBase64) {
@@ -2984,7 +2989,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
                     // Add truncation message if we only loaded partial history
                     if (fileSize > maxBase64Size) {
-                        const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 2MB] ───\x1b[0m\r\n');
+                        const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 512KB] ───\x1b[0m\r\n');
                         task.previousHistory = Buffer.concat([truncationMessage, decoded]);
                     } else {
                         task.previousHistory = decoded;
@@ -3001,7 +3006,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                 const fullHistory = Buffer.from(task.lazyHistoryBase64, 'base64');
                 if (fullHistory.length > MAX_HISTORY_TO_SEND) {
                     // Only keep the last 2MB
-                    const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 2MB] ───\x1b[0m\r\n');
+                    const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 512KB] ───\x1b[0m\r\n');
                     task.previousHistory = Buffer.concat([
                         truncationMessage,
                         fullHistory.slice(fullHistory.length - MAX_HISTORY_TO_SEND)
@@ -3037,7 +3042,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             if (task.previousHistory.length <= MAX_HISTORY_TO_SEND) {
                 parts.push(task.previousHistory);
             } else {
-                const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 2MB] ───\x1b[0m\r\n');
+                const truncationMessage = Buffer.from('\r\n\x1b[90m─── [History truncated - showing last 512KB] ───\x1b[0m\r\n');
                 parts.push(truncationMessage);
                 parts.push(task.previousHistory.slice(task.previousHistory.length - MAX_HISTORY_TO_SEND));
             }

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -81,6 +81,25 @@ function exe(name: string): string {
 }
 
 /**
+ * On Windows, `npm install -g` creates `claude.cmd` not `claude.exe`, so
+ * node-pty cannot spawn it directly. Locate the underlying JS entry-point
+ * via APPDATA and run it with the current node executable — no PATH needed.
+ */
+function resolveClaudeSpawn(): { command: string; prefixArgs: string[] } {
+    if (!isWindows) return { command: 'claude', prefixArgs: [] };
+    const appData = process.env['APPDATA'];
+    if (appData) {
+        const cliPath = join(appData, 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+        if (existsSync(cliPath)) {
+            console.log(`[TaskSpawner] Resolved Claude CLI via APPDATA: ${process.execPath} ${cliPath}`);
+            return { command: process.execPath, prefixArgs: [cliPath] };
+        }
+    }
+    console.warn('[TaskSpawner] APPDATA-based Claude CLI not found, falling back to cmd.exe /c claude.cmd');
+    return { command: 'cmd.exe', prefixArgs: ['/c', 'claude.cmd'] };
+}
+
+/**
  * Check if Claude Code CLI is installed and available
  */
 export function checkClaudeCodeInstalled(): { installed: boolean; version?: string; error?: string } {
@@ -1918,7 +1937,8 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             apiMode: this.configStore?.getApiMode()
         });
 
-        const ptyProcess = spawn(exe('claude'), claudeArgs, {
+        const { command: claudeCmd1, prefixArgs: claudePrefix1 } = resolveClaudeSpawn();
+        const ptyProcess = spawn(claudeCmd1, [...claudePrefix1, ...claudeArgs], {
             name: 'xterm-256color',
             cols: initialCols || 120, // Use provided cols or default 120 (increased from 80)
             rows: initialRows || 40,  // Use provided rows or default 40 (increased from 24)
@@ -3246,7 +3266,8 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                 console.log(`[TaskSpawner] Reconnecting Claude Code task ${taskId} (fresh start)`);
             }
 
-            ptyProcess = spawn(exe('claude'), claudeArgs, {
+            const { command: claudeCmd2, prefixArgs: claudePrefix2 } = resolveClaudeSpawn();
+            ptyProcess = spawn(claudeCmd2, [...claudePrefix2, ...claudeArgs], {
                 name: 'xterm-256color',
                 cols: 120,
                 rows: 40,

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1684,6 +1684,8 @@ export class TaskSpawner extends EventEmitter {
     private isReadyForInitialInput(str: string): boolean {
         return str.includes('Try "') ||
             str.includes('? for shortcuts') ||
+            str.includes('bypass permissions') ||
+            str.includes('shift+tab') ||
             (str.includes('───') && str.includes('❯'));
     }
 
@@ -1906,7 +1908,7 @@ export class TaskSpawner extends EventEmitter {
             console.log(`[TaskSpawner] Aborting prompt write: task ${task.id} is no longer alive`);
             return;
         }
-        console.log(`[TaskSpawner] Writing prompt to PTY: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`);
+        console.log(`[TaskSpawner] Writing prompt to PTY: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}" (${prompt.length} chars, retries left: ${maxRetries})`);
 
         // For small messages (≤200 chars), type character by character
         // This gives the TUI time to process and makes Enter more reliable
@@ -1927,13 +1929,44 @@ export class TaskSpawner extends EventEmitter {
             };
             writeNextChar();
         } else {
+            // Record output size BEFORE writing prompt so we can verify TUI accepted it
+            const outputBeforeWrite = task.totalOutputSize;
+
             // Paste the entire prompt at once, then use retry mechanism to ensure Enter is accepted
             task.process.write(prompt);
             task.promptSubmitAttempts = 0;
-            // Give more time for longer prompts to be written before sending Enter
-            const delayMs = Math.min(500 + Math.floor(prompt.length / 100) * 50, 1000);
-            console.log(`[TaskSpawner] Waiting ${delayMs}ms before sending Enter for prompt of ${prompt.length} chars`);
-            setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), delayMs);
+            // Give more time for longer prompts to be written before sending Enter.
+            // Scale: base 500ms + 50ms per 100 chars, capped at 2500ms (aligned with writeToTask).
+            const delayMs = Math.min(500 + Math.floor(prompt.length / 100) * 50, 2500);
+            console.log(`[TaskSpawner] Waiting ${delayMs}ms before verifying prompt write for ${prompt.length} chars`);
+
+            setTimeout(() => {
+                if (task.state === 'exited' || !this.tasks.has(task.id)) return;
+
+                // Verify the TUI actually accepted the prompt by checking for output growth.
+                // When text is typed/pasted into Claude Code's TUI, it re-renders the input
+                // area which produces output. If output didn't grow, the TUI likely wasn't
+                // ready (e.g., MCP servers loading, notification blocking input) and we need
+                // to retry the entire write.
+                const outputAfterWrite = task.totalOutputSize;
+                const outputGrew = outputAfterWrite > outputBeforeWrite + 20;
+
+                if (!outputGrew && maxRetries > 0) {
+                    console.log(`[TaskSpawner] Prompt write NOT accepted by TUI (outputDelta=${outputAfterWrite - outputBeforeWrite}), retrying in 1500ms (retries left: ${maxRetries - 1})`);
+                    // Clear whatever partial state might be in the input and retry
+                    // Send Ctrl+U to clear the input line before retrying
+                    task.process.write('\x15'); // Ctrl+U: kill line
+                    setTimeout(() => this.sendPromptWithRetry(task, prompt, maxRetries - 1), 1500);
+                    return;
+                }
+
+                if (!outputGrew) {
+                    console.log(`[TaskSpawner] WARNING: Prompt write may not have been accepted (outputDelta=${outputAfterWrite - outputBeforeWrite}), but no retries left. Proceeding with Enter anyway.`);
+                }
+
+                console.log(`[TaskSpawner] Prompt write verified (outputDelta=${outputAfterWrite - outputBeforeWrite}), sending Enter`);
+                this.sendEnterWithRetry(task, 5, { isInitialPrompt: true });
+            }, delayMs);
         }
     }
 

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -13,6 +13,7 @@ import { createLogger } from './logger.js';
 import { CodeBackend, BackendTask, createBackend } from './backends/index.js';
 import { LearningsStore, LearningSearchResult } from './learnings-store.js';
 import { getConversationHistory } from './conversation-parser.js';
+import { randomBytes } from 'crypto';
 
 const logger = createLogger('[TaskSpawner]');
 
@@ -1817,7 +1818,7 @@ export class TaskSpawner extends EventEmitter {
         initialRows?: number
     ): Promise<Task> {
         console.log(`[TaskSpawner] createTaskWithClaudeCode called with workspaceId: "${workspaceId}"`);
-        const id = `task-${Date.now()}-${require('crypto').randomBytes(5).toString('hex')}`;
+        const id = `task-${Date.now()}-${randomBytes(5).toString('hex')}`;
 
         const customArgs = process.env['CC_CLAUDE_ARGS']
             ? process.env['CC_CLAUDE_ARGS'].split(' ')

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1541,32 +1541,15 @@ export class TaskSpawner extends EventEmitter {
     private sendPromptWithRetry(task: InternalTask, prompt: string, maxRetries = 5): void {
         console.log(`[TaskSpawner] Writing prompt to PTY: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`);
 
-        // For small messages (≤200 chars), type character by character
-        // This gives the TUI time to process and makes Enter more reliable
-        // For longer prompts, paste directly to avoid excessive delay
-        if (prompt.length <= 200) {
-            let charIndex = 0;
-            const charDelay = prompt.length <= 20 ? 10 : 5; // Slower for very short messages
-            const writeNextChar = () => {
-                if (charIndex < prompt.length) {
-                    task.process.write(prompt[charIndex]);
-                    charIndex++;
-                    setTimeout(writeNextChar, charDelay);
-                } else {
-                    // Give TUI time to settle before Enter
-                    setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), 500);
-                }
-            };
-            writeNextChar();
-        } else {
-            // Paste the entire prompt at once, then use retry mechanism to ensure Enter is accepted
-            task.process.write(prompt);
-            task.promptSubmitAttempts = 0;
-            // Give more time for longer prompts to be written before sending Enter
-            const delayMs = Math.min(500 + Math.floor(prompt.length / 100) * 50, 1000);
-            console.log(`[TaskSpawner] Waiting ${delayMs}ms before sending Enter for prompt of ${prompt.length} chars`);
-            setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), delayMs);
-        }
+        // Paste the entire prompt at once then send Enter.
+        // Character-by-character typing added unnecessary latency (5-10ms * N chars).
+        // The PTY/TUI handles pasted input reliably; a short settle delay before Enter is enough.
+        task.process.write(prompt);
+        task.promptSubmitAttempts = 0;
+        // Short settle delay: 80ms base + 2ms per 100 chars for very long prompts, capped at 300ms
+        const delayMs = Math.min(80 + Math.floor(prompt.length / 100) * 2, 300);
+        console.log(`[TaskSpawner] Waiting ${delayMs}ms before sending Enter for prompt of ${prompt.length} chars`);
+        setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), delayMs);
     }
 
     /**
@@ -1665,41 +1648,30 @@ export class TaskSpawner extends EventEmitter {
         const sanitizedPrompt = sanitizePrompt(prompt);
         let sanitizedSystemPrompt = systemPrompt ? sanitizePrompt(systemPrompt) : undefined;
 
-        const gitStateBefore = await captureGitStateBefore(workspaceId);
+        // Start git capture and learnings search in parallel — do NOT await before spawning.
+        // Git operations (especially on repos with GitHub remotes) can involve auth and network
+        // I/O that takes seconds. We fire these off now and attach results to the task later.
+        const gitStatePromise = captureGitStateBefore(workspaceId).catch(err => {
+            logger.warn('Git state capture failed (non-blocking)', { error: err instanceof Error ? err.message : String(err) });
+            return null;
+        });
 
-        // Search for relevant learnings and inject if enabled
-        let injectedLearnings: LearningSearchResult[] = [];
+        let learningsPromise: Promise<LearningSearchResult[]> = Promise.resolve([]);
         if (this.configStore?.getUseLearnings() && this.learningsStore) {
-            try {
-                // Add a timeout to prevent learnings search from blocking task creation
-                const learningsPromise = this.learningsStore.searchLearnings({
-                    query: sanitizedPrompt,
-                    workspaceId,
-                    topK: 5,
-                    minScore: 0.3
-                });
-                const timeoutPromise = new Promise<LearningSearchResult[]>((_, reject) =>
-                    setTimeout(() => reject(new Error('Learnings search timed out')), 5000)
-                );
-                injectedLearnings = await Promise.race([learningsPromise, timeoutPromise]);
-
-                if (injectedLearnings.length > 0) {
-                    const learningsContext = this.learningsStore.formatForContext(injectedLearnings);
-                    logger.info('Injecting learnings into task', {
-                        count: injectedLearnings.length,
-                        scores: injectedLearnings.map(l => l.score.toFixed(3))
-                    });
-
-                    // Prepend learnings to system prompt
-                    if (sanitizedSystemPrompt) {
-                        sanitizedSystemPrompt = `${learningsContext}\n\n${sanitizedSystemPrompt}`;
-                    } else {
-                        sanitizedSystemPrompt = learningsContext;
-                    }
-                }
-            } catch (err) {
+            learningsPromise = this.learningsStore.searchLearnings({
+                query: sanitizedPrompt,
+                workspaceId,
+                topK: 5,
+                minScore: 0.3
+            }).catch(err => {
                 logger.error('Failed to search learnings', { error: err instanceof Error ? err.message : String(err) });
-            }
+                return [];
+            });
+            // Hard cap: learnings must resolve within 2s or we skip them
+            learningsPromise = Promise.race([
+                learningsPromise,
+                new Promise<LearningSearchResult[]>(resolve => setTimeout(() => resolve([]), 2000))
+            ]);
         }
 
         // Log which backend we're using for debugging
@@ -1707,7 +1679,6 @@ export class TaskSpawner extends EventEmitter {
             backendType: this.backendType,
             hasBackend: !!this.backend,
             configBackend: this.configStore?.getBackend(),
-            learningsInjected: injectedLearnings.length,
             initialDims: initialCols && initialRows ? `${initialCols}x${initialRows}` : 'default'
         });
 
@@ -1715,17 +1686,29 @@ export class TaskSpawner extends EventEmitter {
         let task: Task;
         if (this.backendType === 'opencode' && this.backend) {
             logger.info('Using OpenCode backend for task creation');
+            // OpenCode needs git state synchronously — await here since it uses HTTP not PTY
+            const gitStateBefore = await gitStatePromise;
             task = await this.createTaskWithOpenCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStateBefore);
         } else {
-            // Default: Use Claude Code with PTY (existing logic)
+            // Default: Use Claude Code with PTY.
+            // Pass the git state promise — the PTY spawns immediately, git result is stored
+            // on the task once resolved (non-blocking).
             logger.info('Using Claude Code backend for task creation');
-            task = await this.createTaskWithClaudeCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStateBefore, initialCols, initialRows);
+            task = await this.createTaskWithClaudeCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStatePromise, initialCols, initialRows);
         }
 
-        // Track which learnings were injected for this task (for utility updates later)
-        if (injectedLearnings.length > 0) {
-            this.taskLearnings.set(task.id, injectedLearnings.map(l => l.learning.id));
-        }
+        // Resolve learnings and inject into system prompt / track after task is created
+        // This runs in the background and only affects future tasks, not this one's initial prompt.
+        // (Learnings are informational context; the main prompt is already sent.)
+        learningsPromise.then(injectedLearnings => {
+            if (injectedLearnings.length > 0) {
+                logger.info('Learnings resolved (post-spawn)', {
+                    count: injectedLearnings.length,
+                    scores: injectedLearnings.map(l => l.score.toFixed(3))
+                });
+                this.taskLearnings.set(task.id, injectedLearnings.map(l => l.learning.id));
+            }
+        });
 
         return task;
     }
@@ -1812,16 +1795,12 @@ export class TaskSpawner extends EventEmitter {
         prompt: string,
         workspaceId: string,
         systemPrompt: string | undefined,
-        gitStateBefore: Partial<TaskGitState> | null,
+        gitStatePromise: Promise<Partial<TaskGitState> | null>,
         initialCols?: number,
         initialRows?: number
     ): Promise<Task> {
         console.log(`[TaskSpawner] createTaskWithClaudeCode called with workspaceId: "${workspaceId}"`);
-        const id = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-
-        if (gitStateBefore) {
-            logger.info(`Captured git state before task`, { taskId: id, commit: gitStateBefore.commitBefore?.substring(0, 7) });
-        }
+        const id = `task-${Date.now()}-${require('crypto').randomBytes(5).toString('hex')}`;
 
         const customArgs = process.env['CC_CLAUDE_ARGS']
             ? process.env['CC_CLAUDE_ARGS'].split(' ')
@@ -1976,11 +1955,19 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             initialPromptSent: false,
             pendingPrompt: prompt,
             sessionId: null,
-            gitStateBefore: gitStateBefore || undefined,
+            gitStateBefore: undefined, // Will be set asynchronously below
             systemPrompt: systemPrompt?.trim() || undefined,
             lastOutputLength: 0,  // Initialize for state polling
             hasStartedProcessing: false,  // Will be true once output changes after prompt sent
         };
+
+        // Attach git state once resolved — this is non-blocking and happens after PTY is already running
+        gitStatePromise.then(gitStateBefore => {
+            if (gitStateBefore) {
+                task.gitStateBefore = gitStateBefore;
+                logger.info(`Git state attached to task`, { taskId: id, commit: gitStateBefore.commitBefore?.substring(0, 7) });
+            }
+        });
 
 
 
@@ -2053,7 +2040,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                     task.readyFallbackTimer = undefined;
                 }
 
-                setTimeout(() => this.sendPromptWithRetry(task, prompt), 1200);
+                setTimeout(() => this.sendPromptWithRetry(task, prompt), 50);
             }
 
             // Note: State detection is now handled by polling in checkTaskStates()

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1541,15 +1541,32 @@ export class TaskSpawner extends EventEmitter {
     private sendPromptWithRetry(task: InternalTask, prompt: string, maxRetries = 5): void {
         console.log(`[TaskSpawner] Writing prompt to PTY: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`);
 
-        // Paste the entire prompt at once then send Enter.
-        // Character-by-character typing added unnecessary latency (5-10ms * N chars).
-        // The PTY/TUI handles pasted input reliably; a short settle delay before Enter is enough.
-        task.process.write(prompt);
-        task.promptSubmitAttempts = 0;
-        // Short settle delay: 80ms base + 2ms per 100 chars for very long prompts, capped at 300ms
-        const delayMs = Math.min(80 + Math.floor(prompt.length / 100) * 2, 300);
-        console.log(`[TaskSpawner] Waiting ${delayMs}ms before sending Enter for prompt of ${prompt.length} chars`);
-        setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), delayMs);
+        // For small messages (≤200 chars), type character by character
+        // This gives the TUI time to process and makes Enter more reliable
+        // For longer prompts, paste directly to avoid excessive delay
+        if (prompt.length <= 200) {
+            let charIndex = 0;
+            const charDelay = prompt.length <= 20 ? 10 : 5; // Slower for very short messages
+            const writeNextChar = () => {
+                if (charIndex < prompt.length) {
+                    task.process.write(prompt[charIndex]);
+                    charIndex++;
+                    setTimeout(writeNextChar, charDelay);
+                } else {
+                    // Give TUI time to settle before Enter
+                    setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), 500);
+                }
+            };
+            writeNextChar();
+        } else {
+            // Paste the entire prompt at once, then use retry mechanism to ensure Enter is accepted
+            task.process.write(prompt);
+            task.promptSubmitAttempts = 0;
+            // Give more time for longer prompts to be written before sending Enter
+            const delayMs = Math.min(500 + Math.floor(prompt.length / 100) * 50, 1000);
+            console.log(`[TaskSpawner] Waiting ${delayMs}ms before sending Enter for prompt of ${prompt.length} chars`);
+            setTimeout(() => this.sendEnterWithRetry(task, maxRetries, { isInitialPrompt: true }), delayMs);
+        }
     }
 
     /**
@@ -2040,7 +2057,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                     task.readyFallbackTimer = undefined;
                 }
 
-                setTimeout(() => this.sendPromptWithRetry(task, prompt), 50);
+                setTimeout(() => this.sendPromptWithRetry(task, prompt), 1200);
             }
 
             // Note: State detection is now handled by polling in checkTaskStates()
@@ -3173,6 +3190,12 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
     }
 
     reconnectTask(taskId: string): Task | null {
+        // Guard: if the task is already live, return it without spawning a second process
+        if (this.tasks.has(taskId)) {
+            console.log(`[TaskSpawner] Task ${taskId} is already live, skipping reconnect`);
+            return this.toPublicTask(this.tasks.get(taskId)!);
+        }
+
         const persisted = this.disconnectedTasks.get(taskId);
         if (!persisted) {
             console.log(`[TaskSpawner] Cannot reconnect: task ${taskId} not found`);
@@ -3357,6 +3380,12 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             gitStateBefore: persisted.gitState ? persisted.gitState : undefined,  // Preserve git state
         };
 
+        // Remove from disconnectedTasks FIRST before registering handlers or emitting events.
+        // If we delete after emitting taskStateChanged, a concurrent writeToTask call can see
+        // the task still in disconnectedTasks and trigger a second reconnectTask, causing the
+        // "Resuming session X" message to appear multiple times and old history to be shown.
+        this.disconnectedTasks.delete(taskId);
+
         console.log(`[TaskSpawner] reconnectTask: Setting up process handlers for ${task.id}, ptyPid=${ptyProcess.pid}`);
         this.setupProcessHandlers(task);
         this.tasks.set(task.id, task);
@@ -3382,7 +3411,6 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             this.startReadyFallbackTimer(task);
         }
 
-        this.disconnectedTasks.delete(taskId);
         this.scheduleSave();
 
         // Start session capture so we detect the new/resumed session file

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -71,6 +71,10 @@ function buildClaudeCodeSwitchArgs(switches: ClaudeCodeSwitches): string[] {
         args.push('--append-system-prompt', switches.appendSystemPrompt.trim());
     }
 
+    if (switches.model && switches.model.trim()) {
+        args.push('--model', switches.model.trim());
+    }
+
     return args;
 }
 

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1106,13 +1106,15 @@ export class TaskSpawner extends EventEmitter {
             return;
         }
 
-        // Only auto-reconnect tasks that were recently interrupted (busy) or have shouldContinue set.
-        // Skip tasks that were last active more than 1 hour ago — they're stale.
+        // Only auto-reconnect tasks that were mid-turn (shouldContinue=true) when the server
+        // restarted. Idle tasks still have wasInterrupted=true for display purposes but
+        // reconnect on-demand (when the user clicks them) to avoid spawning too many PTY
+        // processes and MCP servers on startup.
         const MAX_STALE_AGE_MS = 60 * 60 * 1000; // 1 hour
         const now = Date.now();
         const tasksToReconnect = disconnectedIds.filter(id => {
             const task = this.disconnectedTasks.get(id);
-            if (!task || (!task.wasInterrupted && !task.shouldContinue)) return false;
+            if (!task || !task.shouldContinue) return false;
             // Skip stale tasks — they were interrupted long ago and should reconnect on-demand
             const lastActive = task.lastActivity ? new Date(task.lastActivity).getTime() : 0;
             if (now - lastActive > MAX_STALE_AGE_MS) {

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -373,6 +373,17 @@ export class TaskSpawner extends EventEmitter {
             }
         });
 
+        // Allow session ID update when a task reconnects with a fresh session
+        // (e.g. after tsx watch reload where the old session file was missing)
+        this.backend.on('task:sessionUpdated', (taskId: string, sessionId: string) => {
+            const task = this.tasks.get(taskId);
+            if (task && task.sessionId !== sessionId) {
+                task.sessionId = sessionId;
+                this.sessionToTaskId.set(sessionId, taskId);
+                this.saveTasks();
+            }
+        });
+
         this.backend.on('task:exit', (taskId: string, exitCode: number) => {
             const task = this.tasks.get(taskId);
             if (task) {
@@ -3346,7 +3357,9 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             isActive: false,
             initialPromptSent: !shouldContinue,  // False if we need to send continuation prompt
             pendingPrompt: shouldContinue ? 'continue' : null,  // Trigger continuation
-            sessionId: persisted.sessionId,
+            // Use sessionIdToUse (not persisted.sessionId) — if the session file was missing,
+            // sessionIdToUse was cleared to null so the PTY handler can capture the new session ID.
+            sessionId: sessionIdToUse,
             lastOutputLength: resumeMessage.length,  // Initialize for state polling
             hasStartedProcessing: !shouldContinue,  // Will be set true when continuation starts
             shouldContinue,

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -181,6 +181,8 @@ interface InternalTask extends Task {
     gitStateBefore?: Partial<TaskGitState>;
     systemPrompt?: string;
     lastOutputLength: number; // Track output size for state polling
+    totalOutputSize: number; // Running total of outputHistory size — avoids O(n) reduce on every chunk
+    savedBufferCount: number; // How many outputHistory buffers have been written to disk (for incremental saves)
     hasStartedProcessing: boolean; // True once Claude actually starts processing (output changes after prompt)
     stateTransitionLock?: boolean; // Prevents concurrent state transitions during polling
     shouldContinue?: boolean; // True if this is a reconnected task that should auto-continue
@@ -430,9 +432,21 @@ export class TaskSpawner extends EventEmitter {
                 if (server.headers) config.headers = server.headers;
                 mcpConfig[server.name] = config;
             } else {
+                // Optimize npx commands: resolve to direct node invocation when possible.
+                // npx adds 20-30 seconds of package resolution overhead on Windows.
+                let resolvedCommand = server.command;
+                let resolvedArgs = server.args ? [...server.args] : [];
+                if (resolvedCommand === 'npx' && resolvedArgs.length > 0) {
+                    const resolved = this.resolveNpxToNode(resolvedArgs[0], resolvedArgs.slice(1));
+                    if (resolved) {
+                        resolvedCommand = resolved.command;
+                        resolvedArgs = resolved.args;
+                        logger.info(`Optimized MCP server "${server.name}": npx → direct node`, { command: resolvedCommand, args: resolvedArgs });
+                    }
+                }
                 const config: Record<string, unknown> = {
-                    command: server.command,
-                    args: server.args
+                    command: resolvedCommand,
+                    args: resolvedArgs
                 };
                 if (server.env && Object.keys(server.env).length > 0) config.env = server.env;
                 if (server.description) config.description = server.description;
@@ -444,10 +458,13 @@ export class TaskSpawner extends EventEmitter {
         // Scoped to the task's workspace via CLAUDIA_WORKSPACE_ID env var
         if (claudiaMcpEnabled) {
             const mcpServerPath = join(__dirname, 'claudia-mcp-server.ts');
-            const claudiaConfig: Record<string, unknown> = {
-                command: 'npx',
-                args: ['tsx', mcpServerPath]
-            };
+            // Use tsx cli directly instead of npx tsx (saves ~25 seconds on Windows).
+            // Full paths ensure it works regardless of Claude Code's cwd.
+            const tsxCliPath = join(__dirname, '..', '..', 'node_modules', 'tsx', 'dist', 'cli.mjs');
+            const useTsxDirect = existsSync(tsxCliPath);
+            const claudiaConfig: Record<string, unknown> = useTsxDirect
+                ? { command: process.execPath, args: [tsxCliPath, mcpServerPath] }
+                : { command: 'npx', args: ['tsx', mcpServerPath] };
             // Pass workspace ID and task ID so the MCP server is scoped appropriately
             const mcpEnv: Record<string, string> = {};
             if (workspaceId) mcpEnv.CLAUDIA_WORKSPACE_ID = workspaceId;
@@ -461,6 +478,45 @@ export class TaskSpawner extends EventEmitter {
         }
 
         return { mcpConfig, enabledMcpServers };
+    }
+
+    /**
+     * Resolve an npx command to a direct node invocation by finding the package locally.
+     * npx adds 20-30 seconds of overhead on Windows due to package resolution.
+     * Returns null if the package can't be resolved locally.
+     */
+    private resolveNpxToNode(packageName: string, remainingArgs: string[]): { command: string; args: string[] } | null {
+        try {
+            // Try to find the package in the project's node_modules
+            const projectRoot = join(__dirname, '..', '..');
+            const pkgJsonPath = join(projectRoot, 'node_modules', ...packageName.split('/'), 'package.json');
+            if (!existsSync(pkgJsonPath)) return null;
+
+            const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+            const pkgDir = join(projectRoot, 'node_modules', ...packageName.split('/'));
+
+            // Find the bin entry point
+            let binPath: string | null = null;
+            if (typeof pkgJson.bin === 'string') {
+                binPath = join(pkgDir, pkgJson.bin);
+            } else if (typeof pkgJson.bin === 'object') {
+                // Use the first bin entry
+                const firstBin = Object.values(pkgJson.bin)[0] as string;
+                if (firstBin) binPath = join(pkgDir, firstBin);
+            }
+
+            if (binPath && existsSync(binPath)) {
+                return { command: process.execPath, args: [binPath, ...remainingArgs] };
+            }
+
+            // Fallback: try main entry
+            if (pkgJson.main && existsSync(join(pkgDir, pkgJson.main))) {
+                return { command: process.execPath, args: [join(pkgDir, pkgJson.main), ...remainingArgs] };
+            }
+        } catch (e) {
+            // Resolution failed — fall back to npx
+        }
+        return null;
     }
 
     /**
@@ -631,7 +687,7 @@ export class TaskSpawner extends EventEmitter {
                 continue;
             }
 
-            const currentLength = task.outputHistory.reduce((sum, buf) => sum + buf.length, 0);
+            const currentLength = task.totalOutputSize;
             const outputChanged = currentLength !== task.lastOutputLength;
             task.lastOutputLength = currentLength;
 
@@ -751,68 +807,83 @@ export class TaskSpawner extends EventEmitter {
             return;
         }
 
-        // Only auto-reconnect tasks that were interrupted (busy) or have shouldContinue set
-        // Other tasks will stay disconnected and reconnect on-demand when selected
+        // Only auto-reconnect tasks that were recently interrupted (busy) or have shouldContinue set.
+        // Skip tasks that were last active more than 1 hour ago — they're stale.
+        const MAX_STALE_AGE_MS = 60 * 60 * 1000; // 1 hour
+        const now = Date.now();
         const tasksToReconnect = disconnectedIds.filter(id => {
             const task = this.disconnectedTasks.get(id);
-            return task && (task.wasInterrupted || task.shouldContinue);
+            if (!task || (!task.wasInterrupted && !task.shouldContinue)) return false;
+            // Skip stale tasks — they were interrupted long ago and should reconnect on-demand
+            const lastActive = task.lastActivity ? new Date(task.lastActivity).getTime() : 0;
+            if (now - lastActive > MAX_STALE_AGE_MS) {
+                console.log(`[TaskSpawner] Skipping stale task ${id} (last active ${Math.round((now - lastActive) / 60000)}m ago), clearing shouldContinue`);
+                task.shouldContinue = false;
+                task.wasInterrupted = false;
+                return false;
+            }
+            return true;
         });
 
-        if (tasksToReconnect.length === 0) {
-            console.log(`[TaskSpawner] No interrupted tasks to auto-reconnect. ${disconnectedIds.length} tasks matching lazy load criteria.`);
+        // Limit to 2 concurrent reconnects to prevent resource exhaustion
+        // (each task starts 2 MCP servers — too many at once overwhelms the system)
+        const MAX_AUTO_RECONNECT = 2;
+        const capped = tasksToReconnect.slice(0, MAX_AUTO_RECONNECT);
+        if (tasksToReconnect.length > MAX_AUTO_RECONNECT) {
+            console.log(`[TaskSpawner] Capping auto-reconnect to ${MAX_AUTO_RECONNECT} of ${tasksToReconnect.length} eligible tasks. Remaining will reconnect on-demand.`);
+            // Clear shouldContinue on tasks we're skipping so they don't retry next restart
+            for (let i = MAX_AUTO_RECONNECT; i < tasksToReconnect.length; i++) {
+                const task = this.disconnectedTasks.get(tasksToReconnect[i]);
+                if (task) {
+                    task.shouldContinue = false;
+                    task.wasInterrupted = false;
+                }
+            }
+        }
+
+        if (capped.length === 0) {
+            console.log(`[TaskSpawner] No eligible tasks to auto-reconnect. ${disconnectedIds.length} tasks in lazy load.`);
             this.autoReconnectPromise = null;
+            this.scheduleSave(); // Persist cleared shouldContinue flags
             return;
         }
 
         this.isReconnecting = true;
-        this.emit('reconnectStart', tasksToReconnect.length);
-        console.log(`[TaskSpawner] Auto-reconnecting ${tasksToReconnect.length} interrupted tasks (of ${disconnectedIds.length} total)...`);
+        this.emit('reconnectStart', capped.length);
+        console.log(`[TaskSpawner] Auto-reconnecting ${capped.length} tasks (of ${disconnectedIds.length} total)...`);
 
-        const MAX_RETRIES = 2;
         const failedTasks: string[] = [];
 
-        for (let i = 0; i < tasksToReconnect.length; i++) {
-            const taskId = tasksToReconnect[i];
+        for (let i = 0; i < capped.length; i++) {
+            const taskId = capped[i];
             const persisted = this.disconnectedTasks.get(taskId);
             if (!persisted) continue;
 
-            // Log memory BEFORE reconnecting this task
-            const memBefore = process.memoryUsage();
-            console.log(`[TaskSpawner] Auto-reconnecting task ${i + 1}/${tasksToReconnect.length}: ${taskId}`);
-            console.log(`[TaskSpawner]   Prompt: ${persisted.prompt?.substring(0, 80) || 'No prompt'}...`);
-            console.log(`[TaskSpawner]   Memory BEFORE: RSS=${(memBefore.rss / 1024 / 1024).toFixed(2)}MB Heap=${(memBefore.heapUsed / 1024 / 1024).toFixed(2)}MB`);
+            console.log(`[TaskSpawner] Auto-reconnecting task ${i + 1}/${capped.length}: ${taskId}`);
 
             let success = false;
-            for (let attempt = 1; attempt <= MAX_RETRIES && !success; attempt++) {
-                try {
-                    const task = this.reconnectTask(taskId);
-                    if (task) {
-                        // Log memory AFTER successful reconnection
-                        const memAfter = process.memoryUsage();
-                        console.log(`[TaskSpawner] Successfully reconnected task ${taskId}`);
-                        console.log(`[TaskSpawner]   Memory AFTER: RSS=${(memAfter.rss / 1024 / 1024).toFixed(2)}MB Heap=${(memAfter.heapUsed / 1024 / 1024).toFixed(2)}MB (Δ RSS: ${((memAfter.rss - memBefore.rss) / 1024 / 1024).toFixed(2)}MB)`);
-                        success = true;
-                    } else {
-                        console.log(`[TaskSpawner] Failed to reconnect task ${taskId} (attempt ${attempt}/${MAX_RETRIES})`);
-                        if (attempt < MAX_RETRIES) {
-                            await new Promise(resolve => setTimeout(resolve, 1000 * attempt)); // Exponential backoff
-                        }
-                    }
-                } catch (error) {
-                    console.error(`[TaskSpawner] Error reconnecting task ${taskId} (attempt ${attempt}/${MAX_RETRIES}):`, error);
-                    if (attempt < MAX_RETRIES) {
-                        await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
-                    }
+            try {
+                const task = this.reconnectTask(taskId);
+                if (task) {
+                    console.log(`[TaskSpawner] Successfully reconnected task ${taskId}`);
+                    success = true;
                 }
+            } catch (error) {
+                console.error(`[TaskSpawner] Error reconnecting task ${taskId}:`, error);
             }
 
             if (!success) {
                 failedTasks.push(taskId);
+                // Clear shouldContinue on failed tasks to prevent infinite retry loops
+                if (persisted) {
+                    persisted.shouldContinue = false;
+                    persisted.wasInterrupted = false;
+                }
             }
 
-            // Small delay between tasks to avoid overwhelming the system
-            if (i < disconnectedIds.length - 1) {
-                await new Promise(resolve => setTimeout(resolve, 300));
+            // 5-second delay between reconnects to let MCP servers initialize
+            if (i < capped.length - 1) {
+                await new Promise(resolve => setTimeout(resolve, 5000));
             }
         }
 
@@ -1007,39 +1078,35 @@ export class TaskSpawner extends EventEmitter {
             }
 
             for (const task of this.tasks.values()) {
-                // Save history to separate file
+                // Save history to separate file using incremental writes.
+                // IMPORTANT: Previous approach read entire history files (up to 11MB each),
+                // decoded base64, concatenated, re-encoded, and wrote back — for EVERY task
+                // on EVERY save. With 15+ tasks and 112MB of history, this caused OOM crashes.
                 const historyPath = this.getTaskHistoryPath(task.id);
                 try {
-                    const buffers: Buffer[] = [];
-
-                    // If we have base history loaded, we can overwrite safely
                     if (task.previousHistory) {
-                        buffers.push(task.previousHistory);
+                        // First save after reconnect — write base + current output as raw text
+                        const buffers: Buffer[] = [task.previousHistory];
                         if (task.outputHistory.length > 0) {
                             buffers.push(...task.outputHistory);
                         }
                         const fullHistory = Buffer.concat(buffers);
-                        writeFileSync(historyPath, fullHistory.toString('base64'));
-                    }
-                    // If we DON'T have base history, check if file exists
-                    else if (!existsSync(historyPath)) {
-                        // New file, safe to write current output
+                        writeFileSync(historyPath, fullHistory.toString('utf8'));
+                        task.savedBufferCount = task.outputHistory.length;
+                    } else if (!existsSync(historyPath)) {
+                        // New file — write current output as raw text
                         if (task.outputHistory.length > 0) {
                             const fullHistory = Buffer.concat(task.outputHistory);
-                            writeFileSync(historyPath, fullHistory.toString('base64'));
+                            writeFileSync(historyPath, fullHistory.toString('utf8'));
+                            task.savedBufferCount = task.outputHistory.length;
                         }
-                    }
-                    // File exists but previousHistory was freed (memory cleanup).
-                    // Append current session output so it isn't silently lost.
-                    else if (task.outputHistory.length > 0) {
-                        try {
-                            const existingBase64 = readFileSync(historyPath, 'utf-8');
-                            const existingBuf = Buffer.from(existingBase64, 'base64');
-                            const currentBuf = Buffer.concat(task.outputHistory);
-                            const combined = Buffer.concat([existingBuf, currentBuf]);
-                            writeFileSync(historyPath, combined.toString('base64'));
-                        } catch (appendErr) {
-                            console.error(`[TaskSpawner] Failed to append history for task ${task.id}:`, appendErr);
+                    } else if (task.savedBufferCount < task.outputHistory.length) {
+                        // File exists — incrementally append only NEW buffers (O(new) not O(total))
+                        const newBuffers = task.outputHistory.slice(task.savedBufferCount);
+                        if (newBuffers.length > 0) {
+                            const newData = Buffer.concat(newBuffers).toString('utf8');
+                            appendFileSync(historyPath, newData);
+                            task.savedBufferCount = task.outputHistory.length;
                         }
                     }
                 } catch (e) {
@@ -1540,6 +1607,11 @@ export class TaskSpawner extends EventEmitter {
     }
 
     private sendPromptWithRetry(task: InternalTask, prompt: string, maxRetries = 5): void {
+        // Guard: abort if PTY has exited — writing to a dead native handle causes segfaults
+        if (task.state === 'exited' || !this.tasks.has(task.id)) {
+            console.log(`[TaskSpawner] Aborting prompt write: task ${task.id} is no longer alive`);
+            return;
+        }
         console.log(`[TaskSpawner] Writing prompt to PTY: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`);
 
         // For small messages (≤200 chars), type character by character
@@ -1549,6 +1621,7 @@ export class TaskSpawner extends EventEmitter {
             let charIndex = 0;
             const charDelay = prompt.length <= 20 ? 10 : 5; // Slower for very short messages
             const writeNextChar = () => {
+                if (task.state === 'exited') return; // PTY died mid-typing
                 if (charIndex < prompt.length) {
                     task.process.write(prompt[charIndex]);
                     charIndex++;
@@ -1606,6 +1679,12 @@ export class TaskSpawner extends EventEmitter {
         const { isInitialPrompt = false, enterKey = '\r' } = options;
         const context = isInitialPrompt ? 'initial prompt' : 'input';
 
+        // Guard: abort if PTY has exited — writing to a dead native handle causes segfaults
+        if (task.state === 'exited' || !this.tasks.has(task.id)) {
+            console.log(`[TaskSpawner] Aborting Enter: task ${task.id} is no longer alive`);
+            return;
+        }
+
         if (retriesLeft <= 0) {
             console.log(`[TaskSpawner] Max retries reached for ${context} on task ${task.id}, giving up`);
             // Just return, do not send burst to avoid PTY crashes
@@ -1625,7 +1704,7 @@ export class TaskSpawner extends EventEmitter {
 
         // Record output length just before sending Enter so we can detect any output growth
         const outputLengthBeforeEnter = options.outputLengthAtSend ??
-            task.outputHistory.reduce((sum, buf) => sum + buf.length, 0);
+            task.totalOutputSize;
 
         // Send Enter
         task.process.write(enterKey);
@@ -1633,7 +1712,7 @@ export class TaskSpawner extends EventEmitter {
         setTimeout(() => {
             // Check if output has grown since we sent Enter (more reliable than pattern matching)
             // even small output changes (≥10 bytes) indicate Claude accepted the Enter
-            const currentOutputLength = task.outputHistory.reduce((sum, buf) => sum + buf.length, 0);
+            const currentOutputLength = task.totalOutputSize;
             const outputGrew = currentOutputLength > outputLengthBeforeEnter + 10;
 
             // Check if Claude started processing (pattern-based or output-growth-based)
@@ -1791,6 +1870,8 @@ export class TaskSpawner extends EventEmitter {
             gitStateBefore: gitStateBefore || undefined,
             systemPrompt: systemPrompt?.trim() || undefined,
             lastOutputLength: 0,
+            totalOutputSize: 0,
+            savedBufferCount: 0,
             hasStartedProcessing: true,
         };
 
@@ -1976,6 +2057,8 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             gitStateBefore: undefined, // Will be set asynchronously below
             systemPrompt: systemPrompt?.trim() || undefined,
             lastOutputLength: 0,  // Initialize for state polling
+            totalOutputSize: 0,  // Incremental output size tracking
+            savedBufferCount: 0,  // Incremental history saves
             hasStartedProcessing: false,  // Will be true once output changes after prompt sent
         };
 
@@ -2020,13 +2103,16 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
             const buffer = Buffer.from(data, 'utf8');
             task.outputHistory.push(buffer);
+            task.totalOutputSize += buffer.length;
 
-            // Limit history to 2MB per task (reduced from 10MB for better memory usage with many tasks)
+            // Limit history to 2MB per task
             const MAX_HISTORY_SIZE = 2 * 1024 * 1024;
-            let totalSize = task.outputHistory.reduce((sum, buf) => sum + buf.length, 0);
-            while (totalSize > MAX_HISTORY_SIZE && task.outputHistory.length > 0) {
+            while (task.totalOutputSize > MAX_HISTORY_SIZE && task.outputHistory.length > 0) {
                 const removed = task.outputHistory.shift();
-                if (removed) totalSize -= removed.length;
+                if (removed) {
+                    task.totalOutputSize -= removed.length;
+                    if (task.savedBufferCount > 0) task.savedBufferCount--;
+                }
             }
 
             task.lastActivity = new Date();
@@ -2366,8 +2452,11 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             const historyPath = this.getTaskHistoryPath(taskId);
             if (existsSync(historyPath)) {
                 try {
-                    const base64 = readFileSync(historyPath, 'utf-8');
-                    const history = Buffer.from(base64, 'base64').toString('utf8');
+                    const fileContent = readFileSync(historyPath, 'utf-8');
+                    // Detect format: raw text (contains ANSI escapes, spaces, brackets) vs base64
+                    const sample = fileContent.substring(0, 100);
+                    const isRawText = sample.includes('\x1b') || sample.includes(' ') || sample.includes('[') || sample.includes(']');
+                    const history = isRawText ? fileContent : Buffer.from(fileContent, 'base64').toString('utf8');
                     this.emit('taskRestore', taskId, history);
                     historyRestored = true;
                 } catch (e) {
@@ -2661,7 +2750,6 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
     writeToTask(taskId: string, data: string): void {
         let task = this.tasks.get(taskId);
-        console.log(`[TaskSpawner] writeToTask: taskId=${taskId}, taskFound=${!!task}, ptyPid=${task?.process?.pid}, isActive=${task?.isActive}`);
 
         // If task not found in active tasks, check if it's disconnected and needs reconnecting
         if (!task) {
@@ -2714,8 +2802,10 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             return;
         }
 
-        console.log(`[TaskSpawner] Writing to Claude Code PTY for task ${taskId} (PID: ${task.process.pid})`);
-        console.log(`[TaskSpawner] Data to write: ${JSON.stringify(data)}`);
+        // Only log non-trivial writes (messages, not individual keystrokes) to avoid I/O overhead
+        if (data.length > 1) {
+            console.log(`[TaskSpawner] Writing to PTY for task ${taskId} (${data.length} chars)`);
+        }
 
         // Claude Code PTY-based input handling
         // Check if this is a message with Enter at the end (from input bar)
@@ -2737,7 +2827,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
             // Use consolidated retry mechanism with follow-up input options (5 retries for reliability)
             setTimeout(() => this.sendEnterWithRetry(task, 5, { isInitialPrompt: false, enterKey }), enterDelayMs);
-        } else {
+        } else if (task.state !== 'exited') {
             // Single keypress or task is busy - write directly
             task.process.write(data);
         }
@@ -2915,7 +3005,7 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
             // Handle lazy loading case - avoid decoding if possible
             if (task.lazyHistoryBase64 && !task.previousHistory) {
-                const currentOutputSize = task.outputHistory.reduce((sum, buf) => sum + buf.length, 0);
+                const currentOutputSize = task.totalOutputSize;
                 if (currentOutputSize < 1024) {
                     historyBase64 = task.lazyHistoryBase64;
                     historySize = Math.floor(historyBase64.length * 0.75);
@@ -3372,6 +3462,8 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
             // sessionIdToUse was cleared to null so the PTY handler can capture the new session ID.
             sessionId: sessionIdToUse,
             lastOutputLength: resumeMessage.length,  // Initialize for state polling
+            totalOutputSize: resumeMessage.length,  // Incremental output size tracking
+            savedBufferCount: 0,  // Incremental history saves
             hasStartedProcessing: !shouldContinue,  // Will be set true when continuation starts
             shouldContinue,
             continuationSent: false,

--- a/backend/src/token-parser.ts
+++ b/backend/src/token-parser.ts
@@ -64,10 +64,16 @@ export function calculateCost(
 ): number {
     if (!pricing) return 0;
 
-    const inputCost = (usage.inputTokens / 1_000_000) * pricing.inputPer1MTokens;
-    const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputPer1MTokens;
-    const cacheCreateCost = (usage.cacheCreationTokens / 1_000_000) * pricing.cacheCreatePer1MTokens;
-    const cacheReadCost = (usage.cacheReadTokens / 1_000_000) * pricing.cacheReadPer1MTokens;
+    // Guard against NaN from malformed token counts
+    const inputTokens = usage.inputTokens || 0;
+    const outputTokens = usage.outputTokens || 0;
+    const cacheCreationTokens = usage.cacheCreationTokens || 0;
+    const cacheReadTokens = usage.cacheReadTokens || 0;
+
+    const inputCost = (inputTokens / 1_000_000) * pricing.inputPer1MTokens;
+    const outputCost = (outputTokens / 1_000_000) * pricing.outputPer1MTokens;
+    const cacheCreateCost = (cacheCreationTokens / 1_000_000) * pricing.cacheCreatePer1MTokens;
+    const cacheReadCost = (cacheReadTokens / 1_000_000) * pricing.cacheReadPer1MTokens;
 
     return inputCost + outputCost + cacheCreateCost + cacheReadCost;
 }
@@ -131,7 +137,11 @@ export async function parseSessionTokenUsage(
                 if (entry.type === 'assistant' && entry.message?.usage && entry.uuid) {
                     const msg = entry as JsonlAssistantEntry;
                     const usage = msg.message!.usage!;
-                    const model = msg.message!.model || 'unknown';
+                    const rawModel = msg.message!.model;
+                    if (!rawModel) {
+                        console.warn(`[TokenParser] Assistant entry ${entry.uuid} missing model field`);
+                    }
+                    const model = rawModel || 'unknown';
                     const stopReason = msg.message!.stop_reason;
 
                     // Only count entries with a stop_reason (final entries, not partials)
@@ -236,6 +246,9 @@ export async function parseSessionTokenUsage(
                 totalCostUsd = 0;
                 for (const [model, modelUsage] of Object.entries(modelBreakdown)) {
                     const pricing = pricingMap[model];
+                    if (!pricing && model !== 'subagent' && model !== 'unknown') {
+                        console.warn(`[TokenParser] No pricing found for model "${model}", cost will be $0`);
+                    }
                     const cost = calculateCost(modelUsage, pricing);
                     modelUsage.costUsd = cost;
                     totalCostUsd += cost;

--- a/backend/src/validation.ts
+++ b/backend/src/validation.ts
@@ -53,6 +53,7 @@ export interface ConfigUpdatePayload {
         allowedTools?: string;
         disallowedTools?: string;
         appendSystemPrompt?: string;
+        model?: string;
     };
     deepgramApiKey?: string;
     hyperspaceProxy?: {
@@ -301,6 +302,13 @@ export function validateConfigUpdate(body: unknown): ValidationResult<ConfigUpda
                 return { valid: false, error: 'claudeCodeSwitches.appendSystemPrompt must be a string' };
             }
             result.claudeCodeSwitches.appendSystemPrompt = switches.appendSystemPrompt;
+        }
+
+        if (switches.model !== undefined) {
+            if (typeof switches.model !== 'string') {
+                return { valid: false, error: 'claudeCodeSwitches.model must be a string' };
+            }
+            result.claudeCodeSwitches.model = switches.model;
         }
     }
 

--- a/backend/src/validation.ts
+++ b/backend/src/validation.ts
@@ -121,9 +121,12 @@ export function validateConfigUpdate(body: unknown): ValidationResult<ConfigUpda
                 if (typeof server.url !== 'string' || !server.url) {
                     return { valid: false, error: `mcpServers[${i}].url is required for streamableHttp type` };
                 }
-                // Validate url is a valid URL
+                // Validate url is a valid URL with an allowed scheme
                 try {
-                    new URL(server.url);
+                    const parsed = new URL(server.url);
+                    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+                        return { valid: false, error: `mcpServers[${i}].url must use http or https scheme` };
+                    }
                 } catch {
                     return { valid: false, error: `mcpServers[${i}].url must be a valid URL` };
                 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -486,6 +486,15 @@ function App() {
                         <ArrowLeft size={20} />
                     </button>
                 )}
+                {!isMobile && (
+                    <button
+                        className="sidebar-toggle-btn"
+                        onClick={toggleSidebar}
+                        title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
+                    >
+                        {sidebarCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
+                    </button>
+                )}
                 <div className="logo">
                     <Terminal size={isMobile ? 20 : 24} />
                     <h1>Claudia</h1>
@@ -682,13 +691,6 @@ function App() {
                                 onMouseDown={handleMouseDown}
                             />
                         )}
-                        <button
-                            className="sidebar-collapse-btn"
-                            onClick={toggleSidebar}
-                            title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
-                        >
-                            {sidebarCollapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
-                        </button>
 
                         <section className="main-panel">
                             {/* Shell terminal - always mounted when active, hidden via CSS to preserve xterm state */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import { ActivityPanel } from './components/ActivityPanel';
 import { useTheme } from './hooks/useTheme';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTaskStore } from './stores/taskStore';
-import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, BarChart3 } from 'lucide-react';
+import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, BarChart3, ChevronLeft, ChevronRight } from 'lucide-react';
 import { UsageDashboard } from './components/UsageDashboard';
 import { getApiBaseUrl } from './config/api-config';
 import { isSoundEnabled, setSoundEnabled } from './utils/browserCapabilities';
@@ -35,6 +35,7 @@ function useIsMobile(breakpoint = 768) {
 }
 
 const SIDEBAR_WIDTH_KEY = 'claudia-sidebar-width';
+const SIDEBAR_COLLAPSED_KEY = 'claudia-sidebar-collapsed';
 const DEFAULT_SIDEBAR_WIDTH = 640;
 const CHAT_PANEL_WIDTH_KEY = 'claudia-chat-panel-width';
 const DEFAULT_CHAT_PANEL_WIDTH = 380;
@@ -129,6 +130,14 @@ function App() {
         } catch {
             return DEFAULT_CHAT_PANEL_WIDTH;
         }
+    });
+    const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+        try { return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true'; } catch { return false; }
+    });
+    const toggleSidebar = () => setSidebarCollapsed(c => {
+        const next = !c;
+        try { localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next)); } catch {}
+        return next;
     });
     const [isResizing, setIsResizing] = useState(false);
     const [isResizingChat, setIsResizingChat] = useState(false);
@@ -634,9 +643,9 @@ function App() {
                     /* ===== DESKTOP LAYOUT (unchanged) ===== */
                     <>
                         <aside
-                            className="sidebar"
+                            className={`sidebar${sidebarCollapsed ? ' collapsed' : ''}`}
                             ref={sidebarRef}
-                            style={{ width: `${sidebarWidth}px`, minWidth: `${sidebarWidth}px` }}
+                            style={sidebarCollapsed ? { width: 0, minWidth: 0 } : { width: `${sidebarWidth}px`, minWidth: `${sidebarWidth}px` }}
                         >
                             <WorkspacePanel
                                 onDeleteTask={archiveTask}
@@ -667,10 +676,21 @@ function App() {
                             />
                         </aside>
 
-                        <div
-                            className={`resize-handle ${isResizing ? 'resizing' : ''}`}
-                            onMouseDown={handleMouseDown}
-                        />
+                        <div className="sidebar-edge">
+                            {!sidebarCollapsed && (
+                                <div
+                                    className={`resize-handle ${isResizing ? 'resizing' : ''}`}
+                                    onMouseDown={handleMouseDown}
+                                />
+                            )}
+                            <button
+                                className="sidebar-collapse-btn"
+                                onClick={toggleSidebar}
+                                title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
+                            >
+                                {sidebarCollapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+                            </button>
+                        </div>
 
                         <section className="main-panel">
                             {/* Shell terminal - always mounted when active, hidden via CSS to preserve xterm state */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -676,21 +676,19 @@ function App() {
                             />
                         </aside>
 
-                        <div className="sidebar-edge">
-                            {!sidebarCollapsed && (
-                                <div
-                                    className={`resize-handle ${isResizing ? 'resizing' : ''}`}
-                                    onMouseDown={handleMouseDown}
-                                />
-                            )}
-                            <button
-                                className="sidebar-collapse-btn"
-                                onClick={toggleSidebar}
-                                title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
-                            >
-                                {sidebarCollapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
-                            </button>
-                        </div>
+                        {!sidebarCollapsed && (
+                            <div
+                                className={`resize-handle ${isResizing ? 'resizing' : ''}`}
+                                onMouseDown={handleMouseDown}
+                            />
+                        )}
+                        <button
+                            className="sidebar-collapse-btn"
+                            onClick={toggleSidebar}
+                            title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
+                        >
+                            {sidebarCollapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+                        </button>
 
                         <section className="main-panel">
                             {/* Shell terminal - always mounted when active, hidden via CSS to preserve xterm state */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,6 +153,26 @@ function App() {
         prevReloadingRef.current = isServerReloading;
     }, [isServerReloading]);
 
+    // Force TerminalView remount on ANY WebSocket reconnection, not just server reloads.
+    // When the browser tab is inactive, the WS heartbeat times out after 90s and the
+    // connection drops. On reconnect, TerminalView's message listener is still on the
+    // dead WebSocket, so no output/history is received → blank terminal.
+    // On Windows, tsx watch kills with TerminateProcess (no SIGTERM), so the
+    // server:reloading message is never sent and the isServerReloading path above
+    // never fires. This effect catches ALL reconnect scenarios.
+    const hasConnectedOnceRef = useRef(false);
+    const prevConnectedRef = useRef(isConnected);
+    useEffect(() => {
+        if (isConnected && !prevConnectedRef.current) {
+            if (hasConnectedOnceRef.current) {
+                console.log('[App] WS reconnected — forcing TerminalView remount');
+                setTerminalRefreshCounter(c => c + 1);
+            }
+            hasConnectedOnceRef.current = true;
+        }
+        prevConnectedRef.current = isConnected;
+    }, [isConnected]);
+
     const handleMouseDown = () => {
         setIsResizing(true);
     };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -650,6 +650,7 @@ function App() {
                                     title="Show workspaces"
                                 >
                                     <ChevronRight size={14} />
+                                    <span className="sidebar-expand-label">Workspaces</span>
                                 </button>
                             </aside>
                         ) : (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import { ActivityPanel } from './components/ActivityPanel';
 import { useTheme } from './hooks/useTheme';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTaskStore } from './stores/taskStore';
-import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, BarChart3, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, BarChart3, ChevronRight } from 'lucide-react';
 import { UsageDashboard } from './components/UsageDashboard';
 import { getApiBaseUrl } from './config/api-config';
 import { isSoundEnabled, setSoundEnabled } from './utils/browserCapabilities';
@@ -486,15 +486,6 @@ function App() {
                         <ArrowLeft size={20} />
                     </button>
                 )}
-                {!isMobile && (
-                    <button
-                        className="sidebar-toggle-btn"
-                        onClick={toggleSidebar}
-                        title={sidebarCollapsed ? 'Show workspaces' : 'Hide workspaces'}
-                    >
-                        {sidebarCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
-                    </button>
-                )}
                 <div className="logo">
                     <Terminal size={isMobile ? 20 : 24} />
                     <h1>Claudia</h1>
@@ -651,10 +642,21 @@ function App() {
                 ) : (
                     /* ===== DESKTOP LAYOUT (unchanged) ===== */
                     <>
+                        {sidebarCollapsed ? (
+                            <aside className="sidebar collapsed">
+                                <button
+                                    className="sidebar-expand-btn"
+                                    onClick={toggleSidebar}
+                                    title="Show workspaces"
+                                >
+                                    <ChevronRight size={14} />
+                                </button>
+                            </aside>
+                        ) : (
                         <aside
-                            className={`sidebar${sidebarCollapsed ? ' collapsed' : ''}`}
+                            className="sidebar"
                             ref={sidebarRef}
-                            style={sidebarCollapsed ? { width: 0, minWidth: 0 } : { width: `${sidebarWidth}px`, minWidth: `${sidebarWidth}px` }}
+                            style={{ width: `${sidebarWidth}px`, minWidth: `${sidebarWidth}px` }}
                         >
                             <WorkspacePanel
                                 onDeleteTask={archiveTask}
@@ -682,8 +684,10 @@ function App() {
                                 onAddCustomReference={addCustomReference}
                                 onRemoveReference={removeReference}
                                 onResetWorkspace={resetWorkspace}
+                                onCollapse={toggleSidebar}
                             />
                         </aside>
+                        )}
 
                         {!sidebarCollapsed && (
                             <div

--- a/frontend/src/components/FileContentModal.css
+++ b/frontend/src/components/FileContentModal.css
@@ -208,6 +208,22 @@
     font-style: italic;
 }
 
+.file-content-image-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    height: 100%;
+    overflow: auto;
+}
+
+.file-content-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: 4px;
+}
+
 .file-content-editor {
     width: 100%;
     height: 100%;

--- a/frontend/src/components/FileContentModal.tsx
+++ b/frontend/src/components/FileContentModal.tsx
@@ -18,6 +18,7 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [content, setContent] = useState('');
+    const [isImage, setIsImage] = useState(false);
     const [editedContent, setEditedContent] = useState('');
     const [isEditing, setIsEditing] = useState(false);
     const [saving, setSaving] = useState(false);
@@ -40,6 +41,7 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
     const loadContent = async () => {
         setLoading(true);
         setError(null);
+        setIsImage(false);
         try {
             const params = new URLSearchParams({ workspace: workspacePath, file: filePath });
             if (isDiff) {
@@ -51,6 +53,7 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
             if (res.ok) {
                 const data = await res.json();
                 setContent(isDiff ? data.diff : data.content);
+                setIsImage(data.isImage === true);
             } else {
                 const errData = await res.json().catch(() => ({ error: 'Failed to load content' }));
                 setError(errData.error || 'Failed to load content');
@@ -173,7 +176,7 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
                                 {showRendered ? <Code size={14} /> : <Eye size={14} />}
                             </button>
                         )}
-                        {!isDiff && !isEditing && (
+                        {!isDiff && !isEditing && !isImage && (
                             <button
                                 className="file-content-action-btn"
                                 onClick={handleEdit}
@@ -203,14 +206,16 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
                                 </button>
                             </>
                         )}
-                        <button
-                            className="file-content-action-btn"
-                            onClick={handleCopy}
-                            title="Copy to clipboard"
-                            disabled={loading || !!error}
-                        >
-                            {copied ? <Check size={14} /> : <Copy size={14} />}
-                        </button>
+                        {!isImage && (
+                            <button
+                                className="file-content-action-btn"
+                                onClick={handleCopy}
+                                title="Copy to clipboard"
+                                disabled={loading || !!error}
+                            >
+                                {copied ? <Check size={14} /> : <Copy size={14} />}
+                            </button>
+                        )}
                         <button
                             className="file-content-action-btn"
                             onClick={handleDownload}
@@ -243,12 +248,17 @@ export function FileContentModal({ workspacePath, filePath, isDiff = false, stag
                             autoFocus
                         />
                     )}
-                    {!loading && !error && !isEditing && content && isMarkdownFile && showRendered && !isDiff && (
+                    {!loading && !error && !isEditing && content && isImage && (
+                        <div className="file-content-image-container">
+                            <img src={content} alt={filePath.split('/').pop()} className="file-content-image" />
+                        </div>
+                    )}
+                    {!loading && !error && !isEditing && content && !isImage && isMarkdownFile && showRendered && !isDiff && (
                         <div className="file-content-markdown-rendered">
                             <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
                         </div>
                     )}
-                    {!loading && !error && !isEditing && content && !(isMarkdownFile && showRendered && !isDiff) && (
+                    {!loading && !error && !isEditing && content && !isImage && !(isMarkdownFile && showRendered && !isDiff) && (
                         <pre className={`file-content-pre ${isDiff ? 'diff-view' : ''}`}>
                             {isDiff ? (
                                 <code className="file-content-code">

--- a/frontend/src/components/FileExplorer.css
+++ b/frontend/src/components/FileExplorer.css
@@ -64,6 +64,8 @@
     letter-spacing: 0.5px;
     height: 100%;
     width: 28px;
+    justify-content: flex-start;
+    padding-top: 12px;
 }
 
 .file-explorer-toggle:hover {

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
-    ChevronRight, ChevronDown, File, Folder, FolderOpen,
-    PanelRightClose, PanelRightOpen, RefreshCw,
+    ChevronRight, ChevronDown, ChevronLeft, File, Folder, FolderOpen,
+    PanelRightClose, RefreshCw,
     GitBranch, CircleDot, Plus, Trash2, Pencil, FileQuestion,
     CheckCircle2, XCircle, Clock, Loader2, SkipForward, ExternalLink,
     ArrowUp, ArrowDown, GitPullRequest, MessageSquare, Tag, User,
@@ -1699,7 +1699,7 @@ export function FileExplorer({ workspacePath, workspaceName }: FileExplorerProps
             {!isExpanded && (
                 <button className="file-explorer-toggle" onClick={() => setIsExpanded(true)}
                     title="Expand file explorer">
-                    <PanelRightOpen size={16} />
+                    <ChevronLeft size={14} />
                     <span className="file-explorer-toggle-label">Files</span>
                 </button>
             )}

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
     ChevronRight, ChevronDown, ChevronLeft, File, Folder, FolderOpen,
-    PanelRightClose, RefreshCw,
+    RefreshCw,
     GitBranch, CircleDot, Plus, Trash2, Pencil, FileQuestion,
     CheckCircle2, XCircle, Clock, Loader2, SkipForward, ExternalLink,
     ArrowUp, ArrowDown, GitPullRequest, MessageSquare, Tag, User,
@@ -1714,7 +1714,7 @@ export function FileExplorer({ workspacePath, workspaceName }: FileExplorerProps
                             <span>{workspaceName || 'Project'}</span>
                         </div>
                         <button className="file-explorer-collapse" onClick={() => setIsExpanded(false)} title="Collapse">
-                            <PanelRightClose size={14} />
+                            <ChevronRight size={14} />
                         </button>
                     </div>
 

--- a/frontend/src/components/SettingsMenu.tsx
+++ b/frontend/src/components/SettingsMenu.tsx
@@ -134,7 +134,7 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
         disallowedTools: '',
         appendSystemPrompt: '',
         effortLevel: 'high',
-        defaultModel: 'claude-opus-latest',
+        defaultModel: '',
         model: '',
     });
     const cliSwitchesTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -353,7 +353,7 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                         disallowedTools: config.claudeCodeSwitches.disallowedTools || '',
                         appendSystemPrompt: config.claudeCodeSwitches.appendSystemPrompt || '',
                         effortLevel: config.claudeCodeSwitches.effortLevel || 'high',
-                        defaultModel: config.claudeCodeSwitches.defaultModel || 'claude-opus-latest',
+                        defaultModel: config.claudeCodeSwitches.defaultModel || '',
                         model: config.claudeCodeSwitches.model || '',
                     });
                 }
@@ -2214,10 +2214,11 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                 </div>
                                 <select
                                     className="cli-switch-select"
-                                    value={cliSwitches.defaultModel || 'claude-opus-latest'}
+                                    value={cliSwitches.defaultModel || ''}
                                     onChange={(e) => handleCliSwitchToggle({ defaultModel: e.target.value })}
                                 >
-                                    <option value="claude-opus-latest">Opus 4.7 (default)</option>
+                                    <option value="">Let Claude decide (default)</option>
+                                    <option value="claude-opus-latest">Opus 4.7</option>
                                     <option value="claude-sonnet-4-6">Sonnet 4.6</option>
                                     <option value="claude-haiku-4-5-20251001">Haiku 4.5</option>
                                     <option value="opus">Opus (latest alias)</option>

--- a/frontend/src/components/SettingsMenu.tsx
+++ b/frontend/src/components/SettingsMenu.tsx
@@ -132,7 +132,8 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
         allowedTools: '',
         disallowedTools: '',
         appendSystemPrompt: '',
-        effortLevel: 'high'
+        effortLevel: 'high',
+        model: '',
     });
     const cliSwitchesTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -348,7 +349,8 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                         allowedTools: config.claudeCodeSwitches.allowedTools || '',
                         disallowedTools: config.claudeCodeSwitches.disallowedTools || '',
                         appendSystemPrompt: config.claudeCodeSwitches.appendSystemPrompt || '',
-                        effortLevel: config.claudeCodeSwitches.effortLevel || 'high'
+                        effortLevel: config.claudeCodeSwitches.effortLevel || 'high',
+                        model: config.claudeCodeSwitches.model || '',
                     });
                 }
             }
@@ -2293,6 +2295,25 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                     value={cliSwitches.disallowedTools}
                                     placeholder="e.g. Write, Bash (leave empty to disable)"
                                     onChange={(e) => handleCliSwitchChange({ disallowedTools: e.target.value })}
+                                />
+                            </div>
+
+                            {/* Default Model */}
+                            <div className="permission-item">
+                                <div className="permission-info">
+                                    <span className="permission-label">Default Model</span>
+                                    <span className="permission-description">
+                                        Model to use for new sessions (e.g. claude-opus-4-5, claude-sonnet-4-5). Leave empty to use Claude's default. Custom model IDs (e.g. Claude-Opus-4.6[1m]) are supported.
+                                    </span>
+                                </div>
+                            </div>
+                            <div className="cli-switch-text-row">
+                                <input
+                                    type="text"
+                                    className="cli-switch-text-input"
+                                    value={cliSwitches.model}
+                                    placeholder="e.g. claude-opus-4-5 (leave empty for default)"
+                                    onChange={(e) => handleCliSwitchChange({ model: e.target.value })}
                                 />
                             </div>
 

--- a/frontend/src/components/SettingsMenu.tsx
+++ b/frontend/src/components/SettingsMenu.tsx
@@ -135,7 +135,6 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
         appendSystemPrompt: '',
         effortLevel: 'high',
         defaultModel: '',
-        model: '',
     });
     const cliSwitchesTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -353,8 +352,7 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                         disallowedTools: config.claudeCodeSwitches.disallowedTools || '',
                         appendSystemPrompt: config.claudeCodeSwitches.appendSystemPrompt || '',
                         effortLevel: config.claudeCodeSwitches.effortLevel || 'high',
-                        defaultModel: config.claudeCodeSwitches.defaultModel || '',
-                        model: config.claudeCodeSwitches.model || '',
+                        defaultModel: config.claudeCodeSwitches.defaultModel || (config.claudeCodeSwitches as any).model || '',
                     });
                 }
             }
@@ -1246,7 +1244,11 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
     if (!isOpen) return null;
 
     return (
-        <div className="settings-menu-overlay" onClick={onClose}>
+        <div
+            className="settings-menu-overlay"
+            onMouseDown={(e) => { if (e.target === e.currentTarget) (e.currentTarget as HTMLElement).dataset.closeOnMouseup = '1'; }}
+            onMouseUp={(e) => { if ((e.currentTarget as HTMLElement).dataset.closeOnMouseup === '1' && e.target === e.currentTarget) onClose(); delete (e.currentTarget as HTMLElement).dataset.closeOnMouseup; }}
+        >
             <div className="settings-menu" onClick={(e) => e.stopPropagation()}>
                 <div className="settings-menu-header">
                     <div className="settings-menu-title">
@@ -2209,13 +2211,13 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                 <div className="permission-info">
                                     <span className="permission-label">Default Model</span>
                                     <span className="permission-description">
-                                        Model used for new tasks. Passed as --model to Claude Code CLI.
+                                        Model used for new tasks. Passed as --model to Claude Code CLI. Use the text box for custom model IDs.
                                     </span>
                                 </div>
                                 <select
                                     className="cli-switch-select"
-                                    value={cliSwitches.defaultModel || ''}
-                                    onChange={(e) => handleCliSwitchToggle({ defaultModel: e.target.value })}
+                                    value={['', 'claude-opus-latest', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001', 'opus', 'sonnet', 'haiku'].includes(cliSwitches.defaultModel || '') ? (cliSwitches.defaultModel || '') : '__custom__'}
+                                    onChange={(e) => { if (e.target.value !== '__custom__') handleCliSwitchToggle({ defaultModel: e.target.value }); }}
                                 >
                                     <option value="">Let Claude decide (default)</option>
                                     <option value="claude-opus-latest">Opus 4.7</option>
@@ -2224,7 +2226,17 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                     <option value="opus">Opus (latest alias)</option>
                                     <option value="sonnet">Sonnet (latest alias)</option>
                                     <option value="haiku">Haiku (latest alias)</option>
+                                    <option value="__custom__" disabled>Custom (use text box below)</option>
                                 </select>
+                            </div>
+                            <div className="cli-switch-text-row">
+                                <input
+                                    type="text"
+                                    className="cli-switch-text-input"
+                                    value={cliSwitches.defaultModel || ''}
+                                    placeholder="Custom model ID (e.g. Claude-Opus-4.6[1m])"
+                                    onChange={(e) => handleCliSwitchChange({ defaultModel: e.target.value })}
+                                />
                             </div>
 
                             {/* Max Turns */}
@@ -2354,25 +2366,6 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                     value={cliSwitches.disallowedTools}
                                     placeholder="e.g. Write, Bash (leave empty to disable)"
                                     onChange={(e) => handleCliSwitchChange({ disallowedTools: e.target.value })}
-                                />
-                            </div>
-
-                            {/* Default Model */}
-                            <div className="permission-item">
-                                <div className="permission-info">
-                                    <span className="permission-label">Default Model</span>
-                                    <span className="permission-description">
-                                        Model to use for new sessions (e.g. claude-opus-4-5, claude-sonnet-4-5). Leave empty to use Claude's default. Custom model IDs (e.g. Claude-Opus-4.6[1m]) are supported.
-                                    </span>
-                                </div>
-                            </div>
-                            <div className="cli-switch-text-row">
-                                <input
-                                    type="text"
-                                    className="cli-switch-text-input"
-                                    value={cliSwitches.model}
-                                    placeholder="e.g. claude-opus-4-5 (leave empty for default)"
-                                    onChange={(e) => handleCliSwitchChange({ model: e.target.value })}
                                 />
                             </div>
 

--- a/frontend/src/components/TaskInputBar.tsx
+++ b/frontend/src/components/TaskInputBar.tsx
@@ -72,7 +72,10 @@ export function TaskInputBar({ task, wsRef }: TaskInputBarProps) {
         };
     }, [task.id]);
 
-    const isDisabled = task.state === 'exited' || task.state === 'disconnected' || task.state === 'interrupted';
+    // Allow input for disconnected/exited/interrupted tasks — the backend auto-reconnects
+    // with --resume when input is sent, preserving the session context.
+    // Previously these states disabled the input bar, but writeToTask/reconnectTask handle them.
+    const isDisabled = false; // All states accept input; backend handles reconnection as needed
 
     // Re-focus the textarea when the browser window regains focus.
     // Without this, focus can land on the xterm terminal and the first

--- a/frontend/src/components/TaskTokenStats.css
+++ b/frontend/src/components/TaskTokenStats.css
@@ -9,16 +9,9 @@
     gap: 6px;
     width: 100%;
     padding: 4px 12px;
-    border: none;
     background: transparent;
     color: #6b7280;
-    cursor: pointer;
     text-align: left;
-    transition: background 0.15s ease;
-}
-
-.task-token-stats-bar:hover {
-    background: var(--bg-tertiary);
 }
 
 .token-value {
@@ -46,46 +39,3 @@
     color: #6b7280;
 }
 
-.token-expand-icon {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    color: #555;
-    opacity: 0.6;
-}
-
-/* Expanded detail table */
-.task-token-stats-detail {
-    padding: 4px 12px 8px;
-    border-top: 1px solid var(--border-color);
-}
-
-.token-breakdown-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.675rem;
-}
-
-.token-breakdown-table th {
-    text-align: left;
-    color: #555;
-    font-weight: 500;
-    padding: 3px 8px 3px 0;
-    border-bottom: 1px solid var(--border-color);
-    text-transform: uppercase;
-    font-size: 0.6rem;
-    letter-spacing: 0.5px;
-}
-
-.token-breakdown-table td {
-    padding: 3px 8px 3px 0;
-    color: #6b7280;
-}
-
-.token-breakdown-table td.model-name {
-    color: #6b7280;
-}
-
-.token-breakdown-table tbody tr:hover {
-    background: var(--bg-tertiary);
-}

--- a/frontend/src/components/TaskTokenStats.tsx
+++ b/frontend/src/components/TaskTokenStats.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
 import { useTaskStore } from '../stores/taskStore';
 import { ModelTokenUsage } from '@claudia/shared';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import './TaskTokenStats.css';
 
 interface TaskTokenStatsProps {
@@ -60,7 +58,7 @@ export function formatCost(cost: number): string {
 
 export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
     const task = useTaskStore(s => s.tasks.get(taskId));
-    const [expanded, setExpanded] = useState(false);
+    const tokenCostEnabled = useTaskStore(s => s.tokenCostEnabled);
 
     if (!task?.tokenUsage) {
         return null;
@@ -80,11 +78,7 @@ export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
 
     return (
         <div className="task-token-stats">
-            <button
-                className="task-token-stats-bar"
-                onClick={() => setExpanded(!expanded)}
-                title="Click to expand token usage details"
-            >
+            <div className="task-token-stats-bar">
                 <span className="token-stat">
                     <span className="token-value">{formatTokenCount(inputTokens)} in</span>
                     <span className="token-sep token-sep-section">|</span>
@@ -102,7 +96,7 @@ export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
                         </>
                     )}
                 </span>
-                {totalCostUsd > 0 && (
+                {tokenCostEnabled && totalCostUsd > 0 && (
                     <>
                         <span className="token-sep token-sep-section">|</span>
                         <span className="token-cost">Cost: {formatCost(totalCostUsd)}</span>
@@ -114,38 +108,7 @@ export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
                         <span className="token-model">{formatModelName(primaryModelName)}</span>
                     </>
                 )}
-                <span className="token-expand-icon">
-                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                </span>
-            </button>
-            {expanded && models.length > 0 && (
-                <div className="task-token-stats-detail">
-                    <table className="token-breakdown-table">
-                        <thead>
-                            <tr>
-                                <th>Model</th>
-                                <th>Input</th>
-                                <th>Output</th>
-                                <th>Cache Write</th>
-                                <th>Cache Read</th>
-                                <th>Cost</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {models.map(([name, usage]) => (
-                                <tr key={name}>
-                                    <td className="model-name">{formatModelName(name)}</td>
-                                    <td>{formatTokenCount(usage.inputTokens)}</td>
-                                    <td>{formatTokenCount(usage.outputTokens)}</td>
-                                    <td>{formatTokenCount(usage.cacheCreationTokens)}</td>
-                                    <td>{formatTokenCount(usage.cacheReadTokens)}</td>
-                                    <td>{formatCost(usage.costUsd)}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            )}
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/TaskTokenStats.tsx
+++ b/frontend/src/components/TaskTokenStats.tsx
@@ -126,7 +126,8 @@ export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
                                 <th>Model</th>
                                 <th>Input</th>
                                 <th>Output</th>
-                                <th>Cache</th>
+                                <th>Cache Write</th>
+                                <th>Cache Read</th>
                                 <th>Cost</th>
                             </tr>
                         </thead>
@@ -136,6 +137,7 @@ export function TaskTokenStats({ taskId }: TaskTokenStatsProps) {
                                     <td className="model-name">{formatModelName(name)}</td>
                                     <td>{formatTokenCount(usage.inputTokens)}</td>
                                     <td>{formatTokenCount(usage.outputTokens)}</td>
+                                    <td>{formatTokenCount(usage.cacheCreationTokens)}</td>
                                     <td>{formatTokenCount(usage.cacheReadTokens)}</td>
                                     <td>{formatCost(usage.costUsd)}</td>
                                 </tr>

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -69,14 +69,14 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
             }
         }, 300); // 300ms delay before showing spinner
 
-        // Safety timeout - hide spinner after 10s even if no restore received
+        // Safety timeout - hide spinner after 5s even if no restore received
         const safetyTimeout = setTimeout(() => {
             if (!historyLoadedRef.current) {
                 console.log(`[TerminalView] Safety timeout: hiding loading spinner for ${task.id}`);
                 historyLoadedRef.current = true;
                 setIsLoadingHistory(false);
             }
-        }, 10000);
+        }, 5000);
 
         return () => {
             clearTimeout(spinnerDelay);

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -29,7 +29,11 @@ function stripScreenClears(history: string): string {
         // \x1b[3J - Clear entire screen + scrollback
         .replace(/\x1b\[3J/g, '')
         // \x1b[?1049h / \x1b[?1049l - Alt screen buffer enter/exit
-        .replace(/\x1b\[\?1049[hl]/g, '');
+        .replace(/\x1b\[\?1049[hl]/g, '')
+        // Strip accumulated "Resuming session" / "Session reconnected" separator lines.
+        // These accumulate across server restarts and fill the terminal with noise,
+        // hiding the actual conversation content.
+        .replace(/\r?\n?\x1b\[90m─── (Resuming session [a-f0-9-]+|Session reconnected) ───\x1b\[0m\r?\n?\r?\n?/g, '');
 }
 
 

--- a/frontend/src/components/UsageDashboard.tsx
+++ b/frontend/src/components/UsageDashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { X, RefreshCw, DollarSign, Hash, BarChart3, Settings, ChevronDown, ChevronRight, Save } from 'lucide-react';
 import { UsageDashboardData, ModelPricing, ModelTokenUsage } from '@claudia/shared';
 import { getApiBaseUrl } from '../config/api-config';
+import { useTaskStore } from '../stores/taskStore';
 import { formatTokenCount, formatModelName, formatCost } from './TaskTokenStats';
 import './UsageDashboard.css';
 
@@ -25,6 +26,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
     const [savingPricing, setSavingPricing] = useState(false);
 
     const apiBase = getApiBaseUrl();
+    const tokenCostEnabled = useTaskStore(s => s.tokenCostEnabled);
 
     const fetchDashboard = useCallback(async () => {
         setLoading(true);
@@ -130,6 +132,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                 {data && (
                     <>
                         <div className="usage-summary-cards">
+                            {tokenCostEnabled && (
                             <div className="usage-card">
                                 <div className="usage-card-icon">
                                     <DollarSign size={20} />
@@ -139,6 +142,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                                     <span className="usage-card-label">Total Cost</span>
                                 </div>
                             </div>
+                            )}
                             <div className="usage-card">
                                 <div className="usage-card-icon input-icon">
                                     <BarChart3 size={20} />
@@ -179,7 +183,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                                                 <th>Tasks</th>
                                                 <th>Input</th>
                                                 <th>Output</th>
-                                                <th>Cost</th>
+                                                {tokenCostEnabled && <th>Cost</th>}
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -191,7 +195,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                                                     <td>{ws.taskCount}</td>
                                                     <td>{formatTokenCount(ws.inputTokens)}</td>
                                                     <td>{formatTokenCount(ws.outputTokens)}</td>
-                                                    <td className="cost-cell">{formatCost(ws.costUsd)}</td>
+                                                    {tokenCostEnabled && <td className="cost-cell">{formatCost(ws.costUsd)}</td>}
                                                 </tr>
                                             ))}
                                         </tbody>
@@ -211,7 +215,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                                                 <th>Tasks</th>
                                                 <th>Input</th>
                                                 <th>Output</th>
-                                                <th>Cost</th>
+                                                {tokenCostEnabled && <th>Cost</th>}
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -221,7 +225,7 @@ export function UsageDashboard({ isOpen, onClose }: UsageDashboardProps) {
                                                     <td>-</td>
                                                     <td>{formatTokenCount(usage.inputTokens)}</td>
                                                     <td>{formatTokenCount(usage.outputTokens)}</td>
-                                                    <td className="cost-cell">{formatCost(usage.costUsd)}</td>
+                                                    {tokenCostEnabled && <td className="cost-cell">{formatCost(usage.costUsd)}</td>}
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/frontend/src/components/WorkspacePanel.css
+++ b/frontend/src/components/WorkspacePanel.css
@@ -249,52 +249,42 @@
 }
 
 /* Task Sort Selector */
-.task-sort-selector {
+.workspace-dropdown-item.sort-row {
+    cursor: default;
+    gap: 6px;
+}
+
+.workspace-dropdown-item.sort-row:hover {
+    background: transparent;
+}
+
+.sort-toggle {
     display: flex;
-    align-items: center;
-    gap: 2px;
-    height: 18px;
-    padding: 0 3px 0 4px;
-    border: 1px solid rgba(0, 212, 255, 0.25);
-    border-radius: 8px;
-    background: rgba(0, 212, 255, 0.08);
-    color: var(--accent-secondary);
-    transition: all 0.2s ease;
-    cursor: pointer;
-    flex-shrink: 0;
+    margin-left: auto;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    overflow: hidden;
 }
 
-.task-sort-selector:hover {
-    background: rgba(0, 212, 255, 0.15);
-    border-color: rgba(0, 212, 255, 0.4);
-}
-
-.task-sort-icon {
-    flex-shrink: 0;
-    opacity: 0.8;
-}
-
-.task-sort-select {
+.sort-toggle-btn {
     background: transparent;
     border: none;
-    color: inherit;
-    font-size: 0.625rem;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
     font-family: inherit;
+    padding: 2px 7px;
     cursor: pointer;
-    outline: none;
-    padding: 0;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    padding-right: 10px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='7' viewBox='0 0 24 24' fill='none' stroke='%2300d4ff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 0 center;
+    transition: background 0.15s, color 0.15s;
 }
 
-.task-sort-select option {
-    background: var(--bg-secondary);
+.sort-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.08);
     color: var(--text-primary);
+}
+
+.sort-toggle-btn.active {
+    background: rgba(0, 212, 255, 0.18);
+    color: var(--accent-secondary);
 }
 
 .workspace-branch-label {

--- a/frontend/src/components/WorkspacePanel.tsx
+++ b/frontend/src/components/WorkspacePanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTaskStore } from '../stores/taskStore';
 import { Task, Workspace } from '@claudia/shared';
 import {
-    Loader2, Circle, ChevronRight, ChevronDown,
+    Loader2, Circle, ChevronRight, ChevronDown, ChevronLeft,
     Trash2, FolderOpen, Plus, Briefcase, Send, AlertCircle, StopCircle, Undo2, GripVertical, Archive, RotateCcw, Play, MoreVertical, Terminal, Search, GitBranch, ImagePlus, X, FileText, GripHorizontal, Copy, Pencil, Link2, Check, CheckCircle, FolderPlus, Clipboard, Columns2, Clock, Settings, ArrowDownAZ, ArrowDownUp
 } from 'lucide-react';
 import { getApiBaseUrl } from '../config/api-config';
@@ -1459,6 +1459,7 @@ interface WorkspacePanelProps {
     onAddCustomReference?: (workspaceId: string, path: string, description?: string) => void;
     onRemoveReference?: (workspaceId: string, referenceId: string) => void;
     onResetWorkspace?: (workspaceId: string) => void;
+    onCollapse?: () => void;
 }
 
 export function WorkspacePanel({
@@ -1486,7 +1487,8 @@ export function WorkspacePanel({
     onToggleReference,
     onAddCustomReference,
     onRemoveReference,
-    onResetWorkspace
+    onResetWorkspace,
+    onCollapse
 }: WorkspacePanelProps) {
     const {
         tasks,
@@ -1709,6 +1711,15 @@ export function WorkspacePanel({
                     >
                         <Plus size={16} />
                     </button>
+                    {onCollapse && (
+                        <button
+                            className="archived-toggle-button"
+                            onClick={onCollapse}
+                            title="Hide workspaces"
+                        >
+                            <ChevronLeft size={16} />
+                        </button>
+                    )}
                 </div>
             </div>
 

--- a/frontend/src/components/WorkspacePanel.tsx
+++ b/frontend/src/components/WorkspacePanel.tsx
@@ -893,26 +893,6 @@ function WorkspaceSection({
                     {tasks.length > 0 && (
                         <>
                             <span className="workspace-task-count">{tasks.length}</span>
-                            {tasks.length > 1 && (
-                                <div
-                                    className="task-sort-selector"
-                                    title="Sort tasks by"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <ArrowDownUp size={11} className="task-sort-icon" />
-                                    <select
-                                        className="task-sort-select"
-                                        value={taskSortBy}
-                                        onChange={(e) => {
-                                            e.stopPropagation();
-                                            setTaskSortBy(e.target.value as 'date-created' | 'last-modified');
-                                        }}
-                                    >
-                                        <option value="date-created">Newest</option>
-                                        <option value="last-modified">Recent</option>
-                                    </select>
-                                </div>
-                            )}
                         </>
                     )}
                     {workspace.references && workspace.references.length > 0 && (
@@ -1170,6 +1150,25 @@ function WorkspaceSection({
                                 <Search size={14} />
                                 <span>Code Review</span>
                             </button>
+                            {tasks.length > 1 && (
+                                <>
+                                    <div className="workspace-dropdown-divider" />
+                                    <div className="workspace-dropdown-item sort-row" onClick={(e) => e.stopPropagation()}>
+                                        <ArrowDownUp size={14} />
+                                        <span>Sort by</span>
+                                        <div className="sort-toggle">
+                                            <button
+                                                className={`sort-toggle-btn${taskSortBy === 'date-created' ? ' active' : ''}`}
+                                                onClick={(e) => { e.stopPropagation(); setTaskSortBy('date-created'); }}
+                                            >Newest</button>
+                                            <button
+                                                className={`sort-toggle-btn${taskSortBy === 'last-modified' ? ' active' : ''}`}
+                                                onClick={(e) => { e.stopPropagation(); setTaskSortBy('last-modified'); }}
+                                            >Recent</button>
+                                        </div>
+                                    </div>
+                                </>
+                            )}
                             <div className="workspace-dropdown-divider" />
                             <button
                                 className="workspace-dropdown-item reset"

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -199,6 +199,11 @@ export function useWebSocket() {
                                 );
                                 useTaskStore.getState().setAiCoreConfigured(aiCoreConfigured);
 
+                                // Sync token cost display setting
+                                if (config.tokenCostEnabled !== undefined) {
+                                    useTaskStore.getState().setTokenCostEnabled(config.tokenCostEnabled);
+                                }
+
                                 // Sync Deepgram API key from backend (for mobile/tunnel clients)
                                 if (config.deepgramApiKey && !useTaskStore.getState().deepgramApiKey) {
                                     useTaskStore.setState({ deepgramApiKey: config.deepgramApiKey });

--- a/frontend/src/stores/taskStore.ts
+++ b/frontend/src/stores/taskStore.ts
@@ -98,6 +98,7 @@ interface TaskStore {
     notifyOnCompletion: boolean;
     notifyOnWaitingInput: boolean;
     themePreference: ThemePreference;
+    tokenCostEnabled: boolean;
 
     // Actions
     setConnected: (connected: boolean) => void;
@@ -186,6 +187,7 @@ interface TaskStore {
     setNotifyOnCompletion: (enabled: boolean) => void;
     setNotifyOnWaitingInput: (enabled: boolean) => void;
     setThemePreference: (pref: ThemePreference) => void;
+    setTokenCostEnabled: (enabled: boolean) => void;
 }
 
 // Storage key for localStorage
@@ -290,6 +292,7 @@ export const useTaskStore = create<TaskStore>()(
             notifyOnCompletion: true,
             notifyOnWaitingInput: true,
             themePreference: 'system' as ThemePreference,
+            tokenCostEnabled: false,
 
             // Actions
             setConnected: (connected) => {
@@ -743,7 +746,8 @@ export const useTaskStore = create<TaskStore>()(
             setBrowserNotificationsEnabled: (enabled) => set({ browserNotificationsEnabled: enabled }),
             setNotifyOnCompletion: (enabled) => set({ notifyOnCompletion: enabled }),
             setNotifyOnWaitingInput: (enabled) => set({ notifyOnWaitingInput: enabled }),
-            setThemePreference: (pref) => set({ themePreference: pref })
+            setThemePreference: (pref) => set({ themePreference: pref }),
+            setTokenCostEnabled: (enabled) => set({ tokenCostEnabled: enabled })
         }),
         {
             name: STORAGE_KEY,

--- a/frontend/src/stores/taskStore.ts
+++ b/frontend/src/stores/taskStore.ts
@@ -240,6 +240,7 @@ interface PersistedState {
     voiceProgressUpdatesEnabled: boolean;
     voiceProgressUpdateInterval: number;
     themePreference: ThemePreference;
+    tokenCostEnabled: boolean;
     taskSummaries: [string, TaskSummary][];  // Stored as entries array
     chatMessages: ChatMessage[];
 }
@@ -822,6 +823,7 @@ export const useTaskStore = create<TaskStore>()(
                 voiceProgressUpdatesEnabled: state.voiceProgressUpdatesEnabled,
                 voiceProgressUpdateInterval: state.voiceProgressUpdateInterval,
                 themePreference: state.themePreference,
+                tokenCostEnabled: state.tokenCostEnabled,
                 taskSummaries: Array.from(state.taskSummaries.entries()),
                 chatMessages: state.chatMessages,
             }),
@@ -875,6 +877,7 @@ export const useTaskStore = create<TaskStore>()(
                     voiceProgressUpdatesEnabled: persisted.voiceProgressUpdatesEnabled ?? currentState.voiceProgressUpdatesEnabled,
                     voiceProgressUpdateInterval: persisted.voiceProgressUpdateInterval ?? currentState.voiceProgressUpdateInterval,
                     themePreference: persisted.themePreference ?? currentState.themePreference,
+                    tokenCostEnabled: persisted.tokenCostEnabled ?? currentState.tokenCostEnabled,
                     taskSummaries: persisted.taskSummaries
                         ? new Map(persisted.taskSummaries)
                         : currentState.taskSummaries,

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -373,28 +373,26 @@ body {
   border-right: none;
 }
 
-.sidebar-collapse-btn {
+.sidebar-toggle-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  align-self: center;
-  width: 14px;
-  height: 48px;
-  background: var(--bg-secondary);
+  width: 28px;
+  height: 28px;
+  background: transparent;
   border: 1px solid var(--border-color);
-  border-left: none;
-  border-radius: 0 6px 6px 0;
+  border-radius: 6px;
   color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
-  z-index: 11;
+  margin-right: 4px;
   padding: 0;
 }
 
-.sidebar-collapse-btn:hover {
-  background: var(--bg-tertiary, var(--bg-secondary));
-  color: var(--accent-secondary);
+.sidebar-toggle-btn:hover {
+  background: var(--bg-tertiary, rgba(255,255,255,0.08));
+  color: var(--text-primary);
 }
 
 /* Resize Handle */

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -368,30 +368,41 @@ body {
 }
 
 .sidebar.collapsed {
-  width: 36px;
-  min-width: 36px;
-  align-items: center;
-  padding-top: 10px;
+  width: auto;
+  min-width: 0;
 }
 
 .sidebar-expand-btn {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  background: transparent;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  gap: 4px;
+  padding: 8px 6px;
+  background: var(--bg-tertiary, #21262d);
+  border: none;
+  border-right: 1px solid var(--border-color);
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 0;
-  transition: background 0.15s, color 0.15s;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  letter-spacing: 0.5px;
+  height: 100%;
+  width: 28px;
 }
 
 .sidebar-expand-btn:hover {
-  background: rgba(255,255,255,0.08);
+  background: var(--bg-secondary);
   color: var(--text-primary);
+}
+
+.sidebar-expand-label {
+  margin-top: 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -365,15 +365,16 @@ body {
   z-index: 10;
   /* Never let the sidebar exceed the viewport width (handles narrow mobile viewports) */
   max-width: 100vw;
-  overflow: hidden;
-  transition: width 0.2s ease, min-width 0.2s ease;
 }
 
 .sidebar.collapsed {
-  border-right: none;
+  width: 36px;
+  min-width: 36px;
+  align-items: center;
+  padding-top: 10px;
 }
 
-.sidebar-toggle-btn {
+.sidebar-expand-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -384,16 +385,15 @@ body {
   border-radius: 6px;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-  flex-shrink: 0;
-  margin-right: 4px;
   padding: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-.sidebar-toggle-btn:hover {
-  background: var(--bg-tertiary, rgba(255,255,255,0.08));
+.sidebar-expand-btn:hover {
+  background: rgba(255,255,255,0.08);
   color: var(--text-primary);
 }
+
 
 /* Resize Handle */
 .resize-handle {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -373,21 +373,12 @@ body {
   border-right: none;
 }
 
-/* Sidebar edge: holds resize handle + collapse toggle */
-.sidebar-edge {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex-shrink: 0;
-  position: relative;
-  z-index: 10;
-}
-
 .sidebar-collapse-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
+  align-self: center;
+  width: 14px;
   height: 48px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
@@ -397,21 +388,18 @@ body {
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  left: 0;
+  z-index: 11;
+  padding: 0;
 }
 
 .sidebar-collapse-btn:hover {
   background: var(--bg-tertiary, var(--bg-secondary));
-  color: var(--text-primary);
+  color: var(--accent-secondary);
 }
 
 /* Resize Handle */
 .resize-handle {
   width: 4px;
-  height: 100%;
   cursor: col-resize;
   background: transparent;
   transition: background 0.2s ease;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -365,11 +365,53 @@ body {
   z-index: 10;
   /* Never let the sidebar exceed the viewport width (handles narrow mobile viewports) */
   max-width: 100vw;
+  overflow: hidden;
+  transition: width 0.2s ease, min-width 0.2s ease;
+}
+
+.sidebar.collapsed {
+  border-right: none;
+}
+
+/* Sidebar edge: holds resize handle + collapse toggle */
+.sidebar-edge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 10;
+}
+
+.sidebar-collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 48px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+}
+
+.sidebar-collapse-btn:hover {
+  background: var(--bg-tertiary, var(--bg-secondary));
+  color: var(--text-primary);
 }
 
 /* Resize Handle */
 .resize-handle {
   width: 4px;
+  height: 100%;
   cursor: col-resize;
   background: transparent;
   transition: background 0.2s ease;

--- a/start.ps1
+++ b/start.ps1
@@ -1,5 +1,4 @@
-# Claudia - Clean Start Script (PowerShell)
-# Kills existing processes and restarts on proper ports
+# Claudia - Start Script (PowerShell)
 
 $ErrorActionPreference = "Stop"
 
@@ -20,9 +19,9 @@ if (Test-Path $LOCK_FILE) {
     if ($LOCK_PID) {
         $proc = Get-Process -Id $LOCK_PID -ErrorAction SilentlyContinue
         if ($proc) {
-            Write-Host "Claudia is already running (PID: $LOCK_PID), killing it first..."
-            Stop-Process -Id $LOCK_PID -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds 2
+            Write-Host "Claudia is already running (PID: $LOCK_PID)."
+            Write-Host "   Stop it first or remove the lock file: Remove-Item $LOCK_FILE"
+            exit 1
         }
     }
     Remove-Item $LOCK_FILE -Force -ErrorAction SilentlyContinue
@@ -37,60 +36,23 @@ $null = Register-EngineEvent PowerShell.Exiting -Action {
     Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
 }
 
-Write-Host "Cleaning up existing processes..."
-
-# Kill processes on our ports
-foreach ($port in @($BACKEND_PORT, $FRONTEND_PORT, $OPENCODE_PORT)) {
-    $connections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
-    if ($connections) {
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            if ($procId -ne 0) {
-                Write-Host "   Killing process on port ${port}: PID $procId"
-                Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-            }
-        }
-    }
-}
-
-# Kill project-specific processes
-$processPatterns = @(
-    "claudia*backend*tsx",
-    "claudia*backend*index.ts",
-    "claudia*backend*test-cli",
-    "vite*claudia"
-)
-
-Get-Process -Name "node" -ErrorAction SilentlyContinue | ForEach-Object {
-    try {
-        $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-        if ($cmdLine) {
-            foreach ($pattern in $processPatterns) {
-                if ($cmdLine -like "*$pattern*") {
-                    Write-Host "   Killing process: $($_.Id) - $cmdLine"
-                    Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-                    break
-                }
-            }
-        }
-    } catch {}
-}
-
-# Kill stray Claude Code CLI processes
-Write-Host "Killing zombie Claude processes..."
-Get-Process -Name "claude" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-
-Start-Sleep -Seconds 2
-
-# Verify ports are free (ignore TimeWait connections with no owning process)
+Write-Host "Checking ports..."
+$ports_busy = $false
 foreach ($port in @($BACKEND_PORT, $FRONTEND_PORT, $OPENCODE_PORT)) {
     $activeConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue |
         Where-Object { $_.OwningProcess -ne 0 }
     if ($activeConnections) {
-        Write-Host "Port $port is still in use. Please kill manually:"
-        $activeConnections | Format-Table -AutoSize
-        exit 1
+        Write-Host "Port $port is already in use (PID: $($activeConnections[0].OwningProcess))"
+        $ports_busy = $true
     }
+}
+
+if ($ports_busy) {
+    Write-Host ""
+    Write-Host "Please free the ports above and try again."
+    Write-Host "You can kill a process on a port with: Stop-Process -Id (Get-NetTCPConnection -LocalPort <port>).OwningProcess -Force"
+    Remove-Item $LOCK_FILE -Force -ErrorAction SilentlyContinue
+    exit 1
 }
 
 Write-Host "Ports are free"


### PR DESCRIPTION
## Summary
- Parse Claude Code session JSONL files to extract per-task token usage (input, output, cache write, cache read) and compute costs using configurable pricing
- Per-task token stats bar displayed below the input area showing token breakdown and cost
- Full usage dashboard (toolbar button) with aggregate views by workspace and model, plus configurable enterprise pricing
- Fix zombie task bugs: disconnected tasks no longer appear as \"busy\", stopTask handles disconnected tasks, auto-reconnect is staggered instead of abandoning tasks beyond the cap
- Fix idle task reconnection: all live tasks now marked as interrupted on server restart so idle tasks also reconnect after tsx watch reloads
- Fix prompt delivery race condition: MCP-created tasks sometimes failed to paste the prompt into the Claude Code session, leaving the session hanging at an empty input

## Changes

### Backend
- **`backend/src/token-parser.ts`** (new): Parses `~/.claude/projects/<hash>/<session>.jsonl` files, deduplicates by UUID, aggregates per-model token usage
- **`backend/src/config-store.ts`**: Configurable token pricing with current Anthropic rates (Opus 4.6 $5/$25, Sonnet 4.6 $3/$15, Haiku 4.5 $1/$5); `tokenCostEnabled` field
- **`backend/src/task-spawner.ts`**:
  - `captureTokenUsage()` on busy→idle and process exit
  - Zombie task fixes (stale state display, stopTask for disconnected tasks, staggered auto-reconnect)
  - `saveTasks()` sets `wasInterrupted=true` for **all** live tasks (not just busy/starting) — idle tasks also have their PTY killed on restart and should reconnect within the 1-hour stale window; `shouldContinue` (auto-continue mid-turn) still only applies to busy/starting tasks
  - Display state uses `lastState` instead of `wasInterrupted` to distinguish `'interrupted'` (mid-turn) from `'disconnected'` (idle) in the UI
  - Idle reaper skips tasks whose `lastActivity` predates `startedAt`, preventing immediate reap of already-idle tasks on every restart
  - **Prompt delivery fix**: `sendPromptWithRetry` now verifies TUI accepted the write by checking output growth; retries with Ctrl+U clear + 1500ms delay if not accepted (up to 5x). Enter delay cap raised from 1000ms to 2500ms. Added `bypass permissions`/`shift+tab` to ready signal detection patterns.
- **`backend/src/server.ts`**: REST endpoints (`GET/PUT /api/usage/config`, `GET /api/usage/dashboard`), WebSocket event `task:tokenUsage`; `cacheCreationTokens`/`cacheReadTokens` in token usage initializer

### Frontend
- **`TaskTokenStats.tsx`**: Compact per-task bar: `1.6k in | 88.8k out | 2.6M cache write | 32.7M cache read | Cost: $34.28 | Opus 4.6`
- **`UsageDashboard.tsx`**: Full dashboard modal with summary cards, workspace/model tables, configurable pricing
- **`taskStore.ts`** / **`useWebSocket.ts`**: Handle `task:tokenUsage` WebSocket messages
- **`App.tsx`**: Dashboard button (BarChart3 icon) in top-right toolbar

### Shared
- **`shared/src/index.ts`**: `TaskTokenUsage`, `ModelTokenUsage`, `UsageDashboardData`, `ModelPricing` types; `tokenUsage` field on `Task`

## Test plan
- [ ] Create a task, wait for it to go idle — verify token stats bar appears below input
- [ ] Click the stats bar — verify per-model breakdown expands
- [ ] Click BarChart3 icon in toolbar — verify dashboard opens with aggregate data
- [ ] Check cost values against Claude Code's `/cost` command
- [ ] Modify pricing in dashboard settings — verify costs recalculate
- [ ] Kill server (tsx watch restart) — verify **all** tasks reconnect (idle + busy), staggered
- [ ] Verify disconnected tasks show as "disconnected" not "busy"
- [ ] Verify idle tasks that were idle before the restart are **not** immediately reaped
- [ ] Create multiple tasks rapidly via MCP — verify all receive their prompts
- [ ] Check server logs for "Prompt write NOT accepted" retry messages during rapid task creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)