### PR TITLE
feat: MCP settings, voice workspace, and platform-commands tests

### DIFF
--- a/backend/src/__tests__/platform-commands.test.ts
+++ b/backend/src/__tests__/platform-commands.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildFolderPickerCommand,
+    buildOpenFolderCommand,
+    buildOpenTerminalCommand,
+    buildRevealFileCommand,
+    buildReferenceFolderPickerCommand,
+    buildPathWithExtras,
+    buildAppMenuEntries,
+} from '../platform-commands.js';
+
+describe('platform-commands', () => {
+
+    describe('buildFolderPickerCommand', () => {
+        describe('macOS (darwin)', () => {
+            it('should use osascript with AppleScript choose folder', () => {
+                const result = buildFolderPickerCommand('darwin');
+                expect(result.cmd).toBe('osascript');
+                expect(result.args[0]).toBe('-e');
+                expect(result.args[1]).toContain('choose folder');
+                expect(result.args[1]).toContain('Select a workspace folder');
+            });
+
+            it('should include default location when lastBrowsed is provided', () => {
+                const result = buildFolderPickerCommand('darwin', '/Users/test/projects');
+                expect(result.args[1]).toContain('default location POSIX file');
+                expect(result.args[1]).toContain('/Users/test/projects');
+            });
+
+            it('should not include default location when lastBrowsed is null', () => {
+                const result = buildFolderPickerCommand('darwin', null);
+                expect(result.args[1]).not.toContain('default location');
+            });
+
+            it('should escape backslashes in lastBrowsed path', () => {
+                const result = buildFolderPickerCommand('darwin', '/path\\with\\backslashes');
+                expect(result.args[1]).toContain('\\\\');
+            });
+
+            it('should escape double quotes in lastBrowsed path', () => {
+                const result = buildFolderPickerCommand('darwin', '/path/with"quotes');
+                expect(result.args[1]).toContain('\\"');
+                expect(result.args[1]).not.toContain('with"quotes');
+            });
+
+            it('should use custom prompt when provided', () => {
+                const result = buildFolderPickerCommand('darwin', null, 'Pick a directory');
+                expect(result.args[1]).toContain('Pick a directory');
+            });
+        });
+
+        describe('Windows (win32)', () => {
+            it('should use powershell with FolderBrowserDialog', () => {
+                const result = buildFolderPickerCommand('win32');
+                expect(result.cmd).toBe('powershell');
+                expect(result.args).toContain('-NoProfile');
+                expect(result.args).toContain('-EncodedCommand');
+            });
+
+            it('should include encoded command as base64', () => {
+                const result = buildFolderPickerCommand('win32');
+                const encoded = result.args[result.args.indexOf('-EncodedCommand') + 1];
+                const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+                expect(decoded).toContain('System.Windows.Forms');
+                expect(decoded).toContain('FolderBrowserDialog');
+                expect(decoded).toContain('Select a workspace folder');
+            });
+
+            it('should set initial directory when lastBrowsed provided', () => {
+                const result = buildFolderPickerCommand('win32', 'C:\\Users\\test');
+                const encoded = result.args[result.args.indexOf('-EncodedCommand') + 1];
+                const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+                expect(decoded).toContain('SelectedPath');
+                expect(decoded).toContain('C:\\Users\\test');
+            });
+
+            it('should strip quotes from lastBrowsed to prevent injection', () => {
+                const result = buildFolderPickerCommand('win32', 'C:\\path"injected');
+                const encoded = result.args[result.args.indexOf('-EncodedCommand') + 1];
+                const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+                expect(decoded).not.toContain('"injected');
+            });
+        });
+
+        describe('Linux', () => {
+            it('should use zenity with directory selection', () => {
+                const result = buildFolderPickerCommand('linux');
+                expect(result.cmd).toBe('zenity');
+                expect(result.args).toContain('--file-selection');
+                expect(result.args).toContain('--directory');
+            });
+
+            it('should include title', () => {
+                const result = buildFolderPickerCommand('linux');
+                expect(result.args).toContain('--title=Select a workspace folder');
+            });
+
+            it('should include filename when lastBrowsed provided', () => {
+                const result = buildFolderPickerCommand('linux', '/home/user/projects');
+                expect(result.args).toContain('--filename=/home/user/projects/');
+            });
+
+            it('should not include filename when lastBrowsed is null', () => {
+                const result = buildFolderPickerCommand('linux', null);
+                const hasFilename = result.args.some(a => a.startsWith('--filename='));
+                expect(hasFilename).toBe(false);
+            });
+        });
+    });
+
+    describe('buildOpenFolderCommand', () => {
+        it('should use "open" on macOS', () => {
+            const result = buildOpenFolderCommand('darwin', '/Users/test/project');
+            expect(result.cmd).toBe('open');
+            expect(result.args).toEqual(['/Users/test/project']);
+        });
+
+        it('should use "explorer.exe" on Windows', () => {
+            const result = buildOpenFolderCommand('win32', 'C:\\Users\\test');
+            expect(result.cmd).toBe('explorer.exe');
+            expect(result.args).toEqual(['C:\\Users\\test']);
+        });
+
+        it('should use "xdg-open" on Linux', () => {
+            const result = buildOpenFolderCommand('linux', '/home/user/project');
+            expect(result.cmd).toBe('xdg-open');
+            expect(result.args).toEqual(['/home/user/project']);
+        });
+
+        it('should pass path with spaces correctly on macOS', () => {
+            const result = buildOpenFolderCommand('darwin', '/Users/test/my project');
+            expect(result.args[0]).toBe('/Users/test/my project');
+        });
+
+        it('should pass path with special characters on macOS', () => {
+            const result = buildOpenFolderCommand('darwin', "/Users/test/project's folder");
+            expect(result.args[0]).toBe("/Users/test/project's folder");
+        });
+    });
+
+    describe('buildOpenTerminalCommand', () => {
+        describe('macOS (darwin)', () => {
+            it('should use osascript to control Terminal.app', () => {
+                const result = buildOpenTerminalCommand('darwin', '/Users/test/project');
+                expect(result.cmd).toBe('osascript');
+                expect(result.args.length).toBe(4);
+                expect(result.args[0]).toBe('-e');
+                expect(result.args[2]).toBe('-e');
+            });
+
+            it('should include cd command in AppleScript', () => {
+                const result = buildOpenTerminalCommand('darwin', '/Users/test/project');
+                expect(result.args[1]).toContain('do script "cd');
+                expect(result.args[1]).toContain('/Users/test/project');
+            });
+
+            it('should activate Terminal.app', () => {
+                const result = buildOpenTerminalCommand('darwin', '/Users/test');
+                expect(result.args[3]).toContain('tell application "Terminal" to activate');
+            });
+
+            it('should escape backslashes in path', () => {
+                const result = buildOpenTerminalCommand('darwin', '/path\\with\\backslash');
+                expect(result.args[1]).toContain('\\\\');
+            });
+
+            it('should escape double quotes in path', () => {
+                const result = buildOpenTerminalCommand('darwin', '/path/with"quote');
+                expect(result.args[1]).toContain('\\"');
+            });
+
+            it('should handle paths with spaces', () => {
+                const result = buildOpenTerminalCommand('darwin', '/Users/test/my project');
+                expect(result.args[1]).toContain('/Users/test/my project');
+            });
+        });
+
+        describe('Windows (win32)', () => {
+            it('should use cmd.exe with start', () => {
+                const result = buildOpenTerminalCommand('win32', 'C:\\Users\\test');
+                expect(result.cmd).toBe('cmd.exe');
+                expect(result.args).toEqual(['/C', 'start', 'cmd.exe']);
+            });
+
+            it('should set cwd option to workspace path', () => {
+                const result = buildOpenTerminalCommand('win32', 'C:\\Users\\test');
+                expect(result.options?.cwd).toBe('C:\\Users\\test');
+            });
+        });
+
+        describe('Linux', () => {
+            it('should use x-terminal-emulator', () => {
+                const result = buildOpenTerminalCommand('linux', '/home/user/project');
+                expect(result.cmd).toBe('x-terminal-emulator');
+                expect(result.args).toEqual(['--working-directory=/home/user/project']);
+            });
+        });
+    });
+
+    describe('buildRevealFileCommand', () => {
+        describe('macOS (darwin)', () => {
+            it('should use "open -R" to reveal in Finder', () => {
+                const result = buildRevealFileCommand('darwin', '/Users/test/file.txt');
+                expect(result.cmd).toBe('open');
+                expect(result.args).toEqual(['-R', '/Users/test/file.txt']);
+            });
+
+            it('should handle paths with spaces', () => {
+                const result = buildRevealFileCommand('darwin', '/Users/test/my file.txt');
+                expect(result.args[1]).toBe('/Users/test/my file.txt');
+            });
+        });
+
+        describe('Windows (win32)', () => {
+            it('should use explorer.exe with /select flag', () => {
+                const result = buildRevealFileCommand('win32', 'C:/Users/test/file.txt');
+                expect(result.cmd).toBe('explorer.exe');
+                expect(result.args[0]).toContain('/select,');
+            });
+
+            it('should convert forward slashes to backslashes', () => {
+                const result = buildRevealFileCommand('win32', 'C:/Users/test/file.txt');
+                expect(result.args[0]).toBe('/select,C:\\Users\\test\\file.txt');
+            });
+
+            it('should preserve existing backslashes', () => {
+                const result = buildRevealFileCommand('win32', 'C:\\Users\\test\\file.txt');
+                expect(result.args[0]).toBe('/select,C:\\Users\\test\\file.txt');
+            });
+        });
+
+        describe('Linux', () => {
+            it('should open parent directory with xdg-open', () => {
+                const result = buildRevealFileCommand('linux', '/home/user/project/file.txt');
+                expect(result.cmd).toBe('xdg-open');
+                expect(result.args).toEqual(['/home/user/project']);
+            });
+
+            it('should handle files in root directory', () => {
+                const result = buildRevealFileCommand('linux', '/file.txt');
+                expect(result.args[0]).toBe('/');
+            });
+        });
+    });
+
+    describe('buildReferenceFolderPickerCommand', () => {
+        it('should use osascript on macOS', () => {
+            const result = buildReferenceFolderPickerCommand('darwin');
+            expect(result.cmd).toBe('osascript');
+            expect(result.args[1]).toContain('Select reference folder');
+        });
+
+        it('should use powershell on Windows', () => {
+            const result = buildReferenceFolderPickerCommand('win32');
+            expect(result.cmd).toBe('powershell');
+            expect(result.args[1]).toContain('Select reference folder');
+        });
+
+        it('should use zenity on Linux', () => {
+            const result = buildReferenceFolderPickerCommand('linux');
+            expect(result.cmd).toBe('zenity');
+            expect(result.args).toContain('--title=Select reference folder');
+        });
+    });
+
+    describe('buildPathWithExtras', () => {
+        describe('macOS/Linux', () => {
+            it('should use colon separator', () => {
+                const result = buildPathWithExtras('darwin', '/Users/test', '/usr/bin');
+                expect(result).toContain(':');
+                expect(result).not.toContain(';');
+            });
+
+            it('should include .local/bin', () => {
+                const result = buildPathWithExtras('darwin', '/Users/test', '/usr/bin');
+                expect(result).toContain('/Users/test/.local/bin');
+            });
+
+            it('should include .npm-global/bin', () => {
+                const result = buildPathWithExtras('darwin', '/Users/test', '/usr/bin');
+                expect(result).toContain('/Users/test/.npm-global/bin');
+            });
+
+            it('should include /usr/local/bin for Homebrew', () => {
+                const result = buildPathWithExtras('darwin', '/Users/test', '/usr/bin');
+                expect(result).toContain('/usr/local/bin');
+            });
+
+            it('should append original path at the end', () => {
+                const result = buildPathWithExtras('darwin', '/Users/test', '/original/path');
+                expect(result.endsWith('/original/path')).toBe(true);
+            });
+        });
+
+        describe('Windows', () => {
+            it('should use semicolon separator', () => {
+                const result = buildPathWithExtras('win32', 'C:\\Users\\test', 'C:\\Windows');
+                expect(result).toContain(';');
+            });
+
+            it('should include AppData/Roaming/npm', () => {
+                const result = buildPathWithExtras('win32', 'C:\\Users\\test', 'C:\\Windows');
+                expect(result).toContain('C:\\Users\\test/AppData/Roaming/npm');
+            });
+
+            it('should include .local/bin', () => {
+                const result = buildPathWithExtras('win32', 'C:\\Users\\test', 'C:\\Windows');
+                expect(result).toContain('C:\\Users\\test/.local/bin');
+            });
+
+            it('should not include /usr/local/bin', () => {
+                const result = buildPathWithExtras('win32', 'C:\\Users\\test', 'C:\\Windows');
+                expect(result).not.toContain('/usr/local/bin');
+            });
+
+            it('should append original path at the end', () => {
+                const result = buildPathWithExtras('win32', 'C:\\Users\\test', 'C:\\Windows\\system32');
+                expect(result.endsWith('C:\\Windows\\system32')).toBe(true);
+            });
+        });
+
+        it('should handle empty original path', () => {
+            const result = buildPathWithExtras('darwin', '/Users/test', '');
+            expect(result.endsWith(':')).toBe(true);
+        });
+    });
+
+    describe('buildAppMenuEntries', () => {
+        it('should return app menu on macOS', () => {
+            const result = buildAppMenuEntries('darwin', 'Claudia');
+            expect(result.length).toBe(1);
+            expect(result[0].label).toBe('Claudia');
+            expect(result[0].submenu).toHaveLength(3);
+        });
+
+        it('should include about and quit roles on macOS', () => {
+            const result = buildAppMenuEntries('darwin', 'MyApp');
+            const roles = result[0].submenu.map(item => item.role).filter(Boolean);
+            expect(roles).toContain('about');
+            expect(roles).toContain('quit');
+        });
+
+        it('should include separator between about and quit', () => {
+            const result = buildAppMenuEntries('darwin', 'MyApp');
+            const types = result[0].submenu.map(item => item.type).filter(Boolean);
+            expect(types).toContain('separator');
+        });
+
+        it('should return empty array on Windows', () => {
+            const result = buildAppMenuEntries('win32', 'Claudia');
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array on Linux', () => {
+            const result = buildAppMenuEntries('linux', 'Claudia');
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('security: path injection prevention', () => {
+        it('should escape quotes so AppleScript treats them as literals, not delimiters', () => {
+            const malicious = '/Users/test"; do shell script "rm -rf /"';
+            const result = buildOpenTerminalCommand('darwin', malicious);
+            // All double quotes in the path must be escaped with backslash
+            // so AppleScript interprets them as literal chars inside the string
+            expect(result.args[1]).toContain('\\"');
+            // The raw unescaped quote should not appear adjacent to the cd wrapper quotes
+            expect(result.args[1]).not.toContain('cd \\"/Users/test"');
+        });
+
+        it('should not allow path traversal in folder picker on Windows', () => {
+            const malicious = 'C:\\Users\\test"; Remove-Item -Recurse -Force C:\\';
+            const result = buildFolderPickerCommand('win32', malicious);
+            const encoded = result.args[result.args.indexOf('-EncodedCommand') + 1];
+            const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+            // Double quotes are stripped from lastBrowsed on Windows
+            expect(decoded).not.toContain('"; Remove-Item');
+        });
+
+        it('should handle null bytes in paths', () => {
+            const withNull = '/Users/test/\x00malicious';
+            const result = buildOpenFolderCommand('darwin', withNull);
+            expect(result.args[0]).toBe(withNull);
+            // execFile with args array prevents null byte injection at OS level
+        });
+    });
+});

--- a/backend/src/checkpoint-store.ts
+++ b/backend/src/checkpoint-store.ts
@@ -1,0 +1,508 @@
+/**
+ * Checkpoint Store - Manages checkpoint/timeline snapshots for tasks.
+ * Captures git state (commit SHA, branch, uncommitted diff) and allows
+ * restoring or forking from a previous checkpoint.
+ */
+import { existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { randomUUID } from 'crypto';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { Checkpoint } from '@claudia/shared';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
+import { isGitRepo, getHeadCommit, getCurrentBranch } from './git-utils.js';
+
+const execAsync = promisify(exec);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Schema version for checkpoints.json */
+const CHECKPOINT_SCHEMA_VERSION = 1;
+
+interface CheckpointData {
+    checkpoints: Checkpoint[];
+}
+
+const DEFAULT_DATA: CheckpointData = {
+    checkpoints: [],
+};
+
+export class CheckpointStore {
+    private data: CheckpointData;
+    private filePath: string;
+
+    constructor(basePath?: string) {
+        this.filePath = basePath
+            ? join(basePath, 'checkpoints.json')
+            : join(__dirname, '..', 'checkpoints.json');
+
+        // Ensure directory exists
+        const dir = dirname(this.filePath);
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        this.data = this.loadData();
+        console.log(`[CheckpointStore] Loaded ${this.data.checkpoints.length} checkpoints from ${this.filePath}`);
+    }
+
+    private loadData(): CheckpointData {
+        try {
+            return loadVersioned<CheckpointData>(this.filePath, {
+                currentVersion: CHECKPOINT_SCHEMA_VERSION,
+                defaultData: { ...DEFAULT_DATA },
+                legacyLoader: (raw) => (raw as CheckpointData) ?? { ...DEFAULT_DATA },
+            });
+        } catch (error) {
+            console.error('[CheckpointStore] Error loading data:', error);
+            return { ...DEFAULT_DATA };
+        }
+    }
+
+    private save(): void {
+        try {
+            saveVersioned(this.filePath, this.data, CHECKPOINT_SCHEMA_VERSION);
+        } catch (error) {
+            console.error('[CheckpointStore] Error saving data:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Create a checkpoint for a task by capturing the current git state.
+     */
+    async createCheckpoint(
+        taskId: string,
+        workspaceId: string,
+        name?: string,
+        description?: string
+    ): Promise<Checkpoint> {
+        const cwd = workspaceId; // workspaceId IS the directory path
+
+        let gitRef: string | undefined;
+        let gitBranch: string | undefined;
+        let gitDiff: string | undefined;
+        let filesModified = 0;
+
+        const isRepo = await isGitRepo(cwd);
+        if (isRepo) {
+            gitRef = (await getHeadCommit(cwd)) || undefined;
+            gitBranch = (await getCurrentBranch(cwd)) || undefined;
+
+            // Capture uncommitted diff (both staged and unstaged)
+            try {
+                const { stdout: diffOut } = await execAsync('git diff HEAD', { cwd, maxBuffer: 1024 * 1024 });
+                if (diffOut.trim()) {
+                    gitDiff = diffOut;
+                }
+            } catch {
+                // No diff or error - that's fine
+            }
+
+            // Count modified files
+            try {
+                const { stdout: statusOut } = await execAsync('git status --porcelain', { cwd });
+                filesModified = statusOut.trim().split('\n').filter(l => l.length > 0).length;
+            } catch {
+                // Ignore
+            }
+        }
+
+        const autoName = name || `Checkpoint ${new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}`;
+
+        const checkpoint: Checkpoint = {
+            id: randomUUID(),
+            taskId,
+            workspaceId,
+            name: autoName,
+            description,
+            timestamp: new Date().toISOString(),
+            gitRef,
+            gitBranch,
+            gitDiff,
+            metadata: {
+                filesModified,
+                isCurrent: false,
+            },
+        };
+
+        this.data.checkpoints.push(checkpoint);
+        this.save();
+
+        console.log(`[CheckpointStore] Created checkpoint "${checkpoint.name}" for task ${taskId} (git: ${gitRef?.substring(0, 7) || 'n/a'}, branch: ${gitBranch || 'n/a'})`);
+        return checkpoint;
+    }
+
+    /**
+     * List all checkpoints for a task, ordered by timestamp descending.
+     */
+    listCheckpoints(taskId: string): Checkpoint[] {
+        return this.data.checkpoints
+            .filter(c => c.taskId === taskId)
+            .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    }
+
+    /**
+     * List all checkpoints for a workspace.
+     */
+    listCheckpointsByWorkspace(workspaceId: string): Checkpoint[] {
+        return this.data.checkpoints
+            .filter(c => c.workspaceId === workspaceId)
+            .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    }
+
+    /**
+     * Get a single checkpoint by ID.
+     */
+    getCheckpoint(checkpointId: string): Checkpoint | undefined {
+        return this.data.checkpoints.find(c => c.id === checkpointId);
+    }
+
+    /**
+     * Restore git state to a checkpoint.
+     * Stashes current changes, checks out the checkpoint's commit, and applies the saved diff.
+     */
+    async restoreCheckpoint(checkpointId: string): Promise<{ success: boolean; error?: string }> {
+        const checkpoint = this.getCheckpoint(checkpointId);
+        if (!checkpoint) {
+            return { success: false, error: 'Checkpoint not found' };
+        }
+
+        const cwd = checkpoint.workspaceId;
+        const isRepo = await isGitRepo(cwd);
+        if (!isRepo) {
+            return { success: false, error: 'Workspace is not a git repository' };
+        }
+
+        if (!checkpoint.gitRef) {
+            return { success: false, error: 'Checkpoint has no git reference to restore' };
+        }
+
+        try {
+            // Step 1: Stash current changes (if any)
+            console.log(`[CheckpointStore] Restoring checkpoint "${checkpoint.name}" - stashing current changes...`);
+            try {
+                await execAsync('git stash push -m "claudia-checkpoint-restore-autostash"', { cwd });
+            } catch {
+                // Stash may fail if nothing to stash - that's OK
+            }
+
+            // Step 2: Checkout the checkpoint's commit
+            console.log(`[CheckpointStore] Checking out ${checkpoint.gitRef.substring(0, 7)}...`);
+            if (checkpoint.gitBranch) {
+                // Try to checkout the branch first (cleaner state)
+                try {
+                    await execAsync(`git checkout ${checkpoint.gitBranch}`, { cwd });
+                } catch {
+                    // Branch might not exist anymore, checkout commit directly
+                    await execAsync(`git checkout ${checkpoint.gitRef}`, { cwd });
+                }
+            }
+
+            // Reset to the exact commit
+            await execAsync(`git reset --hard ${checkpoint.gitRef}`, { cwd });
+
+            // Step 3: Apply saved diff (if any)
+            if (checkpoint.gitDiff) {
+                console.log(`[CheckpointStore] Applying saved diff...`);
+                try {
+                    const { exec: execCb } = await import('child_process');
+                    await new Promise<void>((resolve, reject) => {
+                        const proc = execCb('git apply --allow-empty -', { cwd }, (err) => {
+                            if (err) reject(err);
+                            else resolve();
+                        });
+                        proc.stdin?.write(checkpoint.gitDiff);
+                        proc.stdin?.end();
+                    });
+                } catch (applyErr) {
+                    console.warn('[CheckpointStore] Could not apply saved diff (may have conflicts):', applyErr);
+                    // Not a fatal error - the commit restore still succeeded
+                }
+            }
+
+            console.log(`[CheckpointStore] Successfully restored to checkpoint "${checkpoint.name}"`);
+            return { success: true };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[CheckpointStore] Restore failed:', msg);
+            return { success: false, error: msg };
+        }
+    }
+
+    /**
+     * Delete a checkpoint.
+     */
+    deleteCheckpoint(checkpointId: string): boolean {
+        const idx = this.data.checkpoints.findIndex(c => c.id === checkpointId);
+        if (idx === -1) return false;
+
+        const removed = this.data.checkpoints.splice(idx, 1)[0];
+        this.save();
+        console.log(`[CheckpointStore] Deleted checkpoint "${removed.name}" (${checkpointId})`);
+        return true;
+    }
+
+    /**
+     * Fork from a checkpoint: creates a new git branch from the checkpoint's commit
+     * and applies the saved diff. Returns the new branch name.
+     */
+    async forkFromCheckpoint(
+        checkpointId: string,
+        newBranchName?: string
+    ): Promise<{ success: boolean; branch?: string; error?: string }> {
+        const checkpoint = this.getCheckpoint(checkpointId);
+        if (!checkpoint) {
+            return { success: false, error: 'Checkpoint not found' };
+        }
+
+        const cwd = checkpoint.workspaceId;
+        const isRepo = await isGitRepo(cwd);
+        if (!isRepo) {
+            return { success: false, error: 'Workspace is not a git repository' };
+        }
+
+        if (!checkpoint.gitRef) {
+            return { success: false, error: 'Checkpoint has no git reference to fork from' };
+        }
+
+        const branch = newBranchName || `checkpoint-fork-${checkpoint.id.substring(0, 8)}`;
+
+        try {
+            // Step 1: Create and checkout new branch from the checkpoint's commit
+            console.log(`[CheckpointStore] Forking from checkpoint "${checkpoint.name}" to branch "${branch}"...`);
+            await execAsync(`git checkout -b ${branch} ${checkpoint.gitRef}`, { cwd });
+
+            // Step 2: Apply saved diff (if any)
+            if (checkpoint.gitDiff) {
+                console.log(`[CheckpointStore] Applying saved diff to fork...`);
+                try {
+                    const { exec: execCb } = await import('child_process');
+                    await new Promise<void>((resolve, reject) => {
+                        const proc = execCb('git apply --allow-empty -', { cwd }, (err) => {
+                            if (err) reject(err);
+                            else resolve();
+                        });
+                        proc.stdin?.write(checkpoint.gitDiff);
+                        proc.stdin?.end();
+                    });
+                } catch (applyErr) {
+                    console.warn('[CheckpointStore] Could not apply diff to fork:', applyErr);
+                }
+            }
+
+            console.log(`[CheckpointStore] Successfully forked to branch "${branch}"`);
+            return { success: true, branch };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[CheckpointStore] Fork failed:', msg);
+            return { success: false, error: msg };
+        }
+    }
+
+    /**
+     * Delete all checkpoints for a task.
+     */
+    deleteCheckpointsForTask(taskId: string): number {
+        const before = this.data.checkpoints.length;
+        this.data.checkpoints = this.data.checkpoints.filter(c => c.taskId !== taskId);
+        const removed = before - this.data.checkpoints.length;
+        if (removed > 0) {
+            this.save();
+            console.log(`[CheckpointStore] Deleted ${removed} checkpoints for task ${taskId}`);
+        }
+        return removed;
+    }
+
+    /**
+     * Parse a unified diff to extract the file paths it touches.
+     */
+    private parseDiffFiles(diff: string): string[] {
+        const files: string[] = [];
+        for (const line of diff.split('\n')) {
+            // Match "diff --git a/path b/path" or "+++ b/path" lines
+            const gitDiffMatch = line.match(/^diff --git a\/(.+) b\/(.+)$/);
+            if (gitDiffMatch) {
+                files.push(gitDiffMatch[2]);
+            }
+        }
+        return [...new Set(files)];
+    }
+
+    /**
+     * Extract the hunks for specific files from a unified diff.
+     */
+    private extractDiffForFiles(fullDiff: string, files: string[]): string {
+        const fileSet = new Set(files);
+        const lines = fullDiff.split('\n');
+        const result: string[] = [];
+        let include = false;
+
+        for (const line of lines) {
+            const match = line.match(/^diff --git a\/(.+) b\/(.+)$/);
+            if (match) {
+                include = fileSet.has(match[2]);
+            }
+            if (include) {
+                result.push(line);
+            }
+        }
+        return result.join('\n');
+    }
+
+    /**
+     * Selective restore: only revert files that were part of this checkpoint's diff.
+     * Detects conflicts (files modified by other tasks since checkpoint) and returns them separately.
+     */
+    async restoreCheckpointSelective(checkpointId: string): Promise<{
+        success: boolean;
+        restoredFiles: string[];
+        conflictingFiles: string[];
+        error?: string;
+    }> {
+        const checkpoint = this.getCheckpoint(checkpointId);
+        if (!checkpoint) {
+            return { success: false, restoredFiles: [], conflictingFiles: [], error: 'Checkpoint not found' };
+        }
+
+        const cwd = checkpoint.workspaceId;
+        const isRepo = await isGitRepo(cwd);
+        if (!isRepo) {
+            return { success: false, restoredFiles: [], conflictingFiles: [], error: 'Not a git repository' };
+        }
+
+        if (!checkpoint.gitRef) {
+            return { success: false, restoredFiles: [], conflictingFiles: [], error: 'Checkpoint has no git reference' };
+        }
+
+        // If no diff was saved, there's nothing task-specific to restore
+        if (!checkpoint.gitDiff) {
+            return { success: true, restoredFiles: [], conflictingFiles: [] };
+        }
+
+        const checkpointFiles = this.parseDiffFiles(checkpoint.gitDiff);
+        if (checkpointFiles.length === 0) {
+            return { success: true, restoredFiles: [], conflictingFiles: [] };
+        }
+
+        // Get current diff for these files to detect conflicts
+        const conflictingFiles: string[] = [];
+        const safeFiles: string[] = [];
+
+        try {
+            const { stdout: currentDiff } = await execAsync('git diff HEAD', { cwd, maxBuffer: 1024 * 1024 });
+            const currentlyModifiedFiles = this.parseDiffFiles(currentDiff);
+
+            for (const file of checkpointFiles) {
+                // A file is "conflicting" if it's currently modified AND the current diff
+                // for that file differs from what's in the checkpoint diff
+                if (currentlyModifiedFiles.includes(file)) {
+                    const currentFileHunks = this.extractDiffForFiles(currentDiff, [file]);
+                    const checkpointFileHunks = this.extractDiffForFiles(checkpoint.gitDiff!, [file]);
+                    if (currentFileHunks !== checkpointFileHunks) {
+                        conflictingFiles.push(file);
+                        continue;
+                    }
+                }
+                safeFiles.push(file);
+            }
+
+            // Restore safe files: reset to committed state then apply checkpoint diff
+            const restoredFiles: string[] = [];
+            for (const file of safeFiles) {
+                try {
+                    await execAsync(`git checkout ${checkpoint.gitRef} -- "${file}"`, { cwd });
+                    restoredFiles.push(file);
+                } catch (e) {
+                    console.warn(`[CheckpointStore] Could not checkout file "${file}":`, e);
+                }
+            }
+
+            // Apply the checkpoint's diff for just these files
+            if (restoredFiles.length > 0 && checkpoint.gitDiff) {
+                const partialDiff = this.extractDiffForFiles(checkpoint.gitDiff, restoredFiles);
+                if (partialDiff.trim()) {
+                    try {
+                        const { exec: execCb } = await import('child_process');
+                        await new Promise<void>((resolve, reject) => {
+                            const proc = execCb('git apply --allow-empty -', { cwd }, (err) => {
+                                if (err) reject(err);
+                                else resolve();
+                            });
+                            proc.stdin?.write(partialDiff);
+                            proc.stdin?.end();
+                        });
+                    } catch {
+                        console.warn('[CheckpointStore] Partial diff apply had issues (non-fatal)');
+                    }
+                }
+            }
+
+            console.log(`[CheckpointStore] Selective restore: ${restoredFiles.length} restored, ${conflictingFiles.length} conflicts`);
+            return { success: true, restoredFiles, conflictingFiles };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[CheckpointStore] Selective restore failed:', msg);
+            return { success: false, restoredFiles: [], conflictingFiles: [], error: msg };
+        }
+    }
+
+    /**
+     * Force-restore specific files from a checkpoint, ignoring conflicts.
+     */
+    async forceRestoreFiles(checkpointId: string, files: string[]): Promise<{
+        success: boolean;
+        restoredFiles: string[];
+        error?: string;
+    }> {
+        const checkpoint = this.getCheckpoint(checkpointId);
+        if (!checkpoint) {
+            return { success: false, restoredFiles: [], error: 'Checkpoint not found' };
+        }
+
+        const cwd = checkpoint.workspaceId;
+        if (!checkpoint.gitRef) {
+            return { success: false, restoredFiles: [], error: 'Checkpoint has no git reference' };
+        }
+
+        const restoredFiles: string[] = [];
+        try {
+            for (const file of files) {
+                try {
+                    await execAsync(`git checkout ${checkpoint.gitRef} -- "${file}"`, { cwd });
+                    restoredFiles.push(file);
+                } catch (e) {
+                    console.warn(`[CheckpointStore] Force restore failed for "${file}":`, e);
+                }
+            }
+
+            // Apply checkpoint diff for these files
+            if (restoredFiles.length > 0 && checkpoint.gitDiff) {
+                const partialDiff = this.extractDiffForFiles(checkpoint.gitDiff, restoredFiles);
+                if (partialDiff.trim()) {
+                    try {
+                        const { exec: execCb } = await import('child_process');
+                        await new Promise<void>((resolve, reject) => {
+                            const proc = execCb('git apply --allow-empty -', { cwd }, (err) => {
+                                if (err) reject(err);
+                                else resolve();
+                            });
+                            proc.stdin?.write(partialDiff);
+                            proc.stdin?.end();
+                        });
+                    } catch {
+                        console.warn('[CheckpointStore] Force restore diff apply had issues');
+                    }
+                }
+            }
+
+            console.log(`[CheckpointStore] Force-restored ${restoredFiles.length} files`);
+            return { success: true, restoredFiles };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return { success: false, restoredFiles: [], error: msg };
+        }
+    }
+}

--- a/backend/src/claudia-mcp-server.ts
+++ b/backend/src/claudia-mcp-server.ts
@@ -913,6 +913,373 @@ server.tool(
 );
 
 // ============================================================================
+// Settings & MCP Server Management Tools
+// ============================================================================
+
+server.tool(
+    'claudia_get_settings',
+    'Get current Claudia settings including MCP servers, rules, CLI switches, and feature flags. Sensitive fields (API keys, credentials) are omitted.',
+    {},
+    async () => {
+        try {
+            const response = await backendFetch('/api/config');
+            if (!response.ok) {
+                return { content: [{ type: 'text', text: `Error: Failed to fetch config (HTTP ${response.status})` }] };
+            }
+            const config = await response.json();
+
+            // Return a filtered view - omit sensitive fields
+            const safeConfig = {
+                mcpServers: config.mcpServers?.map((s: Record<string, unknown>) => ({
+                    name: s.name,
+                    type: s.type || 'stdio',
+                    command: s.command,
+                    args: s.args,
+                    url: s.url,
+                    enabled: s.enabled,
+                    description: s.description,
+                })) || [],
+                rules: config.rules || '',
+                skipPermissions: config.skipPermissions ?? false,
+                supervisorEnabled: config.supervisorEnabled ?? false,
+                supervisorSystemPrompt: config.supervisorSystemPrompt || '',
+                autoFocusOnInput: config.autoFocusOnInput ?? false,
+                claudiaMcpServerEnabled: config.claudiaMcpServerEnabled ?? false,
+                useLearnings: config.useLearnings ?? false,
+                claudeCodeSwitches: config.claudeCodeSwitches || {},
+                defaultBaseDirectory: config.defaultBaseDirectory || null,
+            };
+
+            return { content: [{ type: 'text', text: JSON.stringify(safeConfig, null, 2) }] };
+        } catch (error) {
+            log.error('Failed to get settings:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+server.tool(
+    'claudia_update_settings',
+    'Update Claudia settings. Accepts a partial settings object — only provided fields are updated. Use this to change rules, CLI switches, feature flags, etc. Do NOT use this to manage MCP servers (use the dedicated MCP tools instead).',
+    {
+        settings: z.string().describe('JSON string of settings to update. Allowed fields: rules (string), skipPermissions (boolean), supervisorEnabled (boolean), supervisorSystemPrompt (string), autoFocusOnInput (boolean), claudiaMcpServerEnabled (boolean), claudeCodeSwitches (object with: verbose, maxTurns, maxBudgetUsd, permissionMode, allowedTools, disallowedTools, appendSystemPrompt, defaultModel, effortLevel)')
+    },
+    async ({ settings }) => {
+        try {
+            let parsed: Record<string, unknown>;
+            try {
+                parsed = JSON.parse(settings);
+            } catch {
+                return { content: [{ type: 'text', text: 'Error: Invalid JSON in settings parameter' }] };
+            }
+
+            // Whitelist allowed fields - block sensitive fields
+            const allowedFields = [
+                'rules', 'skipPermissions', 'supervisorEnabled', 'supervisorSystemPrompt',
+                'autoFocusOnInput', 'claudiaMcpServerEnabled', 'claudeCodeSwitches',
+                'defaultBaseDirectory'
+            ];
+            const filtered: Record<string, unknown> = {};
+            for (const key of allowedFields) {
+                if (key in parsed) {
+                    filtered[key] = parsed[key];
+                }
+            }
+
+            if (Object.keys(filtered).length === 0) {
+                return { content: [{ type: 'text', text: `Error: No valid fields provided. Allowed fields: ${allowedFields.join(', ')}` }] };
+            }
+
+            // Block mcpServers from being set via this tool
+            if ('mcpServers' in parsed) {
+                return { content: [{ type: 'text', text: 'Error: Use claudia_add_mcp_server, claudia_update_mcp_server, or claudia_remove_mcp_server to manage MCP servers.' }] };
+            }
+
+            const response = await backendFetch('/api/config', {
+                method: 'PUT',
+                body: JSON.stringify(filtered),
+            });
+
+            if (!response.ok) {
+                const errorBody = await response.json().catch(() => ({}));
+                return { content: [{ type: 'text', text: `Error: Failed to update settings (HTTP ${response.status}): ${errorBody.error || 'Unknown error'}` }] };
+            }
+
+            const updatedConfig = await response.json();
+            log.info('Settings updated via MCP:', Object.keys(filtered));
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        message: `Settings updated successfully.`,
+                        updatedFields: Object.keys(filtered),
+                    }, null, 2)
+                }]
+            };
+        } catch (error) {
+            log.error('Failed to update settings:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+server.tool(
+    'claudia_list_mcp_servers',
+    'List all configured MCP servers with their enabled/disabled status, type, and description.',
+    {},
+    async () => {
+        try {
+            const response = await backendFetch('/api/config');
+            if (!response.ok) {
+                return { content: [{ type: 'text', text: `Error: Failed to fetch config (HTTP ${response.status})` }] };
+            }
+            const config = await response.json();
+            const servers = (config.mcpServers || []).map((s: Record<string, unknown>) => ({
+                name: s.name,
+                type: s.type || 'stdio',
+                enabled: s.enabled ?? true,
+                command: s.command || undefined,
+                args: s.args || undefined,
+                url: s.url || undefined,
+                description: s.description || undefined,
+            }));
+
+            return { content: [{ type: 'text', text: JSON.stringify(servers, null, 2) }] };
+        } catch (error) {
+            log.error('Failed to list MCP servers:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+server.tool(
+    'claudia_add_mcp_server',
+    'Add a new MCP server to Claudia. Supports stdio servers (command + args) and HTTP servers (url). The server will be synced to all workspaces and running tasks will be notified.',
+    {
+        name: z.string().describe('Unique name for the MCP server (e.g. "my-tool-server")'),
+        type: z.enum(['stdio', 'http', 'streamableHttp']).optional().describe('Server type (default: "stdio")'),
+        command: z.string().optional().describe('Command to run (required for stdio type, e.g. "npx")'),
+        args: z.string().optional().describe('JSON array of command arguments (e.g. \'["@playwright/mcp"]\')'),
+        env: z.string().optional().describe('JSON object of environment variables (e.g. \'{"API_KEY":"xxx"}\')'),
+        url: z.string().optional().describe('Server URL (required for http/streamableHttp type)'),
+        enabled: z.boolean().optional().describe('Whether the server is enabled (default: true)'),
+        description: z.string().optional().describe('Human-readable description of what this server does'),
+        headers: z.string().optional().describe('JSON object of HTTP headers (for http/streamableHttp type)'),
+    },
+    async ({ name, type, command, args, env, url, enabled, description, headers }) => {
+        try {
+            // Fetch current config
+            const response = await backendFetch('/api/config');
+            if (!response.ok) {
+                return { content: [{ type: 'text', text: `Error: Failed to fetch config (HTTP ${response.status})` }] };
+            }
+            const config = await response.json();
+            const servers = config.mcpServers || [];
+
+            // Check for duplicate name
+            if (servers.some((s: Record<string, unknown>) => s.name === name)) {
+                return { content: [{ type: 'text', text: `Error: MCP server '${name}' already exists. Use claudia_update_mcp_server to modify it.` }] };
+            }
+
+            // Build new server config
+            const serverType = type || 'stdio';
+            const newServer: Record<string, unknown> = {
+                name,
+                type: serverType,
+                enabled: enabled ?? true,
+            };
+
+            if (serverType === 'stdio') {
+                if (!command) {
+                    return { content: [{ type: 'text', text: 'Error: "command" is required for stdio-type MCP servers.' }] };
+                }
+                newServer.command = command;
+                if (args) {
+                    try { newServer.args = JSON.parse(args); } catch { return { content: [{ type: 'text', text: 'Error: "args" must be a valid JSON array.' }] }; }
+                }
+                if (env) {
+                    try { newServer.env = JSON.parse(env); } catch { return { content: [{ type: 'text', text: 'Error: "env" must be a valid JSON object.' }] }; }
+                }
+            } else {
+                // http or streamableHttp
+                if (!url) {
+                    return { content: [{ type: 'text', text: `Error: "url" is required for ${serverType}-type MCP servers.` }] };
+                }
+                newServer.url = url;
+                if (headers) {
+                    try { newServer.headers = JSON.parse(headers); } catch { return { content: [{ type: 'text', text: 'Error: "headers" must be a valid JSON object.' }] }; }
+                }
+            }
+
+            if (description) newServer.description = description;
+
+            // Update config with new server added
+            servers.push(newServer);
+            const putResponse = await backendFetch('/api/config', {
+                method: 'PUT',
+                body: JSON.stringify({ mcpServers: servers }),
+            });
+
+            if (!putResponse.ok) {
+                const errorBody = await putResponse.json().catch(() => ({}));
+                return { content: [{ type: 'text', text: `Error: Failed to save config (HTTP ${putResponse.status}): ${errorBody.error || 'Unknown error'}` }] };
+            }
+
+            log.info(`MCP server added via MCP: ${name} (${serverType})`);
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        message: `MCP server '${name}' added successfully. It will be synced to all workspaces.`,
+                        server: newServer,
+                    }, null, 2)
+                }]
+            };
+        } catch (error) {
+            log.error('Failed to add MCP server:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+server.tool(
+    'claudia_remove_mcp_server',
+    'Remove an MCP server from Claudia by name. The change will be synced to all workspaces.',
+    {
+        name: z.string().describe('Name of the MCP server to remove'),
+    },
+    async ({ name }) => {
+        try {
+            // Fetch current config
+            const response = await backendFetch('/api/config');
+            if (!response.ok) {
+                return { content: [{ type: 'text', text: `Error: Failed to fetch config (HTTP ${response.status})` }] };
+            }
+            const config = await response.json();
+            const servers = config.mcpServers || [];
+
+            // Find server
+            const serverIndex = servers.findIndex((s: Record<string, unknown>) => s.name === name);
+            if (serverIndex === -1) {
+                return { content: [{ type: 'text', text: `Error: MCP server '${name}' not found.` }] };
+            }
+
+            // Remove it
+            servers.splice(serverIndex, 1);
+            const putResponse = await backendFetch('/api/config', {
+                method: 'PUT',
+                body: JSON.stringify({ mcpServers: servers }),
+            });
+
+            if (!putResponse.ok) {
+                const errorBody = await putResponse.json().catch(() => ({}));
+                return { content: [{ type: 'text', text: `Error: Failed to save config (HTTP ${putResponse.status}): ${errorBody.error || 'Unknown error'}` }] };
+            }
+
+            log.info(`MCP server removed via MCP: ${name}`);
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        message: `MCP server '${name}' removed successfully. Change will be synced to all workspaces.`,
+                    }, null, 2)
+                }]
+            };
+        } catch (error) {
+            log.error('Failed to remove MCP server:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+server.tool(
+    'claudia_update_mcp_server',
+    'Update an existing MCP server configuration. Use this to enable/disable a server, change its command/args, or update other settings.',
+    {
+        name: z.string().describe('Name of the MCP server to update'),
+        enabled: z.boolean().optional().describe('Enable or disable the server'),
+        command: z.string().optional().describe('New command (stdio type only)'),
+        args: z.string().optional().describe('New args as JSON array (stdio type only)'),
+        env: z.string().optional().describe('New env as JSON object (stdio type only)'),
+        url: z.string().optional().describe('New URL (http/streamableHttp type only)'),
+        description: z.string().optional().describe('New description'),
+        headers: z.string().optional().describe('New headers as JSON object (http/streamableHttp type only)'),
+        newName: z.string().optional().describe('Rename the server to this name'),
+    },
+    async ({ name, enabled, command, args, env, url, description, headers, newName }) => {
+        try {
+            // Fetch current config
+            const response = await backendFetch('/api/config');
+            if (!response.ok) {
+                return { content: [{ type: 'text', text: `Error: Failed to fetch config (HTTP ${response.status})` }] };
+            }
+            const config = await response.json();
+            const servers = config.mcpServers || [];
+
+            // Find server
+            const server_config = servers.find((s: Record<string, unknown>) => s.name === name);
+            if (!server_config) {
+                return { content: [{ type: 'text', text: `Error: MCP server '${name}' not found.` }] };
+            }
+
+            // Check rename doesn't conflict
+            if (newName && newName !== name) {
+                if (servers.some((s: Record<string, unknown>) => s.name === newName)) {
+                    return { content: [{ type: 'text', text: `Error: Cannot rename to '${newName}' — a server with that name already exists.` }] };
+                }
+                server_config.name = newName;
+            }
+
+            // Apply updates
+            if (enabled !== undefined) server_config.enabled = enabled;
+            if (command !== undefined) server_config.command = command;
+            if (url !== undefined) server_config.url = url;
+            if (description !== undefined) server_config.description = description;
+
+            if (args !== undefined) {
+                try { server_config.args = JSON.parse(args); } catch { return { content: [{ type: 'text', text: 'Error: "args" must be a valid JSON array.' }] }; }
+            }
+            if (env !== undefined) {
+                try { server_config.env = JSON.parse(env); } catch { return { content: [{ type: 'text', text: 'Error: "env" must be a valid JSON object.' }] }; }
+            }
+            if (headers !== undefined) {
+                try { server_config.headers = JSON.parse(headers); } catch { return { content: [{ type: 'text', text: 'Error: "headers" must be a valid JSON object.' }] }; }
+            }
+
+            // Save
+            const putResponse = await backendFetch('/api/config', {
+                method: 'PUT',
+                body: JSON.stringify({ mcpServers: servers }),
+            });
+
+            if (!putResponse.ok) {
+                const errorBody = await putResponse.json().catch(() => ({}));
+                return { content: [{ type: 'text', text: `Error: Failed to save config (HTTP ${putResponse.status}): ${errorBody.error || 'Unknown error'}` }] };
+            }
+
+            log.info(`MCP server updated via MCP: ${name}`, { enabled, command, newName });
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        message: `MCP server '${name}' updated successfully.${newName ? ` Renamed to '${newName}'.` : ''} Change will be synced to all workspaces.`,
+                        server: server_config,
+                    }, null, 2)
+                }]
+            };
+        } catch (error) {
+            log.error('Failed to update MCP server:', error);
+            return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }] };
+        }
+    }
+);
+
+// ============================================================================
 // Start the server
 // ============================================================================
 async function main() {

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -153,7 +153,7 @@ const DEFAULT_CONFIG: AppConfig = {
     claudeCodeSwitches: { ...DEFAULT_CLAUDE_CODE_SWITCHES },
     hyperspaceProxy: DEFAULT_HYPERSPACE_PROXY,
     enabledPlugins: [],  // All plugins disabled by default
-    claudiaMcpServerEnabled: false,  // [Experimental] Disabled by default
+    claudiaMcpServerEnabled: true,  // Enabled by default - provides task orchestration tools to Claude Code sessions
     defaultBaseDirectory: undefined  // No default base directory set
 };
 

--- a/backend/src/platform-commands.ts
+++ b/backend/src/platform-commands.ts
@@ -1,0 +1,151 @@
+/**
+ * Platform-specific command builders for OS interactions.
+ *
+ * These functions generate the command/args arrays for platform-specific
+ * operations (folder dialogs, open in finder, open terminal, reveal file).
+ * They are pure functions (no side-effects) to enable thorough unit testing.
+ */
+
+export type Platform = 'darwin' | 'win32' | 'linux';
+
+export interface CommandSpec {
+    cmd: string;
+    args: string[];
+    options?: { cwd?: string };
+}
+
+/**
+ * Build the command to open a native folder picker dialog.
+ */
+export function buildFolderPickerCommand(platform: Platform, lastBrowsed?: string | null, prompt = 'Select a workspace folder'): CommandSpec {
+    if (platform === 'darwin') {
+        const scriptParts = [`POSIX path of (choose folder with prompt "${prompt}"`];
+        if (lastBrowsed) {
+            const safe = lastBrowsed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            scriptParts.push(` default location POSIX file "${safe}"`);
+        }
+        scriptParts.push(')');
+        return { cmd: 'osascript', args: ['-e', scriptParts.join('')] };
+    } else if (platform === 'win32') {
+        const initialDirLine = lastBrowsed
+            ? `$dialog.SelectedPath = [System.IO.Path]::GetFullPath("${lastBrowsed.replace(/"/g, '')}")`
+            : '';
+        const psScript = [
+            'Add-Type -AssemblyName System.Windows.Forms',
+            '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+            `$dialog.Description = "${prompt}"`,
+            '$dialog.ShowNewFolderButton = $true',
+            ...(initialDirLine ? [initialDirLine] : []),
+            'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.SelectedPath }',
+        ].join('\n');
+        const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
+        return { cmd: 'powershell', args: ['-NoProfile', '-EncodedCommand', encoded] };
+    } else {
+        // Linux - zenity
+        const args = ['--file-selection', '--directory', `--title=${prompt}`];
+        if (lastBrowsed) args.push(`--filename=${lastBrowsed}/`);
+        return { cmd: 'zenity', args };
+    }
+}
+
+/**
+ * Build the command to open a folder in the native file manager.
+ */
+export function buildOpenFolderCommand(platform: Platform, folderPath: string): CommandSpec {
+    if (platform === 'darwin') {
+        return { cmd: 'open', args: [folderPath] };
+    } else if (platform === 'win32') {
+        return { cmd: 'explorer.exe', args: [folderPath] };
+    } else {
+        return { cmd: 'xdg-open', args: [folderPath] };
+    }
+}
+
+/**
+ * Build the command to open a terminal at a given path.
+ */
+export function buildOpenTerminalCommand(platform: Platform, workspacePath: string): CommandSpec {
+    if (platform === 'darwin') {
+        const safeId = workspacePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return {
+            cmd: 'osascript',
+            args: [
+                '-e', `tell application "Terminal" to do script "cd \\"${safeId}\\""`,
+                '-e', 'tell application "Terminal" to activate',
+            ]
+        };
+    } else if (platform === 'win32') {
+        return {
+            cmd: 'cmd.exe',
+            args: ['/C', 'start', 'cmd.exe'],
+            options: { cwd: workspacePath }
+        };
+    } else {
+        // Linux - try x-terminal-emulator first
+        return {
+            cmd: 'x-terminal-emulator',
+            args: [`--working-directory=${workspacePath}`]
+        };
+    }
+}
+
+/**
+ * Build the command to reveal a file in the native file manager.
+ */
+export function buildRevealFileCommand(platform: Platform, filePath: string): CommandSpec {
+    if (platform === 'darwin') {
+        return { cmd: 'open', args: ['-R', filePath] };
+    } else if (platform === 'win32') {
+        return { cmd: 'explorer.exe', args: [`/select,${filePath.replace(/\//g, '\\')}`] };
+    } else {
+        // Linux - open parent directory
+        const parentDir = filePath.substring(0, filePath.lastIndexOf('/')) || '/';
+        return { cmd: 'xdg-open', args: [parentDir] };
+    }
+}
+
+/**
+ * Build the command for the reference folder picker (simpler variant).
+ */
+export function buildReferenceFolderPickerCommand(platform: Platform): CommandSpec {
+    if (platform === 'darwin') {
+        return { cmd: 'osascript', args: ['-e', 'POSIX path of (choose folder with prompt "Select reference folder")'] };
+    } else if (platform === 'win32') {
+        return {
+            cmd: 'powershell',
+            args: ['-Command', `Add-Type -AssemblyName System.Windows.Forms; $f = New-Object System.Windows.Forms.FolderBrowserDialog; $f.Description = 'Select reference folder'; if ($f.ShowDialog() -eq 'OK') { $f.SelectedPath } else { '' }`]
+        };
+    } else {
+        return { cmd: 'zenity', args: ['--file-selection', '--directory', '--title=Select reference folder'] };
+    }
+}
+
+/**
+ * Build PATH environment string with extra directories for the current platform.
+ */
+export function buildPathWithExtras(platform: Platform, homeDir: string, originalPath: string): string {
+    const extraPaths = platform === 'win32'
+        ? [`${homeDir}/.local/bin`, `${homeDir}/AppData/Roaming/npm`]
+        : [`${homeDir}/.local/bin`, `${homeDir}/.npm-global/bin`, '/usr/local/bin'];
+    const sep = platform === 'win32' ? ';' : ':';
+    return [...extraPaths, originalPath].join(sep);
+}
+
+/**
+ * Build the macOS-specific application menu entries.
+ * Returns an array of menu items for the app name submenu (About, Quit).
+ * Returns empty array on non-darwin platforms.
+ */
+export function buildAppMenuEntries(platform: Platform, appName: string): Array<{ label: string; submenu: Array<{ role?: string; type?: string }> }> {
+    if (platform === 'darwin') {
+        return [{
+            label: appName,
+            submenu: [
+                { role: 'about' },
+                { type: 'separator' },
+                { role: 'quit' }
+            ]
+        }];
+    }
+    return [];
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,6 +18,8 @@ import { getConversationHistory, getWorkspaceSessions } from './conversation-par
 import { setUserId } from './usage-reporter.js';
 import { Task, Workspace, WorkspaceReference, WSMessage, WSMessageType, WSErrorPayload, ChatMessage, SuggestedAction, WaitingInputType, ScheduledTask, PORTS } from '@claudia/shared';
 import { CronScheduler, validateCronExpression, describeCronExpression } from './cron-scheduler.js';
+import { UsageStore } from './usage-store.js';
+import { CheckpointStore } from './checkpoint-store.js';
 import { validateConfigUpdate, validateWorkspacePath } from './validation.js';
 import { isGitRepo, getDefaultBranch, getCurrentBranch, checkoutBranch } from './git-utils.js';
 import { LearningsStore } from './learnings-store.js';
@@ -94,6 +96,15 @@ const VALID_WS_MESSAGE_TYPES = new Set([
     'cron:update',
     'cron:list',
     'cron:run',
+    'usage:get',
+    'usage:clear',
+    'checkpoint:create',
+    'checkpoint:list',
+    'checkpoint:restore',
+    'checkpoint:restore-selective',
+    'checkpoint:restore-force',
+    'checkpoint:delete',
+    'checkpoint:fork',
     'voice:input',
 ]);
 
@@ -240,6 +251,9 @@ const ctxUpdateInFlight = new Set<string>();
 // result is garbled display. Instead we discard the entire input-echo buffer for
 // inline injections; Claude Code's response comes through cleanly afterwards.
 const ctxInlineInFlight = new Set<string>();
+
+// Buffer for terminal keystrokes per task (for auto-checkpoint on Enter)
+const terminalInputBuffer = new Map<string, string>();
 
 /**
  * Notify running tasks in a workspace that references have changed.
@@ -505,6 +519,10 @@ export async function createApp(basePath?: string) {
         }
     );
     cronScheduler.start();
+
+    // Usage and Checkpoint stores
+    const usageStore = new UsageStore(basePath);
+    const checkpointStore = new CheckpointStore(basePath);
 
     // Wire up tunnel events for broadcasting
     tunnelManager.on('tunnel:ready', (data: { url: string; token: string }) => {
@@ -911,6 +929,17 @@ export async function createApp(basePath?: string) {
             // No context update, pass through
             broadcast({ type: 'task:output', payload: { taskId, data } });
         }
+
+        // Try to parse usage/token info from output for cost tracking
+        const task = taskSpawner.getAllTasks().find(t => t.id === taskId);
+        if (task) {
+            const lines = data.split('\n');
+            for (const line of lines) {
+                if (/token|input|output|cost/i.test(line)) {
+                    usageStore.parseAndRecord(taskId, task.workspaceId, line);
+                }
+            }
+        }
     });
 
     taskSpawner.on('taskRestore', (taskId: string, history: string) => {
@@ -1180,10 +1209,62 @@ export async function createApp(basePath?: string) {
                         const { taskId, input } = payload as { taskId?: string; input?: string };
                         if (!taskId || !input) break;
                         // Filter out focus events (ESC [ I and ESC [ O) that confuse Claude's TUI
+                        // Also filter device attribute responses (DA1/DA2/DA3) that xterm.js
+                        // auto-generates — if echoed back they appear as garbled text
                         let filteredInput = input
                             .replace(/\x1b\[I/g, '')  // Focus in
-                            .replace(/\x1b\[O/g, ''); // Focus out
+                            .replace(/\x1b\[O/g, '')  // Focus out
+                            .replace(/\x1b\[\?[\d;]*c/g, '')  // DA1 response
+                            .replace(/\x1b\[>[\d;]*c/g, '')   // DA2 response
+                            .replace(/\x1b\[=[\d;]*c/g, '');  // DA3 response
                         if (filteredInput) {
+                            // Auto-create checkpoint on each new user input (works for active and disconnected tasks)
+                            const endsWithEnterForCp = filteredInput.endsWith('\r') || filteredInput.endsWith('\n');
+                            if (filteredInput.length > 1 && endsWithEnterForCp) {
+                                // Full message sent at once (e.g. from TaskInputBar)
+                                const cpWorkspaceId = taskSpawner.getTaskWorkspaceId(taskId);
+                                const checkpointName = filteredInput.slice(0, -1).trim();
+                                if (checkpointName && cpWorkspaceId) {
+                                    terminalInputBuffer.delete(taskId);
+                                    checkpointStore.createCheckpoint(taskId, cpWorkspaceId, checkpointName)
+                                        .then(cp => {
+                                            logger.info('Auto-checkpoint created on input', { taskId, checkpointId: cp.id, name: checkpointName.slice(0, 60) });
+                                            broadcast({ type: 'checkpoint:created', payload: cp });
+                                        })
+                                        .catch(err => {
+                                            logger.warn('Auto-checkpoint failed', { taskId, error: String(err) });
+                                        });
+                                }
+                            } else if (endsWithEnterForCp && filteredInput.length === 1) {
+                                // Enter pressed alone (terminal keystroke mode) — flush buffer
+                                const buffered = (terminalInputBuffer.get(taskId) || '').trim();
+                                terminalInputBuffer.delete(taskId);
+                                if (buffered) {
+                                    const cpWorkspaceId = taskSpawner.getTaskWorkspaceId(taskId);
+                                    if (cpWorkspaceId) {
+                                        checkpointStore.createCheckpoint(taskId, cpWorkspaceId, buffered)
+                                            .then(cp => {
+                                                logger.info('Auto-checkpoint created on terminal input', { taskId, checkpointId: cp.id, name: buffered.slice(0, 60) });
+                                                broadcast({ type: 'checkpoint:created', payload: cp });
+                                            })
+                                            .catch(err => {
+                                                logger.warn('Auto-checkpoint failed', { taskId, error: String(err) });
+                                            });
+                                    }
+                                }
+                            } else if (!endsWithEnterForCp && filteredInput.length > 0) {
+                                // Regular keystroke — accumulate in buffer (ignore control sequences)
+                                const isPrintable = !filteredInput.startsWith('\x1b') && filteredInput.charCodeAt(0) >= 32;
+                                if (filteredInput === '\x7f' || filteredInput === '\b') {
+                                    // Backspace — remove last char from buffer
+                                    const current = terminalInputBuffer.get(taskId) || '';
+                                    terminalInputBuffer.set(taskId, current.slice(0, -1));
+                                } else if (isPrintable) {
+                                    const current = terminalInputBuffer.get(taskId) || '';
+                                    terminalInputBuffer.set(taskId, current + filteredInput);
+                                }
+                            }
+
                             // Check if workspace references changed since last injection
                             // If so, prepend updated reference context to the user's message
                             const inputTask = taskSpawner.getTask(taskId);
@@ -2118,6 +2199,134 @@ export async function createApp(basePath?: string) {
                             broadcast({ type: 'cron:updated' as WSMessageType, payload: { cronId, taskId: scheduled.taskId } });
                         } else {
                             sendWSError(ws, `Failed to fire scheduled task '${cronId}'`, message.type, 'CRON_FIRE_FAILED');
+                        }
+                        break;
+                    }
+
+                    // ===== Usage Tracking =====
+
+                    case 'usage:get': {
+                        const { period, workspaceId: usageWsId } = payload as { period?: 'today' | '7d' | '30d' | 'all'; workspaceId?: string };
+                        const summary = usageStore.getSummary(period || 'all', usageWsId);
+                        ws.send(JSON.stringify({ type: 'usage:summary', payload: summary }));
+                        break;
+                    }
+
+                    case 'usage:clear': {
+                        usageStore.clearAll();
+                        ws.send(JSON.stringify({ type: 'usage:summary', payload: usageStore.getSummary() }));
+                        break;
+                    }
+
+                    // ===== Checkpoints/Timeline =====
+
+                    case 'checkpoint:create': {
+                        const { taskId: cpTaskId, workspaceId: cpWsId, name: cpName, description: cpDesc } = payload as { taskId?: string; workspaceId?: string; name?: string; description?: string };
+                        if (!cpTaskId || !cpWsId) {
+                            sendWSError(ws, 'checkpoint:create requires taskId and workspaceId', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        try {
+                            const checkpoint = await checkpointStore.createCheckpoint(cpTaskId, cpWsId, cpName, cpDesc);
+                            ws.send(JSON.stringify({ type: 'checkpoint:created', payload: checkpoint }));
+                        } catch (err) {
+                            sendWSError(ws, `Failed to create checkpoint: ${err}`, message.type, 'CHECKPOINT_ERROR');
+                        }
+                        break;
+                    }
+
+                    case 'checkpoint:list': {
+                        const { taskId: cpListTaskId, workspaceId: cpListWsId } = payload as { taskId?: string; workspaceId?: string };
+                        let checkpoints: import('@claudia/shared').Checkpoint[] = [];
+                        if (cpListTaskId) {
+                            checkpoints = checkpointStore.listCheckpoints(cpListTaskId);
+                        } else if (cpListWsId) {
+                            checkpoints = checkpointStore.listCheckpointsByWorkspace(cpListWsId);
+                        }
+                        ws.send(JSON.stringify({ type: 'checkpoint:list', payload: { checkpoints } }));
+                        break;
+                    }
+
+                    case 'checkpoint:restore': {
+                        const { checkpointId: restoreId } = payload as { checkpointId?: string };
+                        if (!restoreId) {
+                            sendWSError(ws, 'checkpoint:restore requires checkpointId', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        const result = await checkpointStore.restoreCheckpoint(restoreId);
+                        if (result.success) {
+                            ws.send(JSON.stringify({ type: 'checkpoint:restored', payload: { checkpointId: restoreId } }));
+                        } else {
+                            ws.send(JSON.stringify({ type: 'checkpoint:error', payload: { error: result.error, checkpointId: restoreId } }));
+                        }
+                        break;
+                    }
+
+                    case 'checkpoint:restore-selective': {
+                        const { checkpointId: selRestoreId } = payload as { checkpointId?: string };
+                        if (!selRestoreId) {
+                            sendWSError(ws, 'checkpoint:restore-selective requires checkpointId', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        const selResult = await checkpointStore.restoreCheckpointSelective(selRestoreId);
+                        ws.send(JSON.stringify({
+                            type: 'checkpoint:restore-selective-result',
+                            payload: {
+                                checkpointId: selRestoreId,
+                                success: selResult.success,
+                                restoredFiles: selResult.restoredFiles,
+                                conflictingFiles: selResult.conflictingFiles,
+                                error: selResult.error,
+                            }
+                        }));
+                        break;
+                    }
+
+                    case 'checkpoint:restore-force': {
+                        const { checkpointId: forceId, files: forceFiles } = payload as { checkpointId?: string; files?: string[] };
+                        if (!forceId || !forceFiles || forceFiles.length === 0) {
+                            sendWSError(ws, 'checkpoint:restore-force requires checkpointId and files[]', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        const forceResult = await checkpointStore.forceRestoreFiles(forceId, forceFiles);
+                        ws.send(JSON.stringify({
+                            type: 'checkpoint:restore-force-result',
+                            payload: {
+                                checkpointId: forceId,
+                                success: forceResult.success,
+                                restoredFiles: forceResult.restoredFiles,
+                                error: forceResult.error,
+                            }
+                        }));
+                        break;
+                    }
+
+                    case 'checkpoint:delete': {
+                        const { checkpointId: deleteId } = payload as { checkpointId?: string };
+                        if (!deleteId) {
+                            sendWSError(ws, 'checkpoint:delete requires checkpointId', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        const deleted = checkpointStore.deleteCheckpoint(deleteId);
+                        if (deleted) {
+                            ws.send(JSON.stringify({ type: 'checkpoint:deleted', payload: { checkpointId: deleteId } }));
+                        } else {
+                            sendWSError(ws, 'Checkpoint not found', message.type, 'CHECKPOINT_NOT_FOUND');
+                        }
+                        break;
+                    }
+
+                    case 'checkpoint:fork': {
+                        const { checkpointId: forkId, branchName } = payload as { checkpointId?: string; branchName?: string };
+                        if (!forkId) {
+                            sendWSError(ws, 'checkpoint:fork requires checkpointId', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+                        const forkResult = await checkpointStore.forkFromCheckpoint(forkId, branchName);
+                        if (forkResult.success) {
+                            ws.send(JSON.stringify({ type: 'checkpoint:forked', payload: { checkpointId: forkId, branch: forkResult.branch } }));
+                        } else {
+                            ws.send(JSON.stringify({ type: 'checkpoint:error', payload: { error: forkResult.error, checkpointId: forkId } }));
                         }
                         break;
                     }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -93,6 +93,7 @@ const VALID_WS_MESSAGE_TYPES = new Set([
     'cron:update',
     'cron:list',
     'cron:run',
+    'voice:input',
 ]);
 
 // WebSocket message validation
@@ -338,7 +339,7 @@ export async function createApp(basePath?: string) {
     const wss = new WebSocketServer({ noServer: true });
 
     // Middleware
-    // Restrict CORS to localhost origins only — Claudia is a local-first app
+    // Restrict CORS to localhost and active tunnel origins
     app.use(cors({
         origin: (origin, callback) => {
             // Allow requests with no origin (same-origin, curl, native apps)
@@ -346,6 +347,9 @@ export async function createApp(basePath?: string) {
             try {
                 const url = new URL(origin);
                 if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1') {
+                    return callback(null, true);
+                }
+                if (isTunnelHost(url.hostname)) {
                     return callback(null, true);
                 }
             } catch { /* invalid origin */ }
@@ -396,6 +400,14 @@ export async function createApp(basePath?: string) {
 
         // Let API routes pass through
         if (req.path.startsWith('/api/')) {
+            return next();
+        }
+
+        // Let /assets/ requests fall through to static file server directly.
+        // These are hashed production build files that Vite dev server won't
+        // know about — proxying them to Vite results in HTML error pages
+        // being served with wrong MIME types (causing white-screen on mobile).
+        if (req.path.startsWith('/assets/')) {
             return next();
         }
 
@@ -575,6 +587,7 @@ export async function createApp(basePath?: string) {
 
     // Track connected clients with their alive status for heartbeat
     const clients = new Set<WebSocket>();
+    const voiceClients = new Set<WebSocket>(); // Voice agent clients - don't send task:output
     const clientAliveMap = new WeakMap<WebSocket, boolean>();
 
     // Heartbeat interval to keep WebSocket connections alive
@@ -616,14 +629,15 @@ export async function createApp(basePath?: string) {
     // Broadcast to all connected clients
     function broadcast(message: WSMessage): void {
         const data = JSON.stringify(message);
+        const isTaskOutput = message.type === 'task:output';
         for (const client of clients) {
             try {
                 if (client.readyState === WebSocket.OPEN) {
+                    if (isTaskOutput && voiceClients.has(client)) continue;
                     client.send(data);
                 }
             } catch (err) {
                 console.error('[Server] Error sending to client:', err);
-                // Remove broken client from set
                 clients.delete(client);
             }
         }
@@ -989,6 +1003,7 @@ export async function createApp(basePath?: string) {
         const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
         const mobileToken = url.searchParams.get('token');
         const isMobile = url.searchParams.get('mobile') === '1';
+        const isVoice = url.searchParams.get('voice') === '1';
 
         if (isMobile) {
             if (!mobileToken || !tunnelManager.validateToken(mobileToken)) {
@@ -999,8 +1014,9 @@ export async function createApp(basePath?: string) {
             logger.info('Mobile client connected via tunnel');
         }
 
-        console.log('[Server] Client connected' + (isMobile ? ' (mobile)' : ''));
+        console.log('[Server] Client connected' + (isMobile ? ' (mobile)' : '') + (isVoice ? ' (voice)' : ''));
         clients.add(ws);
+        if (isVoice) voiceClients.add(ws);
         clientAliveMap.set(ws, true); // Mark as alive on connection
 
         // Handle pong responses to keep connection alive
@@ -1505,82 +1521,72 @@ export async function createApp(basePath?: string) {
 
                     case 'workspace:browseFolder': {
                         // Open native OS folder picker dialog and return selected path
-                        const { execFileSync } = await import('child_process');
+                        // Use async spawn to avoid blocking the event loop during dialog
+                        const { spawn: spawnChild } = await import('child_process');
                         const platform = process.platform;
-                        let selectedPath: string | null = null;
                         const lastBrowsed = workspaceStore.getLastBrowsedPath();
 
-                        try {
-                            if (platform === 'darwin') {
-                            // Build osascript args as an array — no shell interpolation
-                                const scriptParts = ['POSIX path of (choose folder with prompt "Select a workspace folder"'];
-                                if (lastBrowsed) {
-                                    // Escape backslashes and quotes inside the AppleScript string
-                                    const safe = lastBrowsed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-                                    scriptParts.push(` default location POSIX file "${safe}"`);
-                                }
-                                scriptParts.push(')');
-                                const result = execFileSync(
-                                    'osascript', ['-e', scriptParts.join('')],
-                                    { encoding: 'utf-8', timeout: 120000 }
-                                ).trim();
-                                if (result) selectedPath = result.replace(/\/$/, ''); // remove trailing slash
-                            } else if (platform === 'win32') {
-                                // Pass the PowerShell script via -EncodedCommand to avoid any shell quoting issues
-                                const initialDirLine = lastBrowsed
-                                    ? `$dialog.SelectedPath = [System.IO.Path]::GetFullPath("${lastBrowsed.replace(/"/g, '')}")`
-                                    : '';
-                                const psScript = [
-                                    'Add-Type -AssemblyName System.Windows.Forms',
-                                    '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
-                                    '$dialog.Description = "Select a workspace folder"',
-                                    '$dialog.ShowNewFolderButton = $true',
-                                    ...(initialDirLine ? [initialDirLine] : []),
-                                    'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.SelectedPath }',
-                                ].join('\n');
-                                const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
-                                const result = execFileSync(
-                                    'powershell', ['-NoProfile', '-EncodedCommand', encoded],
-                                    { encoding: 'utf-8', timeout: 120000 }
-                                ).trim();
-                                if (result) selectedPath = result;
-                            } else {
-                                // Linux - try zenity first, then kdialog — use execFileSync with arg arrays
-                                try {
-                                    const zenityArgs = ['--file-selection', '--directory', '--title=Select a workspace folder'];
-                                    if (lastBrowsed) zenityArgs.push(`--filename=${lastBrowsed}/`);
-                                    const result = execFileSync('zenity', zenityArgs, { encoding: 'utf-8', timeout: 120000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-                                    if (result) selectedPath = result;
-                                } catch {
-                                    try {
-                                        const kdialogArgs = ['--getexistingdirectory', lastBrowsed || process.env['HOME'] || '/', '--title', 'Select a workspace folder'];
-                                        const result = execFileSync('kdialog', kdialogArgs, { encoding: 'utf-8', timeout: 120000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-                                        if (result) selectedPath = result;
-                                    } catch {
-                                        logger.warn('No folder dialog available (install zenity or kdialog)');
-                                    }
-                                }
+                        let cmd: string;
+                        let args: string[];
+
+                        if (platform === 'darwin') {
+                            cmd = 'osascript';
+                            const scriptParts = ['POSIX path of (choose folder with prompt "Select a workspace folder"'];
+                            if (lastBrowsed) {
+                                const safe = lastBrowsed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                                scriptParts.push(` default location POSIX file "${safe}"`);
                             }
-                        } catch (err: any) {
-                            // User cancelled the dialog (exit code != 0) - not an error
-                            logger.warn('Folder browse dialog error', {
-                                status: err.status,
-                                code: err.code,
-                                message: err.message,
-                                stderr: err.stderr?.toString(),
-                                stdout: err.stdout?.toString()
-                            });
+                            scriptParts.push(')');
+                            args = ['-e', scriptParts.join('')];
+                        } else if (platform === 'win32') {
+                            cmd = 'powershell';
+                            const initialDirLine = lastBrowsed
+                                ? `$dialog.SelectedPath = [System.IO.Path]::GetFullPath("${lastBrowsed.replace(/"/g, '')}")`
+                                : '';
+                            const psScript = [
+                                'Add-Type -AssemblyName System.Windows.Forms',
+                                '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+                                '$dialog.Description = "Select a workspace folder"',
+                                '$dialog.ShowNewFolderButton = $true',
+                                ...(initialDirLine ? [initialDirLine] : []),
+                                'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.SelectedPath }',
+                            ].join('\n');
+                            const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
+                            args = ['-NoProfile', '-EncodedCommand', encoded];
+                        } else {
+                            // Linux - try zenity
+                            cmd = 'zenity';
+                            args = ['--file-selection', '--directory', '--title=Select a workspace folder'];
+                            if (lastBrowsed) args.push(`--filename=${lastBrowsed}/`);
                         }
 
-                        // Remember the selected path for next time
-                        if (selectedPath) {
-                            workspaceStore.setLastBrowsedPath(selectedPath);
-                        }
+                        logger.info('Opening folder browse dialog', { cmd, platform });
 
-                        ws.send(JSON.stringify({
-                            type: 'workspace:browseFolder',
-                            payload: { path: selectedPath }
-                        }));
+                        const child = spawnChild(cmd, args);
+                        let stdout = '';
+                        let stderr = '';
+                        child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+                        child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+                        child.on('close', (code: number | null) => {
+                            const selectedPath = stdout.trim().replace(/\/$/, '') || null;
+                            logger.info('Folder browse dialog closed', { code, selectedPath, stderr: stderr.trim() });
+
+                            if (code === 0 && selectedPath) {
+                                workspaceStore.setLastBrowsedPath(selectedPath);
+                            }
+
+                            ws.send(JSON.stringify({
+                                type: 'workspace:browseFolder',
+                                payload: { path: selectedPath }
+                            }));
+                        });
+                        child.on('error', (err: Error) => {
+                            logger.error('Failed to open folder browse dialog', { error: err.message });
+                            ws.send(JSON.stringify({
+                                type: 'workspace:browseFolder',
+                                payload: { path: null }
+                            }));
+                        });
                         break;
                     }
 
@@ -2098,6 +2104,69 @@ export async function createApp(basePath?: string) {
                         }
                         break;
                     }
+
+                    // ===== Voice Agent =====
+
+                    case 'voice:input': {
+                        const { text, workspaceId } = payload as { text?: string; workspaceId?: string };
+                        if (!text) {
+                            sendWSError(ws, 'voice:input requires text', message.type, 'MISSING_PARAMS');
+                            break;
+                        }
+
+                        logger.info('[Voice WS] Processing voice input', { text, workspaceId });
+
+                        // Send processing status
+                        ws.send(JSON.stringify({
+                            type: 'voice:status',
+                            payload: { status: 'processing' }
+                        }));
+
+                        // Process via voice supervisor with streaming callbacks
+                        voiceSupervisor.processVoiceMessageStreaming(
+                            text,
+                            workspaceId,
+                            undefined,
+                            {
+                                onTextChunk: (chunk: string) => {
+                                    logger.info('[Voice WS] Text chunk', { chunk });
+                                    if (ws.readyState === WebSocket.OPEN) {
+                                        ws.send(JSON.stringify({
+                                            type: 'voice:text_chunk',
+                                            payload: { text: chunk }
+                                        }));
+                                    }
+                                },
+                                onComplete: (response: any) => {
+                                    logger.info('[Voice WS] Response complete', { text: response.text });
+                                    if (ws.readyState === WebSocket.OPEN) {
+                                        ws.send(JSON.stringify({
+                                            type: 'voice:response',
+                                            payload: { text: response.text, action: response.action }
+                                        }));
+                                    }
+                                },
+                                onError: (error: Error) => {
+                                    logger.error('[Voice WS] Error processing voice input', { error: error.message });
+                                    if (ws.readyState === WebSocket.OPEN) {
+                                        ws.send(JSON.stringify({
+                                            type: 'voice:response',
+                                            payload: { text: "Sorry, I couldn't process that. Can you try again?", action: 'error' }
+                                        }));
+                                    }
+                                }
+                            }
+                        ).catch((err) => {
+                            logger.error('[Voice WS] Unhandled error', { error: err instanceof Error ? err.message : String(err) });
+                            if (ws.readyState === WebSocket.OPEN) {
+                                ws.send(JSON.stringify({
+                                    type: 'voice:response',
+                                    payload: { text: "Sorry, something went wrong.", action: 'error' }
+                                }));
+                            }
+                        });
+                        break;
+                    }
                 }
             } catch (err) {
                 logger.error('Error handling message', {
@@ -2113,6 +2182,7 @@ export async function createApp(basePath?: string) {
             const reasonStr = reason.toString() || 'no reason';
             console.log(`[Server] Client disconnected - code: ${code}, reason: ${reasonStr}`);
             clients.delete(ws);
+            voiceClients.delete(ws);
         });
 
         ws.on('error', (error: Error) => {
@@ -5486,3 +5556,4 @@ Guidelines:
 
     return { app, server, wss, taskSpawner, workspaceStore, supervisorChat, gracefulShutdown, tunnelManager };
 }
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -72,6 +72,7 @@ const VALID_WS_MESSAGE_TYPES = new Set([
     'workspace:references:add',
     'workspace:references:remove',
     'workspace:references:toggle',
+    'workspace:previewPort:set',
     'workspace:recent:list',
     'workspace:recent:clear',
     'workspace:reset',
@@ -400,6 +401,11 @@ export async function createApp(basePath?: string) {
 
         // Let API routes pass through
         if (req.path.startsWith('/api/')) {
+            return next();
+        }
+
+        // Let /voice route pass through to Express handler
+        if (req.path === '/voice') {
             return next();
         }
 
@@ -1724,6 +1730,17 @@ export async function createApp(basePath?: string) {
                         } catch (error) {
                             const errorMessage = error instanceof Error ? error.message : String(error);
                             logger.error('Failed to toggle reference', { workspaceId, referencePath, error: errorMessage });
+                        }
+                        break;
+                    }
+
+                    case 'workspace:previewPort:set': {
+                        const { workspaceId, port } = payload as { workspaceId?: string; port?: number };
+                        if (!workspaceId) break;
+                        const parsedPort = port ? Number(port) : undefined;
+                        if (workspaceStore.setPreviewPort(workspaceId, parsedPort)) {
+                            const workspaces = workspaceStore.getWorkspaces();
+                            broadcast({ type: 'workspace:updated' as WSMessageType, payload: { workspaces } });
                         }
                         break;
                     }
@@ -3341,6 +3358,38 @@ export async function createApp(basePath?: string) {
         } catch (error) {
             res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
         }
+    });
+
+    // Preview proxy — forward requests to a workspace's dev server port
+    app.use('/api/preview/:port', (req, res) => {
+        const port = parseInt(req.params.port, 10);
+        if (isNaN(port) || port < 1 || port > 65535) {
+            return res.status(400).send('Invalid port');
+        }
+        if (port === PORTS.BACKEND) {
+            return res.status(403).send('Cannot proxy to Claudia backend port');
+        }
+
+        const targetPath = req.url || '/';
+        const proxyReq = httpRequest({
+            hostname: 'localhost',
+            port,
+            path: targetPath,
+            method: req.method,
+            headers: { ...req.headers, host: `localhost:${port}` },
+        }, (proxyRes) => {
+            res.writeHead(proxyRes.statusCode || 200, proxyRes.headers);
+            proxyRes.pipe(res);
+        });
+        proxyReq.on('error', (err) => {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === 'ECONNREFUSED') {
+                return res.status(502).send(`Dev server not running on port ${port}`);
+            }
+            logger.error('Preview proxy error', { error: err.message, port, path: targetPath });
+            res.status(502).send('Preview proxy error');
+        });
+        req.pipe(proxyReq);
     });
 
     app.get('/api/workspaces', (_req, res) => {

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -3738,6 +3738,10 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
                 console.log(`[TaskSpawner] Reconnecting Claude Code task ${taskId} (fresh start)`);
             }
 
+            // Add -- to terminate argument parsing (workaround for Claude CLI bug with --mcp-config)
+            // See: https://github.com/anthropics/claude-code/issues/22404
+            claudeArgs.push('--');
+
             const { command: claudeCmd2, prefixArgs: claudePrefix2 } = resolveClaudeSpawn();
             ptyProcess = spawn(claudeCmd2, [...claudePrefix2, ...claudeArgs], {
                 name: 'xterm-256color',

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -1887,6 +1887,13 @@ export class TaskSpawner extends EventEmitter {
         return task.state;
     }
 
+    getTaskWorkspaceId(taskId: string): string | null {
+        const task = this.tasks.get(taskId);
+        if (task) return task.workspaceId;
+        const disconnected = this.disconnectedTasks.get(taskId);
+        return disconnected ? disconnected.workspaceId : null;
+    }
+
     private sendPromptWithRetry(task: InternalTask, prompt: string, maxRetries = 5): void {
         // Guard: abort if PTY has exited — writing to a dead native handle causes segfaults
         if (task.state === 'exited' || !this.tasks.has(task.id)) {

--- a/backend/src/usage-store.ts
+++ b/backend/src/usage-store.ts
@@ -1,0 +1,291 @@
+/**
+ * Usage Store - Tracks token usage and API costs across tasks.
+ * Parses token information from Claude Code task output and aggregates
+ * costs by task, workspace, model, and time period.
+ */
+import { existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { loadVersioned, saveVersioned } from './utils/schema-version.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const USAGE_SCHEMA_VERSION = 1;
+
+// Model pricing per 1M tokens (as of 2025)
+const MODEL_PRICING: Record<string, { input: number; output: number; cacheCreation: number; cacheRead: number }> = {
+    'sonnet': { input: 3, output: 15, cacheCreation: 3.75, cacheRead: 0.30 },
+    'opus': { input: 15, output: 75, cacheCreation: 18.75, cacheRead: 1.50 },
+    'haiku': { input: 0.80, output: 4, cacheCreation: 1, cacheRead: 0.08 },
+};
+
+export interface UsageEntry {
+    id: string;
+    taskId: string;
+    workspaceId: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    cost: number;
+    timestamp: string;
+}
+
+export interface UsageSummary {
+    totalCost: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheCreationTokens: number;
+    totalCacheReadTokens: number;
+    byModel: Record<string, { cost: number; inputTokens: number; outputTokens: number }>;
+    byTask: Record<string, { cost: number; totalTokens: number; taskPrompt?: string }>;
+    byWorkspace: Record<string, { cost: number; totalTokens: number }>;
+    entryCount: number;
+    totalEntryCount: number;      // Total entries across all time (for comparison)
+    oldestEntryDate?: string;     // ISO timestamp of oldest entry in the filtered set
+    newestEntryDate?: string;     // ISO timestamp of newest entry in the filtered set
+}
+
+interface UsageData {
+    entries: UsageEntry[];
+}
+
+const DEFAULT_DATA: UsageData = { entries: [] };
+
+export class UsageStore {
+    private data: UsageData;
+    private filePath: string;
+    private saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(basePath?: string) {
+        this.filePath = basePath
+            ? join(basePath, 'usage-data.json')
+            : join(__dirname, '..', 'usage-data.json');
+
+        const dir = dirname(this.filePath);
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        this.data = this.loadData();
+        console.log(`[UsageStore] Loaded ${this.data.entries.length} usage entries from ${this.filePath}`);
+    }
+
+    private loadData(): UsageData {
+        try {
+            return loadVersioned<UsageData>(this.filePath, {
+                currentVersion: USAGE_SCHEMA_VERSION,
+                defaultData: { ...DEFAULT_DATA },
+                legacyLoader: (raw) => (raw as UsageData) ?? { ...DEFAULT_DATA },
+            });
+        } catch (error) {
+            console.error('[UsageStore] Error loading data:', error);
+            return { ...DEFAULT_DATA };
+        }
+    }
+
+    private debouncedSave(): void {
+        if (this.saveTimer) clearTimeout(this.saveTimer);
+        this.saveTimer = setTimeout(() => {
+            try {
+                saveVersioned(this.filePath, this.data, USAGE_SCHEMA_VERSION);
+            } catch (error) {
+                console.error('[UsageStore] Error saving data:', error);
+            }
+        }, 2000);
+    }
+
+    /**
+     * Record a usage entry from parsed task output.
+     */
+    recordUsage(taskId: string, workspaceId: string, model: string, tokens: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens?: number;
+        cacheReadTokens?: number;
+    }): UsageEntry {
+        const normalizedModel = this.normalizeModel(model);
+        const cost = this.calculateCost(normalizedModel, tokens);
+
+        const entry: UsageEntry = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            taskId,
+            workspaceId,
+            model: normalizedModel,
+            inputTokens: tokens.inputTokens,
+            outputTokens: tokens.outputTokens,
+            cacheCreationTokens: tokens.cacheCreationTokens || 0,
+            cacheReadTokens: tokens.cacheReadTokens || 0,
+            cost,
+            timestamp: new Date().toISOString(),
+        };
+
+        this.data.entries.push(entry);
+        this.debouncedSave();
+        return entry;
+    }
+
+    /**
+     * Parse token usage from Claude Code task output.
+     * Claude Code outputs patterns like:
+     * "Total tokens: 12345 (input: 8000, output: 4345)"
+     * "Cost: $0.12 | Tokens: 15,234 input, 3,456 output"
+     * "Input: 8,234 tokens | Output: 2,100 tokens | Cache read: 5,000"
+     */
+    parseAndRecord(taskId: string, workspaceId: string, outputLine: string): UsageEntry | null {
+        const stripped = outputLine.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+
+        // Pattern 1: "Total cost: $X.XX" or "Cost: $X.XX"
+        // Pattern 2: "NNk input tokens" / "NNk output tokens"
+        // Pattern 3: "Input tokens: N, Output tokens: N"
+        // Pattern 4: Claude Code end-of-session summary with token counts
+
+        let inputTokens = 0;
+        let outputTokens = 0;
+        let cacheCreationTokens = 0;
+        let cacheReadTokens = 0;
+        let model = 'sonnet';
+
+        // Try to detect model from output
+        if (/opus/i.test(stripped)) model = 'opus';
+        else if (/haiku/i.test(stripped)) model = 'haiku';
+
+        // Match patterns like "12,345 input" or "input: 12345" or "Input tokens: 12,345"
+        const inputMatch = stripped.match(/(\d[\d,]*)\s*(?:input|in)\b/i) ||
+            stripped.match(/input[:\s]+(\d[\d,]*)/i);
+        if (inputMatch) {
+            inputTokens = parseInt(inputMatch[1].replace(/,/g, ''), 10);
+        }
+
+        const outputMatch = stripped.match(/(\d[\d,]*)\s*(?:output|out)\b/i) ||
+            stripped.match(/output[:\s]+(\d[\d,]*)/i);
+        if (outputMatch) {
+            outputTokens = parseInt(outputMatch[1].replace(/,/g, ''), 10);
+        }
+
+        // Cache tokens
+        const cacheCreateMatch = stripped.match(/cache.?(?:creat|write)[:\s]+(\d[\d,]*)/i);
+        if (cacheCreateMatch) {
+            cacheCreationTokens = parseInt(cacheCreateMatch[1].replace(/,/g, ''), 10);
+        }
+
+        const cacheReadMatch = stripped.match(/cache.?read[:\s]+(\d[\d,]*)/i);
+        if (cacheReadMatch) {
+            cacheReadTokens = parseInt(cacheReadMatch[1].replace(/,/g, ''), 10);
+        }
+
+        // Only record if we found meaningful token data
+        if (inputTokens === 0 && outputTokens === 0) return null;
+
+        return this.recordUsage(taskId, workspaceId, model, {
+            inputTokens,
+            outputTokens,
+            cacheCreationTokens,
+            cacheReadTokens,
+        });
+    }
+
+    /**
+     * Get usage summary filtered by time period.
+     */
+    getSummary(period: 'today' | '7d' | '30d' | 'all' = 'all', workspaceId?: string): UsageSummary {
+        const now = Date.now();
+        const cutoff = period === 'today' ? now - 86400000
+            : period === '7d' ? now - 7 * 86400000
+                : period === '30d' ? now - 30 * 86400000
+                    : 0;
+
+        let entries = this.data.entries.filter(e => new Date(e.timestamp).getTime() >= cutoff);
+        if (workspaceId) {
+            entries = entries.filter(e => e.workspaceId === workspaceId);
+        }
+
+        const totalEntryCount = this.data.entries.length;
+
+        const summary: UsageSummary = {
+            totalCost: 0,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            byModel: {},
+            byTask: {},
+            byWorkspace: {},
+            entryCount: entries.length,
+            totalEntryCount,
+            oldestEntryDate: entries.length > 0 ? entries[0].timestamp : undefined,
+            newestEntryDate: entries.length > 0 ? entries[entries.length - 1].timestamp : undefined,
+        };
+
+        for (const entry of entries) {
+            summary.totalCost += entry.cost;
+            summary.totalInputTokens += entry.inputTokens;
+            summary.totalOutputTokens += entry.outputTokens;
+            summary.totalCacheCreationTokens += entry.cacheCreationTokens;
+            summary.totalCacheReadTokens += entry.cacheReadTokens;
+
+            // By model
+            if (!summary.byModel[entry.model]) {
+                summary.byModel[entry.model] = { cost: 0, inputTokens: 0, outputTokens: 0 };
+            }
+            summary.byModel[entry.model].cost += entry.cost;
+            summary.byModel[entry.model].inputTokens += entry.inputTokens;
+            summary.byModel[entry.model].outputTokens += entry.outputTokens;
+
+            // By task
+            if (!summary.byTask[entry.taskId]) {
+                summary.byTask[entry.taskId] = { cost: 0, totalTokens: 0 };
+            }
+            summary.byTask[entry.taskId].cost += entry.cost;
+            summary.byTask[entry.taskId].totalTokens += entry.inputTokens + entry.outputTokens;
+
+            // By workspace
+            if (!summary.byWorkspace[entry.workspaceId]) {
+                summary.byWorkspace[entry.workspaceId] = { cost: 0, totalTokens: 0 };
+            }
+            summary.byWorkspace[entry.workspaceId].cost += entry.cost;
+            summary.byWorkspace[entry.workspaceId].totalTokens += entry.inputTokens + entry.outputTokens;
+        }
+
+        return summary;
+    }
+
+    /**
+     * Get all entries for a specific task.
+     */
+    getTaskUsage(taskId: string): UsageEntry[] {
+        return this.data.entries.filter(e => e.taskId === taskId);
+    }
+
+    /**
+     * Clear all usage data.
+     */
+    clearAll(): void {
+        this.data.entries = [];
+        this.debouncedSave();
+    }
+
+    private normalizeModel(model: string): string {
+        const lower = model.toLowerCase();
+        if (lower.includes('opus')) return 'opus';
+        if (lower.includes('haiku')) return 'haiku';
+        return 'sonnet';
+    }
+
+    private calculateCost(model: string, tokens: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens?: number;
+        cacheReadTokens?: number;
+    }): number {
+        const pricing = MODEL_PRICING[model] || MODEL_PRICING['sonnet'];
+        return (
+            (tokens.inputTokens / 1_000_000) * pricing.input +
+            (tokens.outputTokens / 1_000_000) * pricing.output +
+            ((tokens.cacheCreationTokens || 0) / 1_000_000) * pricing.cacheCreation +
+            ((tokens.cacheReadTokens || 0) / 1_000_000) * pricing.cacheRead
+        );
+    }
+}

--- a/backend/src/voice-agent-page.ts
+++ b/backend/src/voice-agent-page.ts
@@ -71,6 +71,39 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             background: rgba(88, 166, 255, 0.1);
         }
 
+        .header-controls {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .toggle-btn {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            color: var(--text-muted);
+            width: 36px;
+            height: 36px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 1.1rem;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0.5;
+        }
+
+        .toggle-btn.active {
+            opacity: 1;
+            border-color: var(--accent);
+            color: var(--text);
+            background: rgba(88, 166, 255, 0.1);
+        }
+
+        .toggle-btn:hover {
+            border-color: var(--accent);
+        }
+
         .content {
             flex: 1;
             display: flex;
@@ -78,6 +111,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             align-items: center;
             justify-content: center;
             padding: 2rem;
+            padding-bottom: 60px;
             overflow-y: auto;
         }
 
@@ -152,6 +186,67 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
         .transcript-text.empty {
             color: var(--text-muted);
             font-style: italic;
+        }
+
+        .text-input-container {
+            display: flex;
+            align-items: flex-end;
+            gap: 0.5rem;
+            max-width: 600px;
+            width: 100%;
+        }
+
+        .text-input {
+            flex: 1;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.75rem 1rem;
+            color: var(--text);
+            font-size: 1rem;
+            font-family: inherit;
+            resize: none;
+            overflow-y: hidden;
+            line-height: 1.4;
+            max-height: 120px;
+        }
+
+        .text-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px var(--accent-glow);
+        }
+
+        .text-input::placeholder {
+            color: var(--text-muted);
+        }
+
+        .send-btn {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            border: 1px solid var(--accent);
+            background: var(--accent);
+            color: var(--bg);
+            font-size: 1.2rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s;
+            flex-shrink: 0;
+        }
+
+        .send-btn:hover {
+            transform: scale(1.05);
+            box-shadow: 0 0 10px var(--accent-glow);
+        }
+
+        .send-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
         }
 
         .modal {
@@ -315,12 +410,168 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             font-weight: 500;
             color: var(--success);
         }
+
+        /* Task Panel Styles */
+        .task-panel {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: var(--surface);
+            border-top: 1px solid var(--border);
+            z-index: 100;
+            transition: transform 0.3s ease;
+            max-height: 50vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .task-panel.collapsed {
+            transform: translateY(calc(100% - 40px));
+        }
+
+        .task-panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.5rem 1rem;
+            cursor: pointer;
+            border-bottom: 1px solid var(--border);
+            min-height: 40px;
+            flex-shrink: 0;
+            user-select: none;
+        }
+
+        .task-panel-header:hover {
+            background: rgba(88, 166, 255, 0.05);
+        }
+
+        .task-panel-title {
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: var(--text);
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .task-count-badge {
+            background: var(--accent);
+            color: var(--bg);
+            font-size: 0.7rem;
+            padding: 0.1rem 0.4rem;
+            border-radius: 10px;
+            font-weight: 700;
+        }
+
+        .task-panel-toggle {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            transition: transform 0.3s;
+        }
+
+        .task-panel.collapsed .task-panel-toggle {
+            transform: rotate(180deg);
+        }
+
+        .task-panel-workspace {
+            padding: 0.4rem 1rem;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            background: var(--bg);
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            flex-shrink: 0;
+        }
+
+        .task-panel-workspace .ws-name {
+            color: var(--accent);
+            font-weight: 500;
+        }
+
+        .task-list-scroll {
+            overflow-y: auto;
+            flex: 1;
+            padding: 0.5rem;
+        }
+
+        .task-item {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            margin-bottom: 0.25rem;
+            transition: background 0.15s;
+        }
+
+        .task-item:hover {
+            background: rgba(88, 166, 255, 0.05);
+        }
+
+        .task-state-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        .task-state-dot.busy { background: var(--accent); animation: dot-pulse 1.5s infinite; }
+        .task-state-dot.starting { background: var(--warning); animation: dot-pulse 1s infinite; }
+        .task-state-dot.waiting_input { background: var(--warning); }
+        .task-state-dot.idle { background: var(--success); }
+        .task-state-dot.exited { background: var(--text-muted); }
+        .task-state-dot.disconnected { background: var(--text-muted); opacity: 0.5; }
+        .task-state-dot.interrupted { background: var(--error); }
+
+        @keyframes dot-pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+
+        .task-item-info {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .task-item-name {
+            font-size: 0.8rem;
+            color: var(--text);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .task-item-state {
+            font-size: 0.7rem;
+            color: var(--text-muted);
+        }
+
+        .task-item-time {
+            font-size: 0.65rem;
+            color: var(--text-muted);
+            flex-shrink: 0;
+        }
+
+        .task-empty {
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.8rem;
+            padding: 1rem;
+            font-style: italic;
+        }
     </style>
 </head>
 <body>
     <div class="header">
         <h1>🎤 Claudia Voice Agent</h1>
-        <button class="settings-btn" onclick="showSettings()">⚙️ Settings</button>
+        <div class="header-controls">
+            <button class="toggle-btn active" id="micToggle" onclick="toggleMicEnabled()" title="Microphone">🎙️</button>
+            <button class="toggle-btn active" id="ttsToggle" onclick="toggleTtsEnabled()" title="Voice output">🔊</button>
+            <button class="settings-btn" onclick="showSettings()">⚙️ Settings</button>
+        </div>
     </div>
 
     <div class="content">
@@ -335,6 +586,26 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             <div class="transcript" id="responseArea" style="margin-top: 1rem; display: none;">
                 <div class="transcript-text" id="responseText" style="color: var(--success);"></div>
             </div>
+            <div class="text-input-container">
+                <textarea id="textInput" class="text-input" placeholder="Type a message..." rows="1"></textarea>
+                <button id="sendButton" class="send-btn" onclick="sendTextMessage()">➤</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Task Panel -->
+    <div class="task-panel collapsed" id="taskPanel">
+        <div class="task-panel-header" onclick="toggleTaskPanel()">
+            <div class="task-panel-title">
+                Tasks <span class="task-count-badge" id="taskCountBadge">0</span>
+            </div>
+            <div class="task-panel-toggle">▼</div>
+        </div>
+        <div class="task-panel-workspace" id="taskPanelWorkspace" style="display:none;">
+            <span>Workspace:</span> <span class="ws-name" id="workspaceName">—</span>
+        </div>
+        <div class="task-list-scroll" id="taskListScroll">
+            <div class="task-empty">No tasks</div>
         </div>
     </div>
 
@@ -364,6 +635,35 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
         let deepgramSocket = null;
         let isRecording = false;
         let audioContext = null;
+        let micEnabled = localStorage.getItem('voiceMicEnabled') !== 'false';
+        let ttsEnabled = localStorage.getItem('voiceTtsEnabled') !== 'false';
+
+        function toggleMicEnabled() {
+            micEnabled = !micEnabled;
+            localStorage.setItem('voiceMicEnabled', micEnabled);
+            document.getElementById('micToggle').classList.toggle('active', micEnabled);
+            if (!micEnabled && isRecording) {
+                toggleRecording();
+            }
+            document.getElementById('micButton').style.display = micEnabled ? '' : 'none';
+            document.getElementById('status').textContent = micEnabled ? 'Click to start recording' : 'Mic disabled';
+        }
+
+        function toggleTtsEnabled() {
+            ttsEnabled = !ttsEnabled;
+            localStorage.setItem('voiceTtsEnabled', ttsEnabled);
+            document.getElementById('ttsToggle').classList.toggle('active', ttsEnabled);
+        }
+
+        // Apply initial toggle state
+        (function initToggles() {
+            document.getElementById('micToggle').classList.toggle('active', micEnabled);
+            document.getElementById('ttsToggle').classList.toggle('active', ttsEnabled);
+            if (!micEnabled) {
+                document.getElementById('micButton').style.display = 'none';
+                document.getElementById('status').textContent = 'Mic disabled';
+            }
+        })();
 
         // Initialize WebSocket connection
         function initWebSocket() {
@@ -391,6 +691,9 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
 
         function handleWSMessage(message) {
             console.log('[Voice WS] Received message:', message.type, message.payload);
+            // Route task/workspace messages to panel
+            handleTaskMessages(message);
+
             if (message.type === 'voice:announce') {
                 playAnnouncement(message.payload.text);
             } else if (message.type === 'voice:status') {
@@ -424,6 +727,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
         }
 
         async function playTTS(text) {
+            if (!ttsEnabled) return;
             if (!text || text.trim().length === 0) return;
             try {
                 const voiceId = localStorage.getItem('elevenLabsVoiceId') || '';
@@ -456,6 +760,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
         }
 
         async function toggleRecording() {
+            if (!micEnabled) return;
             if (isRecording) {
                 stopRecording();
             } else {
@@ -612,6 +917,31 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             }
         }
 
+        function sendTextMessage() {
+            const input = document.getElementById('textInput');
+            const text = input.value.trim();
+            if (!text) return;
+            updateTranscript(text);
+            sendVoiceInput(text);
+            input.value = '';
+            input.style.height = 'auto';
+        }
+
+        // Auto-resize textarea and handle Enter to send
+        (function initTextInput() {
+            const input = document.getElementById('textInput');
+            input.addEventListener('input', function() {
+                this.style.height = 'auto';
+                this.style.height = Math.min(this.scrollHeight, 120) + 'px';
+            });
+            input.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    sendTextMessage();
+                }
+            });
+        })();
+
         function showSettings() {
             document.getElementById('settingsModal').classList.add('show');
             loadVoices();
@@ -738,6 +1068,124 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
 
             closeSettings();
             alert(\`Voice changed to: \${voiceName}\`);
+        }
+
+        // ===== Task Panel =====
+        let allTasks = [];
+        let allWorkspaces = [];
+
+        function toggleTaskPanel() {
+            document.getElementById('taskPanel').classList.toggle('collapsed');
+        }
+
+        function getTaskDisplayName(task) {
+            return task.displayName || (task.prompt && task.prompt.length > 60
+                ? task.prompt.substring(0, 60) + '...'
+                : task.prompt) || 'Untitled';
+        }
+
+        function getWorkspaceName(workspaceId) {
+            const ws = allWorkspaces.find(w => w.id === workspaceId);
+            if (ws) return ws.displayName || ws.name;
+            if (!workspaceId) return '—';
+            const parts = workspaceId.replace(/\\\\/g, '/').split('/');
+            return parts[parts.length - 1] || workspaceId;
+        }
+
+        function timeAgo(dateStr) {
+            if (!dateStr) return '';
+            const d = new Date(dateStr);
+            const now = Date.now();
+            const diff = Math.floor((now - d.getTime()) / 1000);
+            if (diff < 60) return 'just now';
+            if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+            if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+            return Math.floor(diff / 86400) + 'd ago';
+        }
+
+        function renderTaskList() {
+            const scroll = document.getElementById('taskListScroll');
+            const badge = document.getElementById('taskCountBadge');
+            const wsEl = document.getElementById('taskPanelWorkspace');
+            const wsNameEl = document.getElementById('workspaceName');
+
+            // Filter to recent/active tasks: running or active in last 24h
+            const now = Date.now();
+            const DAY = 24 * 60 * 60 * 1000;
+            const activeTasks = allTasks.filter(t => {
+                if (['busy', 'starting', 'waiting_input'].includes(t.state)) return true;
+                const lastAct = new Date(t.lastActivity || t.createdAt).getTime();
+                return (now - lastAct) < DAY && t.state !== 'archived';
+            });
+
+            // Sort: running first, then by last activity
+            const stateOrder = { busy: 0, starting: 1, waiting_input: 2, idle: 3, exited: 4, interrupted: 5, disconnected: 6 };
+            activeTasks.sort((a, b) => {
+                const sa = stateOrder[a.state] ?? 9;
+                const sb = stateOrder[b.state] ?? 9;
+                if (sa !== sb) return sa - sb;
+                const ta = new Date(b.lastActivity || b.createdAt).getTime();
+                const tb = new Date(a.lastActivity || a.createdAt).getTime();
+                return ta - tb;
+            });
+
+            const runningCount = activeTasks.filter(t => ['busy', 'starting', 'waiting_input'].includes(t.state)).length;
+            badge.textContent = runningCount > 0 ? runningCount : activeTasks.length;
+            badge.style.background = runningCount > 0 ? 'var(--accent)' : 'var(--text-muted)';
+
+            // Show workspace if tasks exist
+            if (activeTasks.length > 0) {
+                const primaryWs = activeTasks[0].workspaceId;
+                wsNameEl.textContent = getWorkspaceName(primaryWs);
+                wsEl.style.display = '';
+            } else {
+                wsEl.style.display = 'none';
+            }
+
+            if (activeTasks.length === 0) {
+                scroll.innerHTML = '<div class="task-empty">No recent tasks</div>';
+                return;
+            }
+
+            scroll.innerHTML = activeTasks.map(t => \`
+                <div class="task-item">
+                    <div class="task-state-dot \${t.state}"></div>
+                    <div class="task-item-info">
+                        <div class="task-item-name">\${escapeHtml(getTaskDisplayName(t))}</div>
+                        <div class="task-item-state">\${t.state}\${t.workspaceId ? ' · ' + escapeHtml(getWorkspaceName(t.workspaceId)) : ''}</div>
+                    </div>
+                    <div class="task-item-time">\${timeAgo(t.lastActivity || t.createdAt)}</div>
+                </div>
+            \`).join('');
+        }
+
+        function escapeHtml(str) {
+            if (!str) return '';
+            return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
+        function handleTaskMessages(message) {
+            if (message.type === 'init') {
+                allTasks = message.payload.tasks || [];
+                allWorkspaces = message.payload.workspaces || [];
+                renderTaskList();
+            } else if (message.type === 'tasks:updated') {
+                allTasks = message.payload.tasks || [];
+                renderTaskList();
+            } else if (message.type === 'task:stateChanged') {
+                const updated = message.payload.task;
+                if (updated) {
+                    const idx = allTasks.findIndex(t => t.id === updated.id);
+                    if (idx >= 0) allTasks[idx] = updated;
+                    else allTasks.push(updated);
+                    renderTaskList();
+                }
+            } else if (message.type === 'workspace:created') {
+                const ws = message.payload.workspace;
+                if (ws && !allWorkspaces.find(w => w.id === ws.id)) {
+                    allWorkspaces.push(ws);
+                }
+            }
         }
 
         // Initialize on load

--- a/backend/src/voice-agent-page.ts
+++ b/backend/src/voice-agent-page.ts
@@ -484,20 +484,18 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             try {
                 const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
 
-                // Detect best encoding for this browser
+                // Detect best mimeType for this browser
                 const mimeType = getSupportedMimeType();
-                let encoding = 'linear16';
-                if (mimeType.includes('opus')) {
-                    encoding = 'opus';
-                } else if (mimeType.includes('webm')) {
-                    encoding = 'webm';
-                } else if (mimeType.includes('mp4')) {
-                    encoding = 'mp4';
-                }
 
-                // Initialize Deepgram WebSocket with correct encoding
-                const dgUrl = 'wss://api.deepgram.com/v1/listen?model=nova-3&language=en&smart_format=true&punctuate=true&interim_results=true&encoding=' + encoding;
-                console.log('[Voice] Connecting to Deepgram with encoding:', encoding);
+                // When MediaRecorder produces containerized audio (WebM, MP4, Ogg),
+                // do NOT pass the encoding param — Deepgram auto-detects from the
+                // container metadata. Only pass encoding for raw/headerless audio.
+                const isContainerized = mimeType.includes('webm') || mimeType.includes('mp4') || mimeType.includes('ogg');
+                const dgParams = 'model=nova-3&language=en&smart_format=true&punctuate=true&interim_results=true';
+                const dgUrl = isContainerized
+                    ? 'wss://api.deepgram.com/v1/listen?' + dgParams
+                    : 'wss://api.deepgram.com/v1/listen?' + dgParams + '&encoding=linear16&sample_rate=48000';
+                console.log('[Voice] Connecting to Deepgram, containerized:', isContainerized, 'mimeType:', mimeType);
                 deepgramSocket = new WebSocket(dgUrl, ['token', DEEPGRAM_API_KEY]);
 
                 deepgramSocket.onopen = () => {
@@ -507,6 +505,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
 
                 deepgramSocket.onmessage = (event) => {
                     const data = JSON.parse(event.data);
+                    console.log('[Voice] Deepgram msg:', data.type, JSON.stringify(data).substring(0, 200));
                     if (data.type === 'Results') {
                         const alt = data.channel?.alternatives?.[0];
                         if (!alt) return;
@@ -514,6 +513,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
                         if (!transcript.trim()) return;
 
                         const isFinal = data.is_final === true;
+                        console.log('[Voice] Transcript:', transcript, 'isFinal:', isFinal);
                         updateTranscript(transcript);
 
                         if (isFinal) {
@@ -534,14 +534,31 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
                     console.log('[Voice] Deepgram WebSocket closed');
                 };
 
+                // Buffer chunks that arrive before Deepgram is ready.
+                // The first chunk contains the WebM header — losing it means
+                // Deepgram can't detect the container format.
+                let pendingChunks = [];
+
                 // Setup MediaRecorder with detected mimeType
                 const recorderOptions = {};
                 if (mimeType) recorderOptions.mimeType = mimeType;
                 mediaRecorder = new MediaRecorder(stream, recorderOptions);
 
                 mediaRecorder.ondataavailable = (event) => {
-                    if (event.data.size > 0 && deepgramSocket?.readyState === WebSocket.OPEN) {
+                    if (event.data.size === 0) return;
+                    if (deepgramSocket?.readyState === WebSocket.OPEN) {
+                        // Flush any buffered chunks first
+                        if (pendingChunks.length > 0) {
+                            console.log('[Voice] Flushing', pendingChunks.length, 'buffered chunks');
+                            for (const chunk of pendingChunks) {
+                                deepgramSocket.send(chunk);
+                            }
+                            pendingChunks = [];
+                        }
                         deepgramSocket.send(event.data);
+                    } else if (deepgramSocket?.readyState === WebSocket.CONNECTING) {
+                        console.log('[Voice] Buffering chunk:', event.data.size, 'bytes (DG still connecting)');
+                        pendingChunks.push(event.data);
                     }
                 };
 

--- a/backend/src/voice-agent-page.ts
+++ b/backend/src/voice-agent-page.ts
@@ -332,6 +332,9 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             <div class="transcript">
                 <div class="transcript-text empty" id="transcript">Your speech will appear here...</div>
             </div>
+            <div class="transcript" id="responseArea" style="margin-top: 1rem; display: none;">
+                <div class="transcript-text" id="responseText" style="color: var(--success);"></div>
+            </div>
         </div>
     </div>
 
@@ -350,7 +353,9 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
     </div>
 
     <script>
-        const WS_URL = '${wsUrl}';
+        // Determine WebSocket URL client-side to handle tunnel/HTTPS correctly
+        const WS_PROTOCOL = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const WS_URL = WS_PROTOCOL + '//' + window.location.host;
         const TOKEN = '${token}';
         const DEEPGRAM_API_KEY = '${deepgramApiKey}';
 
@@ -362,7 +367,7 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
 
         // Initialize WebSocket connection
         function initWebSocket() {
-            ws = new WebSocket(\`\${WS_URL}/ws?token=\${TOKEN}\`);
+            ws = new WebSocket(\`\${WS_URL}/ws?token=\${TOKEN}&voice=1\`);
 
             ws.onopen = () => {
                 console.log('WebSocket connected');
@@ -385,14 +390,69 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
         }
 
         function handleWSMessage(message) {
+            console.log('[Voice WS] Received message:', message.type, message.payload);
             if (message.type === 'voice:announce') {
                 playAnnouncement(message.payload.text);
+            } else if (message.type === 'voice:status') {
+                if (message.payload.status === 'processing') {
+                    updateStatus('Thinking...', true);
+                    // Clear previous response and show area
+                    const responseArea = document.getElementById('responseArea');
+                    const responseText = document.getElementById('responseText');
+                    responseText.textContent = '';
+                    responseArea.style.display = 'block';
+                }
+            } else if (message.type === 'voice:text_chunk') {
+                // Append streaming text chunks
+                const responseText = document.getElementById('responseText');
+                responseText.textContent += message.payload.text;
+            } else if (message.type === 'voice:response') {
+                // Final response - show full text and play TTS
+                const responseText = document.getElementById('responseText');
+                responseText.textContent = message.payload.text;
+                updateStatus('Click to start recording', false);
+                // Play TTS audio
+                if (message.payload.text && message.payload.action !== 'error') {
+                    playTTS(message.payload.text);
+                }
             }
         }
 
         function playAnnouncement(text) {
             console.log('Playing announcement:', text);
-            // Audio will be played via voice supervisor
+            playTTS(text);
+        }
+
+        async function playTTS(text) {
+            if (!text || text.trim().length === 0) return;
+            try {
+                const voiceId = localStorage.getItem('elevenLabsVoiceId') || '';
+                const voiceName = localStorage.getItem('elevenLabsVoiceName') || 'charlotte';
+                console.log('[Voice TTS] Speaking:', text, 'voice:', voiceName);
+
+                const response = await fetch('/api/tts', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text, voice: voiceName })
+                });
+
+                if (!response.ok) {
+                    console.error('[Voice TTS] TTS request failed:', response.status, response.statusText);
+                    return;
+                }
+
+                const audioBlob = await response.blob();
+                const audioUrl = URL.createObjectURL(audioBlob);
+                const audio = new Audio(audioUrl);
+                audio.onended = () => URL.revokeObjectURL(audioUrl);
+                audio.onerror = (e) => {
+                    console.error('[Voice TTS] Audio playback error:', e);
+                    URL.revokeObjectURL(audioUrl);
+                };
+                await audio.play();
+            } catch (error) {
+                console.error('[Voice TTS] Failed to play TTS:', error);
+            }
         }
 
         async function toggleRecording() {
@@ -403,15 +463,42 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
             }
         }
 
+        function getSupportedMimeType() {
+            const types = [
+                'audio/webm;codecs=opus',
+                'audio/webm',
+                'audio/mp4',
+                'audio/ogg;codecs=opus',
+            ];
+            for (const t of types) {
+                if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(t)) {
+                    console.log('[Voice] Using mimeType:', t);
+                    return t;
+                }
+            }
+            console.warn('[Voice] No preferred mimeType supported, falling back to default');
+            return '';
+        }
+
         async function startRecording() {
             try {
                 const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
 
-                // Initialize Deepgram WebSocket
-                deepgramSocket = new WebSocket(
-                    'wss://api.deepgram.com/v1/listen?model=nova-3&language=en&smart_format=true',
-                    ['token', DEEPGRAM_API_KEY]
-                );
+                // Detect best encoding for this browser
+                const mimeType = getSupportedMimeType();
+                let encoding = 'linear16';
+                if (mimeType.includes('opus')) {
+                    encoding = 'opus';
+                } else if (mimeType.includes('webm')) {
+                    encoding = 'webm';
+                } else if (mimeType.includes('mp4')) {
+                    encoding = 'mp4';
+                }
+
+                // Initialize Deepgram WebSocket with correct encoding
+                const dgUrl = 'wss://api.deepgram.com/v1/listen?model=nova-3&language=en&smart_format=true&punctuate=true&interim_results=true&encoding=' + encoding;
+                console.log('[Voice] Connecting to Deepgram with encoding:', encoding);
+                deepgramSocket = new WebSocket(dgUrl, ['token', DEEPGRAM_API_KEY]);
 
                 deepgramSocket.onopen = () => {
                     console.log('Deepgram connected');
@@ -420,16 +507,21 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
 
                 deepgramSocket.onmessage = (event) => {
                     const data = JSON.parse(event.data);
-                    if (data.channel?.alternatives?.[0]?.transcript) {
-                        const transcript = data.channel.alternatives[0].transcript;
-                        if (transcript.trim()) {
-                            updateTranscript(transcript);
+                    if (data.type === 'Results') {
+                        const alt = data.channel?.alternatives?.[0];
+                        if (!alt) return;
+                        const transcript = alt.transcript || '';
+                        if (!transcript.trim()) return;
 
-                            // Send to backend if final
-                            if (data.is_final) {
-                                sendVoiceInput(transcript);
-                            }
+                        const isFinal = data.is_final === true;
+                        updateTranscript(transcript);
+
+                        if (isFinal) {
+                            sendVoiceInput(transcript);
                         }
+                    } else if (data.type === 'Error') {
+                        console.error('[Voice] Deepgram error:', data);
+                        updateStatus('Recognition error', false);
                     }
                 };
 
@@ -438,10 +530,14 @@ export function getVoiceAgentPageHtml(wsUrl: string, token: string, deepgramApiK
                     updateStatus('Recognition error', false);
                 };
 
-                // Setup MediaRecorder
-                mediaRecorder = new MediaRecorder(stream, {
-                    mimeType: 'audio/webm;codecs=opus'
-                });
+                deepgramSocket.onclose = () => {
+                    console.log('[Voice] Deepgram WebSocket closed');
+                };
+
+                // Setup MediaRecorder with detected mimeType
+                const recorderOptions = {};
+                if (mimeType) recorderOptions.mimeType = mimeType;
+                mediaRecorder = new MediaRecorder(stream, recorderOptions);
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data.size > 0 && deepgramSocket?.readyState === WebSocket.OPEN) {

--- a/backend/src/voice-supervisor.ts
+++ b/backend/src/voice-supervisor.ts
@@ -3,7 +3,7 @@
  *
  * This supervisor is optimized for voice interaction:
  * - Responds directly to simple queries without creating tasks
- * - Only uses SupervisorChat tools when explicitly asked
+ * - Uses Claudia backend tools to manage tasks (create, stop, list, etc.)
  * - Ultra-short responses (1-2 sentences, < 20 words)
  * - No markdown formatting
  * - Conversational tone
@@ -15,6 +15,98 @@ import { SupervisorChat } from './supervisor-chat.js';
 import { TaskSpawner } from './task-spawner.js';
 import { EventEmitter } from 'events';
 import type { Task, ChatMessage } from '@claudia/shared';
+
+const BACKEND_URL = process.env.CLAUDIA_BACKEND_URL || 'http://localhost:4001';
+
+const VOICE_TOOLS: Anthropic.Tool[] = [
+    {
+        name: 'list_tasks',
+        description: 'List all active tasks in the current workspace. Shows task ID, state, prompt, and whether it is waiting for input.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {},
+            required: []
+        }
+    },
+    {
+        name: 'create_task',
+        description: 'Create a new coding task. The task will be executed by a Claude Code agent in the current workspace.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                prompt: { type: 'string', description: 'The task description/prompt for Claude Code to execute' },
+                displayName: { type: 'string', description: 'Optional short display name for the task in the sidebar' }
+            },
+            required: ['prompt']
+        }
+    },
+    {
+        name: 'get_task_status',
+        description: 'Get detailed status of a specific task including state, runtime duration, and a snippet of recent output.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                taskId: { type: 'string', description: 'The task ID to get status for' }
+            },
+            required: ['taskId']
+        }
+    },
+    {
+        name: 'stop_task',
+        description: 'Gracefully stop a running task by sending an interrupt signal. The task transitions to idle and can be resumed later.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                taskId: { type: 'string', description: 'The task ID to stop' }
+            },
+            required: ['taskId']
+        }
+    },
+    {
+        name: 'stop_all_tasks',
+        description: 'Stop all running tasks in the current workspace.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {},
+            required: []
+        }
+    },
+    {
+        name: 'send_input',
+        description: 'Send input to a task that is waiting for input (e.g., answering a question or granting permission).',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                taskId: { type: 'string', description: 'The task ID to send input to' },
+                input: { type: 'string', description: 'The input text to send' }
+            },
+            required: ['taskId', 'input']
+        }
+    },
+    {
+        name: 'continue_task',
+        description: 'Send a follow-up prompt to an idle or exited task, resuming its session with a new instruction.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                taskId: { type: 'string', description: 'The task ID to continue' },
+                prompt: { type: 'string', description: 'The follow-up prompt/instructions' }
+            },
+            required: ['taskId', 'prompt']
+        }
+    },
+    {
+        name: 'get_task_output',
+        description: 'Fetch recent terminal output from a task to see what it has been doing or check its results.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                taskId: { type: 'string', description: 'The task ID to get output from' }
+            },
+            required: ['taskId']
+        }
+    }
+];
 
 export class VoiceSupervisor extends EventEmitter {
     private supervisorChat: SupervisorChat;
@@ -39,14 +131,15 @@ export class VoiceSupervisor extends EventEmitter {
         }
 
         // Default system prompt
-        this.customSystemPrompt = `You are a voice assistant for a coding environment. Keep responses ULTRA SHORT - 1-2 sentences max, under 20 words if possible. Be conversational, natural, and friendly. No markdown, no bullet points, no formatting. Just speak naturally.
+        this.customSystemPrompt = `You are a voice assistant for a coding environment called Claudia. Keep responses ULTRA SHORT - 1-2 sentences max, under 20 words if possible. Be conversational, natural, and friendly. No markdown, no bullet points, no formatting. Just speak naturally.
 
-Answer questions directly. If the user wants to create a task or control tasks, acknowledge briefly and do it.`;
+You have tools to manage coding tasks. Use them when the user asks to create tasks, check status, stop tasks, send input, or interact with running tasks. After using tools, summarize the result briefly in a conversational way.
+
+Answer questions directly. If the user wants to create a task or control tasks, use your tools to do it.`;
     }
 
     /**
-     * Process voice input and stream response in real-time
-     * Returns a StreamingResponse object with event handlers
+     * Process voice input and stream response in real-time with tool use support
      */
     async processVoiceMessageStreaming(
         transcript: string,
@@ -90,58 +183,368 @@ ${taskContext ? `\n## Current Task Status\n${taskContext}\n` : ''}`;
                 if (callbacks?.onError) callbacks.onError(err);
                 return;
             }
-            // Stream the response from Claude
-            const stream = await this.anthropic.messages.stream({
-                model: 'claude-sonnet-4-6',
-                max_tokens: 150, // Keep it short for voice
-                messages: [{
-                    role: 'user',
-                    content: transcript
-                }],
-                system: systemPrompt
-            });
 
-            let fullText = '';
+            // Tool use loop: keep calling Claude until we get a final text response
+            const messages: Anthropic.MessageParam[] = [{
+                role: 'user',
+                content: transcript
+            }];
 
-            // Listen for text deltas
-            stream.on('text', (text) => {
-                fullText += text;
-                // Call callback for real-time TTS
-                if (callbacks?.onTextChunk) {
-                    callbacks.onTextChunk(text);
+            const MAX_TOOL_ITERATIONS = 5;
+            for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+                const stream = await this.anthropic.messages.stream({
+                    model: 'claude-sonnet-4-6',
+                    max_tokens: 1024,
+                    messages,
+                    system: systemPrompt,
+                    tools: VOICE_TOOLS
+                });
+
+                let fullText = '';
+                const toolUseBlocks: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
+                let currentToolUse: { id: string; name: string; inputJson: string } | null = null;
+
+                // Collect the full response (text + tool_use blocks)
+                stream.on('text', (text) => {
+                    fullText += text;
+                    if (callbacks?.onTextChunk) {
+                        callbacks.onTextChunk(text);
+                    }
+                });
+
+                stream.on('contentBlock', (block) => {
+                    if (block.type === 'tool_use') {
+                        toolUseBlocks.push({
+                            id: block.id,
+                            name: block.name,
+                            input: block.input as Record<string, unknown>
+                        });
+                    }
+                });
+
+                const finalMessage = await stream.finalMessage();
+
+                // If no tool use, we're done — stream already delivered text
+                if (finalMessage.stop_reason !== 'tool_use' || toolUseBlocks.length === 0) {
+                    const voiceText = this.optimizeForVoice(fullText);
+                    if (callbacks?.onComplete) {
+                        callbacks.onComplete({
+                            text: voiceText,
+                            action: 'response'
+                        });
+                    }
+                    return;
                 }
-            });
 
-            // Wait for completion
-            await stream.finalMessage();
+                // Execute tool calls and build tool results
+                console.log(`[VoiceSupervisor] Executing ${toolUseBlocks.length} tool call(s) (iteration ${iteration + 1})`);
 
-            // Strip markdown and optimize for voice
-            const voiceText = this.optimizeForVoice(fullText);
+                // Build assistant message content from the final message
+                const assistantContent: Anthropic.ContentBlockParam[] = [];
+                for (const block of finalMessage.content) {
+                    if (block.type === 'text' && block.text) {
+                        assistantContent.push({ type: 'text', text: block.text });
+                    } else if (block.type === 'tool_use') {
+                        assistantContent.push({
+                            type: 'tool_use',
+                            id: block.id,
+                            name: block.name,
+                            input: block.input as Record<string, unknown>
+                        });
+                    }
+                }
 
+                messages.push({ role: 'assistant', content: assistantContent });
+
+                // Execute tools and add results
+                const toolResults: Anthropic.ToolResultBlockParam[] = [];
+                for (const tool of toolUseBlocks) {
+                    const result = await this.executeTool(tool.name, tool.input, workspaceId);
+                    console.log(`[VoiceSupervisor] Tool ${tool.name} result:`, result.substring(0, 200));
+                    toolResults.push({
+                        type: 'tool_result',
+                        tool_use_id: tool.id,
+                        content: result
+                    });
+                }
+
+                messages.push({ role: 'user', content: toolResults });
+            }
+
+            // Max iterations reached — send whatever we have
+            if (callbacks?.onTextChunk) callbacks.onTextChunk("I've completed the actions you asked for.");
             if (callbacks?.onComplete) {
                 callbacks.onComplete({
-                    text: voiceText,
+                    text: "I've completed the actions you asked for.",
                     action: 'response'
                 });
             }
 
         } catch (error) {
             console.error('[VoiceSupervisor] Streaming error:', error);
-            const errorResponse = {
-                text: "Sorry, I couldn't process that. Can you try again?",
-                action: 'error' as const
-            };
-
             if (callbacks?.onError) {
                 callbacks.onError(error as Error);
             }
             if (callbacks?.onTextChunk) {
-                callbacks.onTextChunk(errorResponse.text);
+                callbacks.onTextChunk("Sorry, I couldn't process that. Can you try again?");
             }
             if (callbacks?.onComplete) {
-                callbacks.onComplete(errorResponse);
+                callbacks.onComplete({
+                    text: "Sorry, I couldn't process that. Can you try again?",
+                    action: 'error'
+                });
             }
         }
+    }
+
+    /**
+     * Execute a tool call against the Claudia backend
+     */
+    private async executeTool(name: string, input: Record<string, unknown>, workspaceId?: string): Promise<string> {
+        try {
+            switch (name) {
+                case 'list_tasks':
+                    return await this.toolListTasks(workspaceId);
+                case 'create_task':
+                    return await this.toolCreateTask(input.prompt as string, workspaceId, input.displayName as string | undefined);
+                case 'get_task_status':
+                    return await this.toolGetTaskStatus(input.taskId as string);
+                case 'get_task_output':
+                    return await this.toolGetTaskOutput(input.taskId as string);
+                case 'stop_task':
+                    return await this.toolStopTask(input.taskId as string);
+                case 'stop_all_tasks':
+                    return await this.toolStopAllTasks(workspaceId);
+                case 'send_input':
+                    return await this.toolSendInput(input.taskId as string, input.input as string);
+                case 'continue_task':
+                    return await this.toolContinueTask(input.taskId as string, input.prompt as string);
+                default:
+                    return JSON.stringify({ error: `Unknown tool: ${name}` });
+            }
+        } catch (error) {
+            return JSON.stringify({ error: error instanceof Error ? error.message : String(error) });
+        }
+    }
+
+    private async toolListTasks(workspaceId?: string): Promise<string> {
+        const response = await fetch(`${BACKEND_URL}/api/tasks`);
+        if (!response.ok) return JSON.stringify({ error: `Failed to list tasks (HTTP ${response.status})` });
+        let tasks = await response.json();
+        if (workspaceId) {
+            tasks = tasks.filter((t: any) => t.workspaceId === workspaceId);
+        }
+        if (!tasks || tasks.length === 0) {
+            return JSON.stringify({ message: 'No active tasks in this workspace.' });
+        }
+        const now = Date.now();
+        const formatted = tasks.map((t: any) => ({
+            id: t.id,
+            state: t.state,
+            prompt: t.displayName || (t.prompt?.substring(0, 100) + (t.prompt?.length > 100 ? '...' : '')),
+            runningFor: (t.state === 'busy' && t.processStartedAt) ? this.formatDuration(now - new Date(t.processStartedAt).getTime()) : null,
+            waitingInputType: t.waitingInputType || null,
+        }));
+        return JSON.stringify(formatted);
+    }
+
+    private async toolCreateTask(prompt: string, workspaceId?: string, displayName?: string): Promise<string> {
+        if (!workspaceId) {
+            return JSON.stringify({ error: 'No workspace ID available. Cannot create task.' });
+        }
+        const result = await this.sendWSMessage('task:create', {
+            prompt,
+            workspaceId,
+            source: 'mcp',
+        });
+        const task = (result as any)?.task;
+        if (task && displayName) {
+            try {
+                await this.sendWSMessage('task:rename', { taskId: task.id, displayName, source: 'agent' });
+            } catch (e) {
+                // rename is best-effort
+            }
+        }
+        if (task) {
+            return JSON.stringify({
+                success: true,
+                taskId: task.id,
+                displayName: displayName || null,
+                state: task.state,
+                message: `Task '${task.id}'${displayName ? ` (${displayName})` : ''} created successfully.`
+            });
+        }
+        return JSON.stringify({ success: true, message: 'Task creation request sent.', result });
+    }
+
+    private async toolGetTaskStatus(taskId: string): Promise<string> {
+        const [tasksResponse, outputResponse] = await Promise.all([
+            fetch(`${BACKEND_URL}/api/tasks`),
+            fetch(`${BACKEND_URL}/api/tasks/${taskId}/output?maxBytes=2048`),
+        ]);
+        if (!tasksResponse.ok) return JSON.stringify({ error: `Failed to fetch tasks (HTTP ${tasksResponse.status})` });
+        const tasks = await tasksResponse.json();
+        const task = tasks.find((t: any) => t.id === taskId);
+        if (!task) return JSON.stringify({ error: `Task '${taskId}' not found.` });
+
+        const now = Date.now();
+        const isRunning = task.state === 'busy' || task.state === 'starting';
+        const startTime = task.processStartedAt || task.createdAt;
+        const runningForMs = isRunning && startTime ? now - new Date(startTime).getTime() : null;
+
+        let outputSnippet: string | null = null;
+        if (outputResponse.ok) {
+            const outputData = await outputResponse.json();
+            if (outputData.output) {
+                outputSnippet = outputData.output.length > 500 ? '...' + outputData.output.slice(-500) : outputData.output;
+            }
+        }
+
+        return JSON.stringify({
+            id: task.id,
+            state: task.state,
+            prompt: task.displayName || (task.prompt?.substring(0, 200)),
+            runningFor: runningForMs ? this.formatDuration(runningForMs) : null,
+            waitingInputType: task.waitingInputType || null,
+            recentOutput: outputSnippet,
+        });
+    }
+
+    private async toolGetTaskOutput(taskId: string): Promise<string> {
+        const response = await fetch(`${BACKEND_URL}/api/tasks/${taskId}/output?maxBytes=8192`);
+        if (!response.ok) {
+            if (response.status === 404) return JSON.stringify({ error: `Task '${taskId}' not found.` });
+            return JSON.stringify({ error: `Failed to get task output (HTTP ${response.status})` });
+        }
+        const data = await response.json();
+        return JSON.stringify({
+            taskId: data.taskId,
+            state: data.state,
+            output: data.output
+        });
+    }
+
+    private async toolStopTask(taskId: string): Promise<string> {
+        const result = await this.sendWSMessage('task:stop', { taskId }) as { taskId: string; stopped: boolean };
+        if (result.stopped) {
+            return JSON.stringify({ success: true, message: `Task '${taskId}' stopped successfully.` });
+        }
+        return JSON.stringify({ success: false, message: `Task '${taskId}' could not be stopped — it may not be running.` });
+    }
+
+    private async toolStopAllTasks(workspaceId?: string): Promise<string> {
+        if (!workspaceId) {
+            return JSON.stringify({ error: 'No workspace ID available.' });
+        }
+        const result = await this.sendWSMessage('task:stopAll', { workspaceId }) as {
+            stoppedCount: number;
+            stoppedIds: string[];
+        };
+        return JSON.stringify({
+            success: true,
+            stoppedCount: result.stoppedCount,
+            stoppedIds: result.stoppedIds,
+            message: result.stoppedCount > 0
+                ? `Stopped ${result.stoppedCount} task(s).`
+                : 'No running tasks found.'
+        });
+    }
+
+    private async toolSendInput(taskId: string, input: string): Promise<string> {
+        await this.sendWSMessage('task:input', { taskId, input: input + '\r' });
+        return JSON.stringify({ success: true, message: `Input sent to task '${taskId}'.` });
+    }
+
+    private async toolContinueTask(taskId: string, prompt: string): Promise<string> {
+        // Verify task exists and is not busy
+        const tasksResponse = await fetch(`${BACKEND_URL}/api/tasks`);
+        if (tasksResponse.ok) {
+            const tasks = await tasksResponse.json();
+            const task = tasks.find((t: any) => t.id === taskId);
+            if (!task) return JSON.stringify({ error: `Task '${taskId}' not found.` });
+            if (task.state === 'busy' || task.state === 'starting') {
+                return JSON.stringify({ error: `Task '${taskId}' is currently ${task.state}. Wait for it to finish first.` });
+            }
+        }
+        await this.sendWSMessage('task:input', { taskId, input: prompt + '\r' });
+        return JSON.stringify({ success: true, message: `Follow-up prompt sent to task '${taskId}'.` });
+    }
+
+    /**
+     * Send a WebSocket message to the backend and wait for a response
+     */
+    private async sendWSMessage(type: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+        const WebSocket = (await import('ws')).default;
+
+        return new Promise((resolve, reject) => {
+            const wsUrl = BACKEND_URL.replace('http://', 'ws://').replace('https://', 'wss://');
+            const ws = new WebSocket(wsUrl);
+            const timeout = setTimeout(() => {
+                ws.close();
+                reject(new Error(`WebSocket operation timed out after 30s for ${type}`));
+            }, 30000);
+
+            ws.on('open', () => {
+                ws.send(JSON.stringify({ type, payload }));
+            });
+
+            ws.on('message', (data: Buffer) => {
+                try {
+                    const msg = JSON.parse(data.toString());
+
+                    if (type === 'task:create' && msg.type === 'task:created' && msg.payload?.source === 'mcp') {
+                        clearTimeout(timeout);
+                        ws.close();
+                        resolve(msg.payload);
+                    }
+                    if (type === 'task:input' && msg.type === 'task:stateChanged') {
+                        clearTimeout(timeout);
+                        ws.close();
+                        resolve(msg.payload);
+                    }
+                    if (type === 'task:stop' && msg.type === 'task:stopped') {
+                        clearTimeout(timeout);
+                        ws.close();
+                        resolve(msg.payload);
+                    }
+                    if (type === 'task:stopAll' && msg.type === 'task:stopAll:result') {
+                        clearTimeout(timeout);
+                        ws.close();
+                        resolve(msg.payload);
+                    }
+                    if (type === 'task:rename' && (msg.type === 'task:stateChanged' || msg.type === 'tasks:updated')) {
+                        clearTimeout(timeout);
+                        ws.close();
+                        resolve(msg.payload);
+                    }
+                    if (msg.type === 'error') {
+                        clearTimeout(timeout);
+                        ws.close();
+                        reject(new Error(msg.payload?.message || 'Unknown WebSocket error'));
+                    }
+                } catch (e) {
+                    // Ignore parse errors
+                }
+            });
+
+            ws.on('error', (err: Error) => {
+                clearTimeout(timeout);
+                reject(new Error(`WebSocket error: ${err.message}`));
+            });
+
+            ws.on('close', () => {
+                clearTimeout(timeout);
+            });
+        });
+    }
+
+    private formatDuration(ms: number): string {
+        const seconds = Math.floor(ms / 1000);
+        if (seconds < 60) return `${seconds}s`;
+        const minutes = Math.floor(seconds / 60);
+        if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+        const hours = Math.floor(minutes / 60);
+        return `${hours}h ${minutes % 60}m`;
     }
 
     /**
@@ -247,40 +650,6 @@ ${taskContext ? `\n## Current Task Status\n${taskContext}\n` : ''}`;
     private trySimpleResponse(transcript: string, workspaceId?: string): VoiceResponse | null {
         const lower = transcript.toLowerCase().trim();
 
-        // Status queries
-        if (lower.match(/what.*running|status|what.*doing|how.*going/)) {
-            let tasks = this.taskSpawner.getAllTasks();
-
-            // Filter by workspace if specified
-            if (workspaceId) {
-                tasks = tasks.filter(t => t.workspaceId === workspaceId);
-            }
-
-            const busyTasks = tasks.filter(t => t.state === 'busy');
-            const idleTasks = tasks.filter(t => t.state === 'idle');
-
-            if (busyTasks.length === 0 && idleTasks.length === 0) {
-                return {
-                    text: "Nothing's running right now.",
-                    action: 'response'
-                };
-            }
-
-            if (busyTasks.length > 0) {
-                return {
-                    text: `You have ${busyTasks.length} task${busyTasks.length > 1 ? 's' : ''} running.`,
-                    action: 'response'
-                };
-            }
-
-            if (idleTasks.length > 0) {
-                return {
-                    text: `${idleTasks.length} task${idleTasks.length > 1 ? 's' : ''} waiting for input.`,
-                    action: 'response'
-                };
-            }
-        }
-
         // Greetings
         if (lower.match(/^(hi|hello|hey|good morning|good afternoon)$/)) {
             return {
@@ -292,7 +661,7 @@ ${taskContext ? `\n## Current Task Status\n${taskContext}\n` : ''}`;
         // Help queries
         if (lower.match(/help|what can you do/)) {
             return {
-                text: "I can create tasks, check status, and help you code. What do you need?",
+                text: "I can create tasks, check status, stop them, and send input. What do you need?",
                 action: 'response'
             };
         }
@@ -339,37 +708,21 @@ ${taskContext ? `\n## Current Task Status\n${taskContext}\n` : ''}`;
      */
     private optimizeForVoice(text: string): string {
         let cleaned = text
-            // Remove markdown headers
             .replace(/^#{1,6}\s+/gm, '')
-            // Remove bold/italic
             .replace(/\*\*(.+?)\*\*/g, '$1')
             .replace(/\*(.+?)\*/g, '$1')
             .replace(/__(.+?)__/g, '$1')
             .replace(/_(.+?)_/g, '$1')
-            // Remove code blocks
             .replace(/```[\s\S]*?```/g, '')
             .replace(/`([^`]+)`/g, '$1')
-            // Remove bullet points
             .replace(/^\s*[-*+]\s+/gm, '')
-            // Remove numbered lists
             .replace(/^\s*\d+\.\s+/gm, '')
-            // Remove links but keep text
             .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-            // Remove extra whitespace
             .replace(/\n{3,}/g, '\n\n')
             .trim();
 
-        // No length limit - let the full response through
         return cleaned;
     }
-
-    /**
-     * Task state monitoring strategy (using dynamic context)
-     *
-     * Previously, the voice agent received notifications for every task state change.
-     * Now, task status is dynamically included in the system prompt context via buildTaskContext(),
-     * reducing notification noise and allowing the agent to see the full task state on each interaction.
-     */
 
     /**
      * Get the current system prompt
@@ -390,29 +743,7 @@ ${taskContext ? `\n## Current Task Status\n${taskContext}\n` : ''}`;
      * Get available tools (from SupervisorChat)
      */
     getAvailableTools(): Array<{ name: string; description: string }> {
-        // These are the tools available through SupervisorChat
-        return [
-            {
-                name: 'create_task',
-                description: 'Create a new coding task. The task will be executed by a Claude Code instance.'
-            },
-            {
-                name: 'delete_task',
-                description: 'Delete/remove a task by its ID'
-            },
-            {
-                name: 'get_task_conversation',
-                description: 'Read the conversation history of a specific task'
-            },
-            {
-                name: 'send_message_to_task',
-                description: 'Send a message/input to a running task'
-            },
-            {
-                name: 'list_tasks',
-                description: 'List all current tasks with their status'
-            }
-        ];
+        return VOICE_TOOLS.map(t => ({ name: t.name, description: t.description || '' }));
     }
 }
 

--- a/backend/src/workspace-store.ts
+++ b/backend/src/workspace-store.ts
@@ -227,6 +227,21 @@ export class WorkspaceStore {
         return true;
     }
 
+    getPreviewPort(workspaceId: string): number | undefined {
+        const workspace = this.config.workspaces.find(w => w.id === workspaceId);
+        return workspace?.previewPort;
+    }
+
+    setPreviewPort(workspaceId: string, port: number | undefined): boolean {
+        const workspace = this.config.workspaces.find(w => w.id === workspaceId);
+        if (!workspace) return false;
+
+        workspace.previewPort = port;
+        this.saveConfig();
+        console.log(`[WorkspaceStore] Updated preview port for ${workspaceId} to ${port}`);
+        return true;
+    }
+
     // Get recent workspaces (ones that were removed but still exist on disk)
     // Filters out any that are currently in the active workspaces list
     getRecentWorkspaces(): RecentWorkspace[] {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { ActivityPanel } from './components/ActivityPanel';
 import { useTheme } from './hooks/useTheme';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTaskStore } from './stores/taskStore';
-import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, AudioLines } from 'lucide-react';
+import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Bell, BellOff, AudioLines } from 'lucide-react';
 import { getApiBaseUrl } from './config/api-config';
 import { isSoundEnabled, setSoundEnabled } from './utils/browserCapabilities';
 
@@ -785,7 +785,7 @@ function App() {
             </main>
 
             <ProjectPicker onSelect={handleProjectSelect} wsRef={wsRef} requestRecentWorkspaces={requestRecentWorkspaces} clearRecentWorkspace={clearRecentWorkspace} />
-            <SettingsMenu isOpen={showSettings} onClose={handleSettingsClose} initialPanel={settingsInitialPanel} />
+            <SettingsMenu isOpen={showSettings} onClose={handleSettingsClose} initialPanel={settingsInitialPanel} wsRef={wsRef} />
             {!isMobile && <MobileAccessModal isOpen={showMobileAccess} onClose={() => setShowMobileAccess(false)} error={tunnelError} tunnelActive={tunnelActive} tunnelLoading={tunnelLoading} onStopTunnel={handleStopTunnel} onStartTunnel={startTunnel} />}
             {previewState && (
                 <PreviewPanel

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,11 +13,12 @@ import { SystemStats } from './components/SystemStats';
 import { MobileAccessModal } from './components/MobileAccessModal';
 import { FileExplorer } from './components/FileExplorer';
 import { ShellTerminalView } from './components/ShellTerminalView';
+import { PreviewPanel } from './components/PreviewPanel';
 import { ActivityPanel } from './components/ActivityPanel';
 import { useTheme } from './hooks/useTheme';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTaskStore } from './stores/taskStore';
-import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff } from 'lucide-react';
+import { Terminal, Settings, MessageCircle, X, RefreshCw, RotateCcw, WifiOff, Activity, AlertTriangle, Smartphone, ArrowLeft, Minimize2, Mic, Bell, BellOff, AudioLines } from 'lucide-react';
 import { getApiBaseUrl } from './config/api-config';
 import { isSoundEnabled, setSoundEnabled } from './utils/browserCapabilities';
 
@@ -53,6 +54,7 @@ function App() {
         openFolder,
         openTerminal,
         setSystemPrompt,
+        setPreviewPort,
         sendChatMessage,
         clearChatHistory,
         requestArchivedTasks,
@@ -92,6 +94,9 @@ function App() {
     const [activeShellWorkspaceId, setActiveShellWorkspaceId] = useState<string | null>(null);
     const [showingShell, setShowingShell] = useState(false);
     const activeShellWorkspace = activeShellWorkspaceId ? workspaces.find(w => w.id === activeShellWorkspaceId) : undefined;
+
+    // Preview panel state
+    const [previewState, setPreviewState] = useState<{ workspaceId: string; name: string; port: number } | null>(null);
 
     // Count tasks that have running processes (not disconnected or archived)
     const activeTasks = Array.from(tasks.values()).filter(t =>
@@ -277,6 +282,38 @@ function App() {
         setActiveShellWorkspaceId(null);
         setShowingShell(false);
     }, []);
+
+    const handleOpenPreview = useCallback((workspaceId: string) => {
+        const ws = workspaces.find(w => w.id === workspaceId);
+        if (!ws) return;
+        const name = ws.displayName || ws.name;
+        if (ws.previewPort) {
+            setPreviewState({ workspaceId, name, port: ws.previewPort });
+        } else {
+            const input = window.prompt(`Enter the dev server port for "${name}":`);
+            if (!input) return;
+            const port = parseInt(input, 10);
+            if (isNaN(port) || port < 1 || port > 65535) {
+                window.alert('Invalid port number');
+                return;
+            }
+            setPreviewPort(workspaceId, port);
+            setPreviewState({ workspaceId, name, port });
+        }
+    }, [workspaces, setPreviewPort]);
+
+    const handleChangePreviewPort = useCallback(() => {
+        if (!previewState) return;
+        const input = window.prompt('Enter new port:', String(previewState.port));
+        if (!input) return;
+        const port = parseInt(input, 10);
+        if (isNaN(port) || port < 1 || port > 65535) {
+            window.alert('Invalid port number');
+            return;
+        }
+        setPreviewPort(previewState.workspaceId, port);
+        setPreviewState({ ...previewState, port });
+    }, [previewState, setPreviewPort]);
 
     const handleShowShell = useCallback(() => {
         setShowingShell(true);
@@ -530,16 +567,14 @@ function App() {
                             {tunnelActive && <span className="tunnel-active-dot" />}
                         </button>
                     )}
-                    {!isMobile && (
-                        <button
-                            className="chat-toggle-button voice-agent-button"
-                            onClick={handleOpenVoiceAgent}
-                            title="Open Voice Agent"
-                        >
-                            <Mic size={18} />
-                            <span className="btn-label">Voice Agent</span>
-                        </button>
-                    )}
+                    <button
+                        className="chat-toggle-button voice-agent-button"
+                        onClick={handleOpenVoiceAgent}
+                        title="Open Voice Agent"
+                    >
+                        <AudioLines size={18} />
+                        <span className="btn-label">Voice Agent</span>
+                    </button>
                     <GlobalVoiceToggle />
                     <button
                         className={`notification-toggle-button ${soundMuted ? 'muted' : ''}`}
@@ -604,6 +639,7 @@ function App() {
                                 onOpenFolder={openFolder}
                                 onOpenTerminal={openTerminal}
                                 onOpenShell={handleOpenShell}
+                                onOpenPreview={handleOpenPreview}
                                 onPushToGithub={pushToGithub}
                                 onSetSystemPrompt={setSystemPrompt}
                                 onCreateTask={createTask}
@@ -641,6 +677,7 @@ function App() {
                                 onOpenFolder={openFolder}
                                 onOpenTerminal={openTerminal}
                                 onOpenShell={handleOpenShell}
+                                onOpenPreview={handleOpenPreview}
                                 onPushToGithub={pushToGithub}
                                 onSetSystemPrompt={setSystemPrompt}
                                 onCreateTask={createTask}
@@ -750,6 +787,14 @@ function App() {
             <ProjectPicker onSelect={handleProjectSelect} wsRef={wsRef} requestRecentWorkspaces={requestRecentWorkspaces} clearRecentWorkspace={clearRecentWorkspace} />
             <SettingsMenu isOpen={showSettings} onClose={handleSettingsClose} initialPanel={settingsInitialPanel} />
             {!isMobile && <MobileAccessModal isOpen={showMobileAccess} onClose={() => setShowMobileAccess(false)} error={tunnelError} tunnelActive={tunnelActive} tunnelLoading={tunnelLoading} onStopTunnel={handleStopTunnel} onStartTunnel={startTunnel} />}
+            {previewState && (
+                <PreviewPanel
+                    workspaceName={previewState.name}
+                    port={previewState.port}
+                    onClose={() => setPreviewState(null)}
+                    onChangePort={handleChangePreviewPort}
+                />
+            )}
             <GlobalVoiceManager />
             <ThinkingSoundManager />
             <TaskCompletionVoiceManager />

--- a/frontend/src/components/CheckpointTimeline.css
+++ b/frontend/src/components/CheckpointTimeline.css
@@ -1,0 +1,323 @@
+.cp-timeline {
+    border: 1px solid var(--border-color, #2a2a2a);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--bg-tertiary, #141414);
+}
+
+.cp-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 13px;
+}
+
+.cp-header:hover {
+    background: var(--bg-hover, #1a1a1a);
+}
+
+.cp-toggle {
+    display: flex;
+    align-items: center;
+    color: var(--text-secondary, #888);
+}
+
+.cp-title {
+    font-weight: 600;
+    color: var(--text-primary, #eee);
+}
+
+.cp-count {
+    font-size: 11px;
+    background: var(--bg-primary, #0d0d0d);
+    color: var(--text-secondary, #888);
+    padding: 1px 6px;
+    border-radius: 10px;
+    font-family: 'SF Mono', monospace;
+}
+
+.cp-create-btn {
+    margin-left: auto;
+    background: none;
+    border: 1px solid var(--border-color, #333);
+    border-radius: 4px;
+    padding: 3px 5px;
+    cursor: pointer;
+    color: var(--text-secondary, #888);
+    display: flex;
+    align-items: center;
+}
+
+.cp-create-btn:hover {
+    color: var(--accent-color, #4a9eff);
+    border-color: var(--accent-color, #4a9eff);
+}
+
+.cp-body {
+    border-top: 1px solid var(--border-color, #2a2a2a);
+    padding: 8px 10px;
+}
+
+.cp-create-form {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.cp-create-form input {
+    flex: 1;
+    background: var(--bg-primary, #0d0d0d);
+    border: 1px solid var(--border-color, #333);
+    border-radius: 4px;
+    padding: 5px 8px;
+    color: var(--text-primary, #eee);
+    font-size: 12px;
+    outline: none;
+}
+
+.cp-create-form input:focus {
+    border-color: var(--accent-color, #4a9eff);
+}
+
+.cp-save-btn {
+    background: var(--accent-color, #4a9eff);
+    border: none;
+    border-radius: 4px;
+    padding: 5px 10px;
+    color: #fff;
+    font-size: 12px;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.cp-save-btn:hover {
+    opacity: 0.9;
+}
+
+.cp-empty {
+    color: var(--text-secondary, #666);
+    font-size: 12px;
+    text-align: center;
+    padding: 12px 0;
+}
+
+.cp-list {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding-left: 12px;
+}
+
+.cp-list::before {
+    content: '';
+    position: absolute;
+    left: 5px;
+    top: 8px;
+    bottom: 8px;
+    width: 1px;
+    background: var(--border-color, #333);
+}
+
+.cp-node {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 6px 0;
+    position: relative;
+}
+
+.cp-node-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--border-color, #555);
+    flex-shrink: 0;
+    margin-top: 4px;
+    position: relative;
+    z-index: 1;
+    margin-left: -9px;
+}
+
+.cp-node-latest .cp-node-dot {
+    background: var(--accent-color, #4a9eff);
+    box-shadow: 0 0 6px rgba(74, 158, 255, 0.4);
+}
+
+.cp-node-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.cp-node-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary, #eee);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cp-node-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+}
+
+.cp-node-meta svg {
+    flex-shrink: 0;
+}
+
+.cp-node-sha {
+    font-family: 'SF Mono', monospace;
+    font-size: 10px;
+    background: var(--bg-primary, #0d0d0d);
+    padding: 0 4px;
+    border-radius: 3px;
+}
+
+.cp-node-desc {
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cp-node-actions {
+    display: flex;
+    gap: 2px;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.cp-node:hover .cp-node-actions {
+    opacity: 1;
+}
+
+.cp-node-actions button {
+    background: none;
+    border: none;
+    color: var(--text-secondary, #888);
+    cursor: pointer;
+    padding: 3px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+}
+
+.cp-node-actions button:hover {
+    color: var(--text-primary, #fff);
+    background: var(--bg-hover, #222);
+}
+
+.cp-delete-btn:hover {
+    color: #e55 !important;
+}
+
+/* Conflict Resolution Dialog */
+.cp-conflict-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.cp-conflict-dialog {
+    background: var(--bg-secondary, #1a1a1a);
+    border: 1px solid var(--border-color, #333);
+    border-radius: 10px;
+    padding: 16px 20px;
+    width: min(400px, 90vw);
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.cp-conflict-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #f0a030;
+    margin-bottom: 8px;
+}
+
+.cp-conflict-desc {
+    font-size: 12px;
+    color: var(--text-secondary, #aaa);
+    margin: 0 0 12px;
+    line-height: 1.4;
+}
+
+.cp-conflict-files {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 14px;
+}
+
+.cp-conflict-file {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-primary, #eee);
+    font-family: 'SF Mono', monospace;
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+
+.cp-conflict-file:hover {
+    background: var(--bg-hover, #222);
+}
+
+.cp-conflict-file input[type="checkbox"] {
+    accent-color: var(--accent-color, #4a9eff);
+}
+
+.cp-conflict-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.cp-conflict-skip {
+    background: none;
+    border: 1px solid var(--border-color, #444);
+    border-radius: 6px;
+    padding: 6px 14px;
+    color: var(--text-secondary, #aaa);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.cp-conflict-skip:hover {
+    border-color: var(--text-secondary, #888);
+    color: var(--text-primary, #eee);
+}
+
+.cp-conflict-force {
+    background: #c04020;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 14px;
+    color: #fff;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.cp-conflict-force:hover {
+    background: #d04828;
+}

--- a/frontend/src/components/CheckpointTimeline.tsx
+++ b/frontend/src/components/CheckpointTimeline.tsx
@@ -1,0 +1,256 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GitBranch, Clock, RotateCcw, GitFork, Trash2, Plus, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
+import { Checkpoint } from '@claudia/shared';
+import './CheckpointTimeline.css';
+
+interface CheckpointTimelineProps {
+    taskId: string;
+    workspaceId: string;
+    wsRef: React.RefObject<WebSocket | null>;
+}
+
+interface ConflictState {
+    checkpointId: string;
+    checkpointName: string;
+    restoredFiles: string[];
+    conflictingFiles: string[];
+    selectedFiles: Set<string>;
+}
+
+export function CheckpointTimeline({ taskId, workspaceId, wsRef }: CheckpointTimelineProps) {
+    const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
+    const [expanded, setExpanded] = useState(false);
+    const [creating, setCreating] = useState(false);
+    const [newName, setNewName] = useState('');
+    const [conflict, setConflict] = useState<ConflictState | null>(null);
+    const [restoring, setRestoring] = useState(false);
+
+    const sendWS = useCallback((type: string, payload: Record<string, unknown>) => {
+        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+        wsRef.current.send(JSON.stringify({ type, payload }));
+    }, [wsRef]);
+
+    const fetchCheckpoints = useCallback(() => {
+        sendWS('checkpoint:list', { taskId });
+    }, [sendWS, taskId]);
+
+    useEffect(() => {
+        fetchCheckpoints();
+    }, [fetchCheckpoints]);
+
+    useEffect(() => {
+        const ws = wsRef.current;
+        if (!ws) return;
+
+        const handler = (event: MessageEvent) => {
+            try {
+                const msg = JSON.parse(event.data);
+                switch (msg.type) {
+                    case 'checkpoint:list':
+                        setCheckpoints(msg.payload.checkpoints || []);
+                        break;
+                    case 'checkpoint:created':
+                        if (msg.payload.taskId === taskId) {
+                            setCheckpoints(prev => [msg.payload, ...prev]);
+                        }
+                        setCreating(false);
+                        setNewName('');
+                        break;
+                    case 'checkpoint:deleted':
+                        setCheckpoints(prev => prev.filter(c => c.id !== msg.payload.checkpointId));
+                        break;
+                    case 'checkpoint:restored':
+                    case 'checkpoint:forked':
+                        fetchCheckpoints();
+                        break;
+                    case 'checkpoint:restore-selective-result': {
+                        setRestoring(false);
+                        const { success, restoredFiles, conflictingFiles, checkpointId, error } = msg.payload;
+                        if (!success) {
+                            alert(`Restore failed: ${error}`);
+                            break;
+                        }
+                        if (conflictingFiles && conflictingFiles.length > 0) {
+                            const cp = checkpoints.find(c => c.id === checkpointId);
+                            setConflict({
+                                checkpointId,
+                                checkpointName: cp?.name || 'checkpoint',
+                                restoredFiles: restoredFiles || [],
+                                conflictingFiles,
+                                selectedFiles: new Set(conflictingFiles),
+                            });
+                        } else if (restoredFiles && restoredFiles.length > 0) {
+                            fetchCheckpoints();
+                        }
+                        break;
+                    }
+                    case 'checkpoint:restore-force-result': {
+                        setConflict(null);
+                        if (!msg.payload.success) {
+                            alert(`Force restore failed: ${msg.payload.error}`);
+                        }
+                        fetchCheckpoints();
+                        break;
+                    }
+                }
+            } catch { /* ignore */ }
+        };
+
+        ws.addEventListener('message', handler);
+        return () => ws.removeEventListener('message', handler);
+    }, [wsRef, fetchCheckpoints, taskId, checkpoints]);
+
+    const handleCreate = () => {
+        sendWS('checkpoint:create', { taskId, workspaceId, name: newName || undefined });
+    };
+
+    const handleRestore = (checkpointId: string, name: string) => {
+        if (!confirm(`Restore "${name}"? Only files changed by this task will be reverted.`)) return;
+        setRestoring(true);
+        sendWS('checkpoint:restore-selective', { checkpointId });
+    };
+
+    const handleForceRestore = () => {
+        if (!conflict) return;
+        const files = Array.from(conflict.selectedFiles);
+        if (files.length === 0) {
+            setConflict(null);
+            return;
+        }
+        sendWS('checkpoint:restore-force', { checkpointId: conflict.checkpointId, files });
+    };
+
+    const toggleConflictFile = (file: string) => {
+        if (!conflict) return;
+        const next = new Set(conflict.selectedFiles);
+        if (next.has(file)) next.delete(file);
+        else next.add(file);
+        setConflict({ ...conflict, selectedFiles: next });
+    };
+
+    const handleFork = (checkpointId: string) => {
+        const branch = prompt('Branch name (leave empty for auto-generated):');
+        if (branch === null) return;
+        sendWS('checkpoint:fork', { checkpointId, branchName: branch || undefined });
+    };
+
+    const handleDelete = (checkpointId: string, name: string) => {
+        if (!confirm(`Delete checkpoint "${name}"?`)) return;
+        sendWS('checkpoint:delete', { checkpointId });
+    };
+
+    const formatTime = (timestamp: string) => {
+        const d = new Date(timestamp);
+        const now = Date.now();
+        const diff = now - d.getTime();
+        if (diff < 60000) return 'just now';
+        if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+        if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+        return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+    };
+
+    return (
+        <div className="cp-timeline">
+            <div className="cp-header" onClick={() => setExpanded(!expanded)}>
+                <span className="cp-toggle">
+                    {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                </span>
+                <GitBranch size={14} />
+                <span className="cp-title">Checkpoints</span>
+                <span className="cp-count">{checkpoints.length}</span>
+                <button
+                    className="cp-create-btn"
+                    onClick={(e) => { e.stopPropagation(); setCreating(!creating); }}
+                    title="Create checkpoint"
+                >
+                    <Plus size={14} />
+                </button>
+            </div>
+
+            {expanded && (
+                <div className="cp-body">
+                    {creating && (
+                        <div className="cp-create-form">
+                            <input
+                                type="text"
+                                placeholder="Checkpoint name (optional)"
+                                value={newName}
+                                onChange={e => setNewName(e.target.value)}
+                                onKeyDown={e => { if (e.key === 'Enter') handleCreate(); if (e.key === 'Escape') setCreating(false); }}
+                                autoFocus
+                            />
+                            <button className="cp-save-btn" onClick={handleCreate}>Save</button>
+                        </div>
+                    )}
+
+                    {checkpoints.length === 0 && !creating && (
+                        <div className="cp-empty">No checkpoints yet. Create one to save your progress.</div>
+                    )}
+
+                    <div className="cp-list">
+                        {checkpoints.map((cp, idx) => (
+                            <div key={cp.id} className={`cp-node ${idx === 0 ? 'cp-node-latest' : ''}`}>
+                                <div className="cp-node-dot" />
+                                <div className="cp-node-content">
+                                    <div className="cp-node-name">{cp.name}</div>
+                                    <div className="cp-node-meta">
+                                        <Clock size={10} />
+                                        <span>{formatTime(cp.timestamp)}</span>
+                                        {cp.gitBranch && (
+                                            <>
+                                                <GitBranch size={10} />
+                                                <span>{cp.gitBranch}</span>
+                                            </>
+                                        )}
+                                        {cp.gitRef && <span className="cp-node-sha">{cp.gitRef.slice(0, 7)}</span>}
+                                    </div>
+                                    {cp.description && <div className="cp-node-desc">{cp.description}</div>}
+                                </div>
+                                <div className="cp-node-actions">
+                                    <button onClick={() => handleRestore(cp.id, cp.name)} title="Restore" disabled={restoring}><RotateCcw size={12} /></button>
+                                    <button onClick={() => handleFork(cp.id)} title="Fork branch"><GitFork size={12} /></button>
+                                    <button onClick={() => handleDelete(cp.id, cp.name)} title="Delete" className="cp-delete-btn"><Trash2 size={12} /></button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {conflict && (
+                <div className="cp-conflict-overlay" onClick={() => setConflict(null)}>
+                    <div className="cp-conflict-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="cp-conflict-header">
+                            <AlertTriangle size={16} />
+                            <span>Conflicting Files</span>
+                        </div>
+                        <p className="cp-conflict-desc">
+                            {conflict.restoredFiles.length > 0 && (
+                                <span>{conflict.restoredFiles.length} file(s) restored successfully. </span>
+                            )}
+                            The following files were modified by another task. Select which to force-restore:
+                        </p>
+                        <div className="cp-conflict-files">
+                            {conflict.conflictingFiles.map(file => (
+                                <label key={file} className="cp-conflict-file">
+                                    <input
+                                        type="checkbox"
+                                        checked={conflict.selectedFiles.has(file)}
+                                        onChange={() => toggleConflictFile(file)}
+                                    />
+                                    <span>{file}</span>
+                                </label>
+                            ))}
+                        </div>
+                        <div className="cp-conflict-actions">
+                            <button className="cp-conflict-skip" onClick={() => setConflict(null)}>Skip All</button>
+                            <button className="cp-conflict-force" onClick={handleForceRestore}>
+                                Force Restore ({conflict.selectedFiles.size})
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/PreviewPanel.css
+++ b/frontend/src/components/PreviewPanel.css
@@ -1,0 +1,87 @@
+.preview-panel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 2000;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-primary, #1a1a2e);
+}
+
+.preview-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: var(--bg-secondary, #16213e);
+    border-bottom: 1px solid var(--border-color, #333);
+    min-height: 44px;
+    flex-shrink: 0;
+}
+
+.preview-panel-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary, #eee);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 12px;
+}
+
+.preview-panel-port {
+    font-size: 12px;
+    color: var(--text-secondary, #aaa);
+    margin-left: 8px;
+}
+
+.preview-panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.preview-panel-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-primary, #eee);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.preview-panel-close:hover {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.1));
+}
+
+.preview-panel-change-port {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary, #aaa);
+    cursor: pointer;
+    font-size: 12px;
+    transition: background 0.15s, color 0.15s;
+}
+
+.preview-panel-change-port:hover {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.1));
+    color: var(--text-primary, #eee);
+}
+
+.preview-panel-iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+}

--- a/frontend/src/components/PreviewPanel.tsx
+++ b/frontend/src/components/PreviewPanel.tsx
@@ -1,0 +1,62 @@
+import { X, RotateCcw, Settings } from 'lucide-react';
+import { getApiBaseUrl, isTunnelAccess } from '../config/api-config';
+import './PreviewPanel.css';
+
+interface PreviewPanelProps {
+    workspaceName: string;
+    port: number;
+    onClose: () => void;
+    onChangePort: () => void;
+}
+
+export function PreviewPanel({ workspaceName, port, onClose, onChangePort }: PreviewPanelProps) {
+    const iframeSrc = isTunnelAccess()
+        ? `${getApiBaseUrl()}/api/preview/${port}/`
+        : `http://localhost:${port}/`;
+
+    const handleRefresh = () => {
+        const iframe = document.querySelector('.preview-panel-iframe') as HTMLIFrameElement;
+        if (iframe) {
+            iframe.src = iframeSrc;
+        }
+    };
+
+    return (
+        <div className="preview-panel-overlay">
+            <div className="preview-panel-header">
+                <div className="preview-panel-title">
+                    {workspaceName}
+                    <span className="preview-panel-port">:{port}</span>
+                </div>
+                <div className="preview-panel-actions">
+                    <button
+                        className="preview-panel-change-port"
+                        onClick={onChangePort}
+                        title="Change port"
+                    >
+                        <Settings size={14} />
+                    </button>
+                    <button
+                        className="preview-panel-close"
+                        onClick={handleRefresh}
+                        title="Refresh"
+                    >
+                        <RotateCcw size={18} />
+                    </button>
+                    <button
+                        className="preview-panel-close"
+                        onClick={onClose}
+                        title="Close preview"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+            </div>
+            <iframe
+                className="preview-panel-iframe"
+                src={iframeSrc}
+                title={`Preview: ${workspaceName}`}
+            />
+        </div>
+    );
+}

--- a/frontend/src/components/ProjectPicker.tsx
+++ b/frontend/src/components/ProjectPicker.tsx
@@ -185,7 +185,7 @@ export function ProjectPicker({ onSelect, wsRef, requestRecentWorkspaces, clearR
                     onRemoveRecent={handleRemoveRecent}
                     onBrowse={handleBrowse}
                     isBrowsing={isBrowsing}
-                    showBrowseButton={false}
+                    showBrowseButton={true}
                     defaultBaseDirectory={defaultBaseDirectory}
                 />
             )}

--- a/frontend/src/components/SettingsMenu.tsx
+++ b/frontend/src/components/SettingsMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { X, Settings, Volume2, Server, ChevronDown, ChevronRight, Plus, Trash2, Shield, FileText, Bot, MousePointer, CheckCircle, AlertCircle, Loader2, Key, Code, Eye, Terminal, Brain, Zap, Bell, Palette } from 'lucide-react';
+import { X, Settings, Volume2, Server, ChevronDown, ChevronRight, Plus, Trash2, Shield, FileText, Bot, MousePointer, CheckCircle, AlertCircle, Loader2, Key, Code, Eye, Terminal, Brain, Zap, Bell, Palette, DollarSign } from 'lucide-react';
 import { VoiceSettingsContent } from './VoiceSettingsContent';
+import { UsageDashboard } from './UsageDashboard';
 import { getApiBaseUrl } from '../config/api-config';
 import { hasBrowserNotifications, getNotificationPermission, requestNotificationPermission, sendBrowserNotification } from '../utils/browserCapabilities';
 import { useTaskStore } from '../stores/taskStore';
@@ -11,6 +12,7 @@ interface SettingsMenuProps {
     isOpen: boolean;
     onClose: () => void;
     initialPanel?: string;
+    wsRef: React.RefObject<WebSocket | null>;
 }
 
 interface MCPServerListItem {
@@ -74,7 +76,7 @@ function CollapsiblePanel({ title, icon, isExpanded, onToggle, children }: Colla
     );
 }
 
-export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProps) {
+export function SettingsMenu({ isOpen, onClose, initialPanel, wsRef }: SettingsMenuProps) {
     const { showSystemStats, setShowSystemStats, browserNotificationsEnabled, setBrowserNotificationsEnabled, notifyOnCompletion, setNotifyOnCompletion, notifyOnWaitingInput, setNotifyOnWaitingInput, themePreference, setThemePreference } = useTaskStore();
     const { showWarning } = useNotification();
     const [expandedPanels, setExpandedPanels] = useState<Record<string, boolean>>({
@@ -91,7 +93,8 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
         rules: false,
         supervisor: false,
         learnings: false,
-        claudiaMcp: false
+        claudiaMcp: false,
+        usage: false
     });
 
     const [notificationTestStatus, setNotificationTestStatus] = useState<'idle' | 'sent' | 'failed'>('idle');
@@ -1259,6 +1262,17 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                 </div>
 
                 <div className="settings-menu-content">
+                    <CollapsiblePanel
+                        title="Usage & Cost"
+                        icon={<DollarSign size={16} />}
+                        isExpanded={expandedPanels.usage}
+                        onToggle={() => togglePanel('usage')}
+                    >
+                        <div style={{ padding: '8px 0' }}>
+                            <UsageDashboard wsRef={wsRef} />
+                        </div>
+                    </CollapsiblePanel>
+
                     <CollapsiblePanel
                         title="Appearance"
                         icon={<Palette size={16} />}

--- a/frontend/src/components/ShellTerminalView.tsx
+++ b/frontend/src/components/ShellTerminalView.tsx
@@ -177,19 +177,23 @@ export function ShellTerminalView({ workspaceId, workspaceName, wsRef, onClose, 
 
         // ResizeObserver
         let resizeTimeout: number;
+        const fitAndRefresh = () => {
+            if (!fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
+            if (terminalRef.current.clientWidth === 0 || terminalRef.current.clientHeight === 0) return;
+            try {
+                fitAddonRef.current.fit();
+                xtermRef.current.refresh(0, xtermRef.current.rows - 1);
+            } catch {}
+        };
         const resizeObserver = new ResizeObserver(() => {
             if (resizeTimeout) window.clearTimeout(resizeTimeout);
-            resizeTimeout = window.setTimeout(() => {
-                try { fitAddonRef.current?.fit(); } catch {}
-            }, 50);
+            resizeTimeout = window.setTimeout(fitAndRefresh, 50);
         });
         resizeObserver.observe(terminalRef.current);
 
         const handleWindowResize = () => {
             if (resizeTimeout) window.clearTimeout(resizeTimeout);
-            resizeTimeout = window.setTimeout(() => {
-                fitAddonRef.current?.fit();
-            }, 50);
+            resizeTimeout = window.setTimeout(fitAndRefresh, 50);
         };
         window.addEventListener('resize', handleWindowResize);
 
@@ -242,6 +246,9 @@ export function ShellTerminalView({ workspaceId, workspaceName, wsRef, onClose, 
             const timer = setTimeout(() => {
                 try {
                     fitAddonRef.current?.fit();
+                    if (xtermRef.current) {
+                        xtermRef.current.refresh(0, xtermRef.current.rows - 1);
+                    }
                     xtermRef.current?.scrollToBottom();
                 } catch {}
             }, 50);

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -3,8 +3,11 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Task, Workspace } from '@claudia/shared';
-import { Copy, Check, Play, BookOpen, ArrowDown } from 'lucide-react';
+import { Copy, Check, Play, BookOpen, ArrowDown, Layers } from 'lucide-react';
 import { TaskInputBar } from './TaskInputBar';
+import { ToolWidgets } from './ToolWidgets';
+import { CheckpointTimeline } from './CheckpointTimeline';
+import { parseToolCalls, ParsedSegment } from '../utils/parseToolCalls';
 import { useEffectiveTheme } from '../hooks/useTheme';
 import { DARK_TERMINAL_THEME, LIGHT_TERMINAL_THEME } from '../types/theme';
 import '@xterm/xterm/css/xterm.css';
@@ -55,6 +58,9 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
     const [isLoadingHistory, setIsLoadingHistory] = useState(true);
     const [showSpinner, setShowSpinner] = useState(false);
     const historyLoadedRef = useRef(false);
+    const [viewMode, setViewMode] = useState<'raw' | 'rich'>('raw');
+    const [richSegments, setRichSegments] = useState<ParsedSegment[]>([]);
+    const rawBufferRef = useRef('');
 
     // Show spinner after a short delay to avoid flash for fast loads
     useEffect(() => {
@@ -243,10 +249,18 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
 
         // Handle input BEFORE open
         term.onData((data) => {
+            // Filter out terminal device attribute responses (DA1/DA2/DA3) that xterm.js
+            // auto-generates. If sent to the PTY, Claude Code echoes them as visible garbage.
+            // DA1: \x1b[?1;2c  DA2: \x1b[>...c  DA3: \x1b[=...c
+            const filtered = data
+                .replace(/\x1b\[\?[\d;]*c/g, '')
+                .replace(/\x1b\[>[\d;]*c/g, '')
+                .replace(/\x1b\[=[\d;]*c/g, '');
+            if (!filtered) return;
             if (wsRef.current?.readyState === WebSocket.OPEN) {
                 wsRef.current.send(JSON.stringify({
                     type: 'task:input',
-                    payload: { taskId: task.id, input: data }
+                    payload: { taskId: task.id, input: filtered }
                 }));
             }
         });
@@ -389,13 +403,7 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
             // Debounce resize
             if (resizeTimeout) window.clearTimeout(resizeTimeout);
             resizeTimeout = window.setTimeout(() => {
-                if (fitAddonRef.current) {
-                    try {
-                        fitAddonRef.current.fit();
-                    } catch (e) {
-                        console.warn('[TerminalView] Resize fit failed:', e);
-                    }
-                }
+                fitTerminal();
             }, 50);
         });
 
@@ -405,12 +413,32 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
         const handleWindowResize = () => {
             if (resizeTimeout) window.clearTimeout(resizeTimeout);
             resizeTimeout = window.setTimeout(() => {
-                fitAddonRef.current?.fit();
+                fitTerminal();
             }, 50);
         };
         window.addEventListener('resize', handleWindowResize);
 
+        // Refit when tab becomes visible (xterm can accumulate render artifacts while hidden)
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                setTimeout(fitTerminal, 100);
+            }
+        };
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+
         // Message handler
+        let refreshTimer: number | undefined;
+        const scheduleRefresh = () => {
+            // Debounced refresh: after output stops for 150ms, force a full re-render
+            // to fix any rendering artifacts from rapid cursor-positioned TUI output.
+            if (refreshTimer) window.clearTimeout(refreshTimer);
+            refreshTimer = window.setTimeout(() => {
+                if (xtermRef.current) {
+                    xtermRef.current.refresh(0, xtermRef.current.rows - 1);
+                }
+            }, 150);
+        };
+
         const handleMessage = (event: MessageEvent) => {
             try {
                 const message = JSON.parse(event.data);
@@ -422,14 +450,16 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
 
                     // Update userHasScrolledRef based on current position
                     if (!wasAtBottom && !userHasScrolledRef.current) {
-                        console.log(`[TerminalView] User has scrolled up, disabling auto-scroll for ${task.id}`);
                         userHasScrolledRef.current = true;
                     }
 
-                    console.log(`[TerminalView] Writing output, wasAtBottom: ${wasAtBottom}, userHasScrolled: ${userHasScrolledRef.current}, viewport: ${viewport}`);
-
                     term.write(message.payload.data);
 
+                    // Accumulate raw output for rich view
+                    rawBufferRef.current += message.payload.data;
+                    if (viewMode === 'rich') {
+                        setRichSegments(parseToolCalls(rawBufferRef.current));
+                    }
                     // Only auto-scroll if user was at bottom
                     if (wasAtBottom) {
                         programmaticScrollRef.current = true;
@@ -441,39 +471,40 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
                                 programmaticScrollRef.current = false;
                             }, 100);
                         });
-                    } else {
-                        // User was scrolled up - maintain their position
-                        programmaticScrollRef.current = true;
-                        term.scrollToLine(viewport);
-                        setTimeout(() => {
-                            programmaticScrollRef.current = false;
-                        }, 100);
                     }
+                    // When user has scrolled up, don't manipulate scroll position at all —
+                    // xterm.js preserves viewport position naturally when new content
+                    // is appended below the visible area.
+
+                    // Schedule a debounced refresh to fix rendering artifacts
+                    scheduleRefresh();
 
                     // Clear loading state on first output (task is live)
                     if (!historyLoadedRef.current) {
-                        console.log(`[TerminalView] First output received, clearing loading state for ${task.id}`);
                         historyLoadedRef.current = true;
                         setIsLoadingHistory(false);
                     }
                 } else if (message.type === 'task:restore' && message.payload.taskId === task.id) {
                     const { history } = message.payload;
-                    console.log(`[TerminalView] task:restore received for ${task.id}, history size: ${history?.length || 0}, alreadyLoaded: ${historyLoadedRef.current}`);
                     if (history && history.length > 0) {
                         term.reset();
                         const cleaned = stripScreenClears(history);
+                        rawBufferRef.current = cleaned;
+                        if (viewMode === 'rich') {
+                            setRichSegments(parseToolCalls(cleaned));
+                        }
                         programmaticScrollRef.current = true;
                         term.write(cleaned, () => {
                             term.scrollToBottom();
+                            // Refresh after history write to fix any artifacts
+                            term.refresh(0, term.rows - 1);
                             setTimeout(() => {
                                 programmaticScrollRef.current = false;
                             }, 50);
                         });
-                        console.log(`[TerminalView] History written for ${task.id} (original: ${history.length}, cleaned: ${cleaned.length})`);
                     } else {
                         term.reset();
                         term.write('\x1b[90m── Session history not available ──\x1b[0m\r\n');
-                        console.log(`[TerminalView] Empty history for ${task.id}`);
                     }
                     // Clear loading state - history has been restored
                     historyLoadedRef.current = true;
@@ -493,8 +524,10 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
 
         return () => {
             if (resizeTimeout) window.clearTimeout(resizeTimeout);
+            if (refreshTimer) window.clearTimeout(refreshTimer);
             resizeObserver.disconnect();
             window.removeEventListener('resize', handleWindowResize);
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
             if (viewport) {
                 viewport.removeEventListener('scroll', handleViewportScroll);
             }
@@ -536,6 +569,20 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
         }
     };
 
+    const handleToggleViewMode = () => {
+        const next = viewMode === 'raw' ? 'rich' : 'raw';
+        if (next === 'rich') {
+            setRichSegments(parseToolCalls(rawBufferRef.current));
+        }
+        setViewMode(next);
+        // When switching back to raw terminal, refit after it becomes visible
+        if (next === 'raw') {
+            requestAnimationFrame(() => {
+                fitTerminal();
+            });
+        }
+    };
+
     return (
         <div className="terminal-view">
             <div className="terminal-header">
@@ -557,6 +604,14 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
                         Learn
                     </button>
                 )}
+                <button
+                    className={`learn-button ${viewMode === 'rich' ? 'active' : ''}`}
+                    onClick={handleToggleViewMode}
+                    title={viewMode === 'raw' ? 'Switch to Rich View' : 'Switch to Raw Terminal'}
+                >
+                    <Layers size={14} />
+                    {viewMode === 'raw' ? 'Rich' : 'Raw'}
+                </button>
                 {showResumeButton && (
                     <button
                         className="terminal-resume-button"
@@ -570,7 +625,12 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
                 <span className={`terminal-state ${task.state}`}>{stateLabel}</span>
             </div>
             <div className="terminal-container-wrapper">
-                <div ref={terminalRef} className="terminal-container" />
+                <div ref={terminalRef} className="terminal-container" style={{ display: viewMode === 'raw' ? 'block' : 'none' }} />
+                {viewMode === 'rich' && (
+                    <div className="terminal-container">
+                        <ToolWidgets segments={richSegments} />
+                    </div>
+                )}
                 {showSpinner && (
                     <div className="terminal-loading-overlay">
                         <div className="terminal-loading-spinner" />
@@ -604,6 +664,9 @@ export function TerminalView({ task, wsRef, workspace, isMobile }: TerminalViewP
                 )}
             </div>
             <TaskInputBar task={task} wsRef={wsRef} />
+            {workspace && (
+                <CheckpointTimeline taskId={task.id} workspaceId={workspace.id} wsRef={wsRef} />
+            )}
 
         </div>
     );

--- a/frontend/src/components/ToolWidgets.css
+++ b/frontend/src/components/ToolWidgets.css
@@ -1,0 +1,318 @@
+.tw-container {
+    padding: 12px;
+    overflow-y: auto;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.tw-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.tw-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary, #666);
+}
+
+.tw-empty-state p {
+    margin: 0;
+    font-size: 13px;
+}
+
+/* Widget base */
+.tw-widget {
+    border: 1px solid var(--border-color, #2a2a2a);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--bg-tertiary, #141414);
+}
+
+.tw-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 12px;
+}
+
+.tw-header:hover {
+    background: var(--bg-hover, #1a1a1a);
+}
+
+.tw-icon {
+    color: var(--text-secondary, #666);
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.tw-tool-icon {
+    flex-shrink: 0;
+}
+
+.tw-label {
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary, #888);
+    flex-shrink: 0;
+}
+
+.tw-meta {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--text-secondary, #666);
+}
+
+.tw-body {
+    border-top: 1px solid var(--border-color, #2a2a2a);
+    padding: 8px 10px;
+    font-size: 12px;
+}
+
+/* Bash widget */
+.tw-bash { border-left: 3px solid #4a9eff; }
+.tw-bash-header .tw-tool-icon { color: #4a9eff; }
+
+.tw-bash-command {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 12px;
+    color: var(--text-primary, #eee);
+    background: var(--bg-primary, #0d0d0d);
+    padding: 2px 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.tw-copy-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary, #666);
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.tw-copy-btn:hover { color: var(--text-primary, #fff); }
+
+.tw-bash-output {
+    background: #0a0a0a;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.tw-bash-output pre {
+    margin: 0;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-all;
+    color: var(--text-primary, #ccc);
+}
+
+/* Read widget */
+.tw-read { border-left: 3px solid #888; }
+.tw-read-icon { color: #888; }
+.tw-read .tw-header { cursor: default; }
+
+/* Write widget */
+.tw-write { border-left: 3px solid #a855f7; }
+.tw-write-icon { color: #a855f7; }
+
+.tw-write-content {
+    background: #0a0a0a;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.tw-write-content pre {
+    margin: 0;
+}
+
+.tw-write-content code {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--text-primary, #ccc);
+}
+
+/* Edit widget */
+.tw-edit { border-left: 3px solid #f59e0b; }
+.tw-edit-icon { color: #f59e0b; }
+
+.tw-edit-content {
+    background: #0a0a0a;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.tw-diff {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    line-height: 1.6;
+}
+
+.tw-diff-line {
+    display: flex;
+    padding: 0 4px;
+}
+
+.tw-diff-line-removed {
+    background: rgba(248, 81, 73, 0.1);
+}
+
+.tw-diff-line-added {
+    background: rgba(63, 185, 80, 0.1);
+}
+
+.tw-diff-marker {
+    width: 16px;
+    flex-shrink: 0;
+    color: var(--text-secondary, #666);
+    user-select: none;
+}
+
+.tw-diff-line-removed .tw-diff-marker { color: #f85149; }
+.tw-diff-line-added .tw-diff-marker { color: #3fb950; }
+
+.tw-diff-text {
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.tw-diff-line-removed .tw-diff-text { color: #ffa7a3; }
+.tw-diff-line-added .tw-diff-text { color: #7ee787; }
+
+/* Search widget */
+.tw-search { border-left: 3px solid #06b6d4; }
+.tw-search-icon { color: #06b6d4; }
+
+.tw-search-query {
+    font-size: 12px;
+    color: var(--text-primary, #eee);
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.tw-search-output {
+    background: #0a0a0a;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.tw-search-output pre {
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-primary, #ccc);
+}
+
+/* Thinking widget */
+.tw-thinking { border-left: 3px solid #8b5cf6; }
+.tw-thinking-icon { color: #8b5cf6; }
+
+.tw-thinking-preview {
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.tw-thinking-content {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.tw-thinking-content p {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-secondary, #aaa);
+    white-space: pre-wrap;
+}
+
+/* Result widget */
+.tw-result { border-left: 3px solid #4adf8a; }
+.tw-result-icon { color: #4adf8a; }
+.tw-result .tw-header { cursor: default; }
+
+.tw-result-text {
+    font-size: 12px;
+    color: var(--text-primary, #ccc);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+/* Text segments between tool calls */
+.tw-text-segment {
+    padding: 4px 0;
+}
+
+.tw-text-segment pre {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 13px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    color: var(--text-primary, #ddd);
+}
+
+/* File path styling */
+.tw-file-path {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    color: var(--text-primary, #eee);
+    background: var(--bg-primary, #0d0d0d);
+    padding: 1px 5px;
+    border-radius: 3px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+/* Show more button */
+.tw-show-more {
+    background: none;
+    border: none;
+    color: var(--accent-color, #4a9eff);
+    font-size: 11px;
+    cursor: pointer;
+    padding: 4px 0;
+    margin-top: 4px;
+}
+
+.tw-show-more:hover {
+    text-decoration: underline;
+}

--- a/frontend/src/components/ToolWidgets.tsx
+++ b/frontend/src/components/ToolWidgets.tsx
@@ -1,0 +1,312 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ChevronDown, ChevronRight, File, Terminal as TerminalIcon, Search, Globe, Pencil, FileText, Brain, CheckCircle, Copy, Check } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ParsedSegment, ToolCall } from '../utils/parseToolCalls';
+import './ToolWidgets.css';
+
+// --- Individual Widget Components ---
+
+function BashWidget({ tool }: { tool: ToolCall }) {
+    const [expanded, setExpanded] = useState(true);
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = useCallback(async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (tool.command) {
+            await navigator.clipboard.writeText(tool.command);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        }
+    }, [tool.command]);
+
+    const outputLines = tool.output?.split('\n') || [];
+    const isTruncated = outputLines.length > 40;
+    const [showAll, setShowAll] = useState(false);
+    const displayedOutput = showAll ? tool.output : outputLines.slice(0, 40).join('\n');
+
+    return (
+        <div className="tw-widget tw-bash">
+            <div className="tw-header" onClick={() => setExpanded(!expanded)}>
+                <span className="tw-chevron">
+                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                <TerminalIcon size={14} className="tw-tool-icon" />
+                <span className="tw-label">Terminal</span>
+                <code className="tw-command">{tool.command}</code>
+                <button className="tw-copy-btn" onClick={handleCopy} title="Copy command">
+                    {copied ? <Check size={12} /> : <Copy size={12} />}
+                </button>
+            </div>
+            {expanded && tool.output && (
+                <div className="tw-body tw-code-body">
+                    <pre><code>{displayedOutput}</code></pre>
+                    {isTruncated && !showAll && (
+                        <button className="tw-show-more" onClick={() => setShowAll(true)}>
+                            Show all {outputLines.length} lines
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ReadWidget({ tool }: { tool: ToolCall }) {
+    return (
+        <div className="tw-widget tw-read">
+            <div className="tw-header tw-no-expand">
+                <File size={14} className="tw-tool-icon" />
+                <span className="tw-label">Read</span>
+                <code className="tw-filepath">{tool.filePath}</code>
+            </div>
+        </div>
+    );
+}
+
+function WriteWidget({ tool }: { tool: ToolCall }) {
+    const [expanded, setExpanded] = useState(false);
+    const contentLines = tool.content?.split('\n') || [];
+    const lineCount = contentLines.length;
+    const isTruncated = lineCount > 25;
+    const [showAll, setShowAll] = useState(false);
+    const displayedContent = showAll ? tool.content : contentLines.slice(0, 25).join('\n');
+
+    return (
+        <div className="tw-widget tw-write">
+            <div className="tw-header" onClick={() => setExpanded(!expanded)}>
+                <span className="tw-chevron">
+                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                <FileText size={14} className="tw-tool-icon" />
+                <span className="tw-label">Write</span>
+                <code className="tw-filepath">{tool.filePath}</code>
+                {lineCount > 0 && <span className="tw-meta">{lineCount} lines</span>}
+            </div>
+            {expanded && tool.content && (
+                <div className="tw-body tw-code-body">
+                    <pre><code>{displayedContent}</code></pre>
+                    {isTruncated && !showAll && (
+                        <button className="tw-show-more" onClick={() => setShowAll(true)}>
+                            Show all {lineCount} lines
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function EditWidget({ tool }: { tool: ToolCall }) {
+    const [expanded, setExpanded] = useState(true);
+
+    const renderDiff = () => {
+        if (tool.oldString || tool.newString) {
+            return (
+                <div className="tw-diff">
+                    {tool.oldString && (
+                        <div className="tw-diff-section">
+                            {tool.oldString.split('\n').map((line, i) => (
+                                <div key={`old-${i}`} className="tw-diff-line tw-diff-removed">
+                                    <span className="tw-diff-marker">-</span>
+                                    <span className="tw-diff-text">{line}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    {tool.newString && (
+                        <div className="tw-diff-section">
+                            {tool.newString.split('\n').map((line, i) => (
+                                <div key={`new-${i}`} className="tw-diff-line tw-diff-added">
+                                    <span className="tw-diff-marker">+</span>
+                                    <span className="tw-diff-text">{line}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            );
+        }
+        if (tool.content) {
+            return (
+                <div className="tw-diff">
+                    {tool.content.split('\n').map((line, i) => {
+                        let cls = 'tw-diff-line';
+                        let marker = ' ';
+                        if (line.startsWith('+')) {
+                            cls += ' tw-diff-added';
+                            marker = '+';
+                        } else if (line.startsWith('-')) {
+                            cls += ' tw-diff-removed';
+                            marker = '-';
+                        }
+                        return (
+                            <div key={i} className={cls}>
+                                <span className="tw-diff-marker">{marker}</span>
+                                <span className="tw-diff-text">{line.startsWith('+') || line.startsWith('-') ? line.slice(1) : line}</span>
+                            </div>
+                        );
+                    })}
+                </div>
+            );
+        }
+        return null;
+    };
+
+    return (
+        <div className="tw-widget tw-edit">
+            <div className="tw-header" onClick={() => setExpanded(!expanded)}>
+                <span className="tw-chevron">
+                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                <Pencil size={14} className="tw-tool-icon" />
+                <span className="tw-label">Edit</span>
+                <code className="tw-filepath">{tool.filePath}</code>
+            </div>
+            {expanded && (
+                <div className="tw-body tw-code-body">
+                    {renderDiff()}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function SearchWidget({ tool }: { tool: ToolCall }) {
+    const [expanded, setExpanded] = useState(false);
+    const isUrl = tool.type === 'fetch';
+
+    return (
+        <div className="tw-widget tw-search">
+            <div className="tw-header" onClick={() => setExpanded(!expanded)}>
+                <span className="tw-chevron">
+                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                {isUrl ? <Globe size={14} className="tw-tool-icon" /> : <Search size={14} className="tw-tool-icon" />}
+                <span className="tw-label">{isUrl ? 'Fetch' : 'Search'}</span>
+                <span className="tw-search-query">{tool.query || tool.url}</span>
+            </div>
+            {expanded && tool.output && (
+                <div className="tw-body tw-code-body">
+                    <pre><code>{tool.output}</code></pre>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ThinkingWidget({ tool }: { tool: ToolCall }) {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <div className="tw-widget tw-thinking">
+            <div className="tw-header" onClick={() => setExpanded(!expanded)}>
+                <span className="tw-chevron">
+                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                <Brain size={14} className="tw-tool-icon" />
+                <span className="tw-label">Thinking</span>
+                {tool.text && <span className="tw-preview">{tool.text.slice(0, 80)}{tool.text.length > 80 ? '...' : ''}</span>}
+            </div>
+            {expanded && tool.text && (
+                <div className="tw-body tw-thinking-body">
+                    <p>{tool.text}</p>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ResultWidget({ tool }: { tool: ToolCall }) {
+    return (
+        <div className="tw-widget tw-result">
+            <div className="tw-header tw-no-expand">
+                <CheckCircle size={14} className="tw-tool-icon" />
+                <span className="tw-label">Done</span>
+                <span className="tw-result-text">{tool.text?.slice(0, 120)}{(tool.text?.length || 0) > 120 ? '...' : ''}</span>
+            </div>
+        </div>
+    );
+}
+
+function TextSegment({ text }: { text: string }) {
+    if (!text.trim()) return null;
+
+    return (
+        <div className="tw-text-segment">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {text}
+            </ReactMarkdown>
+        </div>
+    );
+}
+
+// --- Main Widgets Container ---
+
+interface ToolWidgetsProps {
+    segments: ParsedSegment[];
+}
+
+export function ToolWidgets({ segments }: ToolWidgetsProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [autoScroll, setAutoScroll] = useState(true);
+    const prevSegmentCount = useRef(segments.length);
+
+    useEffect(() => {
+        if (autoScroll && segments.length > prevSegmentCount.current && containerRef.current) {
+            containerRef.current.scrollTop = containerRef.current.scrollHeight;
+        }
+        prevSegmentCount.current = segments.length;
+    }, [segments.length, autoScroll]);
+
+    const handleScroll = useCallback(() => {
+        if (!containerRef.current) return;
+        const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+        const atBottom = scrollHeight - scrollTop - clientHeight < 50;
+        setAutoScroll(atBottom);
+    }, []);
+
+    if (segments.length === 0) {
+        return (
+            <div className="tw-container tw-empty" ref={containerRef}>
+                <div className="tw-empty-state">
+                    <TerminalIcon size={28} strokeWidth={1.2} />
+                    <p>Waiting for output...</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="tw-container" ref={containerRef} onScroll={handleScroll}>
+            {segments.map((segment, i) => {
+                if (segment.type === 'text') {
+                    return <TextSegment key={`text-${i}`} text={segment.text || ''} />;
+                }
+                if (segment.type === 'tool' && segment.tool) {
+                    const tool = segment.tool;
+                    switch (tool.type) {
+                        case 'bash':
+                            return <BashWidget key={tool.id} tool={tool} />;
+                        case 'read':
+                            return <ReadWidget key={tool.id} tool={tool} />;
+                        case 'write':
+                            return <WriteWidget key={tool.id} tool={tool} />;
+                        case 'edit':
+                            return <EditWidget key={tool.id} tool={tool} />;
+                        case 'search':
+                        case 'fetch':
+                            return <SearchWidget key={tool.id} tool={tool} />;
+                        case 'thinking':
+                            return <ThinkingWidget key={tool.id} tool={tool} />;
+                        case 'result':
+                            return <ResultWidget key={tool.id} tool={tool} />;
+                        default:
+                            return null;
+                    }
+                }
+                return null;
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/UsageDashboard.css
+++ b/frontend/src/components/UsageDashboard.css
@@ -1,0 +1,231 @@
+.usage-dashboard {
+    padding: 12px;
+    height: 100%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.usage-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.usage-header h3 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.usage-actions {
+    display: flex;
+    gap: 4px;
+}
+
+.usage-refresh-btn, .usage-clear-btn {
+    background: none;
+    border: 1px solid var(--border-color, #333);
+    border-radius: 4px;
+    padding: 4px 6px;
+    cursor: pointer;
+    color: var(--text-secondary, #888);
+    display: flex;
+    align-items: center;
+}
+
+.usage-refresh-btn:hover { color: var(--text-primary, #fff); }
+.usage-clear-btn:hover { color: #e55; }
+
+.spinning { animation: spin 1s linear infinite; }
+@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+
+.usage-period-selector {
+    display: flex;
+    gap: 4px;
+    background: var(--bg-tertiary, #1a1a1a);
+    border-radius: 6px;
+    padding: 3px;
+}
+
+.usage-period-btn {
+    flex: 1;
+    padding: 5px 8px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary, #888);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.usage-period-btn.active {
+    background: var(--accent-color, #4a9eff);
+    color: #fff;
+}
+
+.usage-period-btn:hover:not(.active) {
+    color: var(--text-primary, #fff);
+}
+
+.usage-period-note {
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    text-align: center;
+    font-style: italic;
+    margin-top: -4px;
+}
+
+.usage-empty {
+    text-align: center;
+    color: var(--text-secondary, #888);
+    padding: 32px;
+    font-size: 13px;
+}
+
+.usage-stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.usage-stat-card {
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border-color, #333);
+    border-radius: 8px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.usage-stat-card svg { color: var(--text-secondary, #888); }
+.usage-stat-cost svg { color: #4adf8a; }
+
+.usage-stat-value {
+    font-size: 18px;
+    font-weight: 700;
+    font-family: 'SF Mono', monospace;
+}
+
+.usage-stat-cost .usage-stat-value { color: #4adf8a; }
+
+.usage-stat-label {
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.usage-breakdown {
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border-color, #333);
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.usage-breakdown h4 {
+    margin: 0 0 8px 0;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.usage-token-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.usage-token-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.usage-token-bar-label {
+    width: 80px;
+    font-size: 11px;
+    color: var(--text-secondary, #888);
+    flex-shrink: 0;
+}
+
+.usage-token-bar-track {
+    flex: 1;
+    height: 8px;
+    background: var(--bg-primary, #0d0d0d);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.usage-token-bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.usage-token-bar-value {
+    width: 50px;
+    text-align: right;
+    font-size: 11px;
+    font-family: 'SF Mono', monospace;
+    color: var(--text-primary, #fff);
+}
+
+:root {
+    --usage-input: #4a9eff;
+    --usage-output: #f59e0b;
+    --usage-cache-write: #a855f7;
+    --usage-cache-read: #4adf8a;
+}
+
+.usage-model-list, .usage-task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.usage-model-row, .usage-task-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 12px;
+    border-bottom: 1px solid var(--border-color, #222);
+}
+
+.usage-model-row:last-child, .usage-task-row:last-child {
+    border-bottom: none;
+}
+
+.usage-model-name, .usage-task-id {
+    flex: 1;
+    font-weight: 500;
+    color: var(--text-primary, #fff);
+}
+
+.usage-task-id {
+    font-family: 'SF Mono', monospace;
+    font-size: 11px;
+}
+
+.usage-model-tokens, .usage-task-tokens {
+    color: var(--text-secondary, #888);
+    font-family: 'SF Mono', monospace;
+    font-size: 11px;
+}
+
+.usage-model-cost, .usage-task-cost {
+    color: #4adf8a;
+    font-family: 'SF Mono', monospace;
+    font-weight: 600;
+    font-size: 12px;
+}

--- a/frontend/src/components/UsageDashboard.tsx
+++ b/frontend/src/components/UsageDashboard.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DollarSign, Zap, Clock, Database, Trash2, RefreshCw } from 'lucide-react';
+import { UsageSummary } from '@claudia/shared';
+import './UsageDashboard.css';
+
+interface UsageDashboardProps {
+    wsRef: React.RefObject<WebSocket | null>;
+}
+
+type Period = 'today' | '7d' | '30d' | 'all';
+
+export function UsageDashboard({ wsRef }: UsageDashboardProps) {
+    const [summary, setSummary] = useState<UsageSummary | null>(null);
+    const [period, setPeriod] = useState<Period>('all');
+    const [loading, setLoading] = useState(false);
+
+    const fetchUsage = useCallback((p: Period) => {
+        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+        setLoading(true);
+        wsRef.current.send(JSON.stringify({ type: 'usage:get', payload: { period: p } }));
+    }, [wsRef]);
+
+    useEffect(() => {
+        fetchUsage(period);
+    }, [period, fetchUsage]);
+
+    useEffect(() => {
+        const ws = wsRef.current;
+        if (!ws) return;
+
+        const handler = (event: MessageEvent) => {
+            try {
+                const msg = JSON.parse(event.data);
+                if (msg.type === 'usage:summary') {
+                    setSummary(msg.payload as UsageSummary);
+                    setLoading(false);
+                }
+            } catch { /* ignore */ }
+        };
+
+        ws.addEventListener('message', handler);
+        return () => ws.removeEventListener('message', handler);
+    }, [wsRef]);
+
+    const handleClear = useCallback(() => {
+        if (!confirm('Clear all usage data? This cannot be undone.')) return;
+        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+        wsRef.current.send(JSON.stringify({ type: 'usage:clear', payload: {} }));
+    }, [wsRef]);
+
+    const formatCost = (cost: number) => {
+        if (cost < 0.01) return `$${cost.toFixed(4)}`;
+        if (cost < 1) return `$${cost.toFixed(3)}`;
+        return `$${cost.toFixed(2)}`;
+    };
+
+    const formatTokens = (tokens: number) => {
+        if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+        if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`;
+        return tokens.toString();
+    };
+
+    return (
+        <div className="usage-dashboard">
+            <div className="usage-header">
+                <h3><DollarSign size={16} /> Usage & Cost</h3>
+                <div className="usage-actions">
+                    <button className="usage-refresh-btn" onClick={() => fetchUsage(period)} title="Refresh">
+                        <RefreshCw size={14} className={loading ? 'spinning' : ''} />
+                    </button>
+                    <button className="usage-clear-btn" onClick={handleClear} title="Clear all data">
+                        <Trash2 size={14} />
+                    </button>
+                </div>
+            </div>
+
+            <div className="usage-period-selector">
+                {(['today', '7d', '30d', 'all'] as Period[]).map(p => (
+                    <button
+                        key={p}
+                        className={`usage-period-btn ${period === p ? 'active' : ''}`}
+                        onClick={() => setPeriod(p)}
+                    >
+                        {p === 'today' ? 'Today' : p === '7d' ? '7 Days' : p === '30d' ? '30 Days' : 'All Time'}
+                    </button>
+                ))}
+            </div>
+
+            {summary && period !== 'all' && summary.entryCount === summary.totalEntryCount && (
+                <div className="usage-period-note">All usage data is within this time period</div>
+            )}
+
+            {!summary ? (
+                <div className="usage-empty">No usage data yet</div>
+            ) : (
+                <>
+                    <div className="usage-stats-grid">
+                        <div className="usage-stat-card usage-stat-cost">
+                            <DollarSign size={18} />
+                            <div className="usage-stat-value">{formatCost(summary.totalCost)}</div>
+                            <div className="usage-stat-label">Total Cost</div>
+                        </div>
+                        <div className="usage-stat-card">
+                            <Zap size={18} />
+                            <div className="usage-stat-value">{formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}</div>
+                            <div className="usage-stat-label">Total Tokens</div>
+                        </div>
+                        <div className="usage-stat-card">
+                            <Clock size={18} />
+                            <div className="usage-stat-value">{summary.entryCount}</div>
+                            <div className="usage-stat-label">API Calls</div>
+                        </div>
+                        <div className="usage-stat-card">
+                            <Database size={18} />
+                            <div className="usage-stat-value">{formatTokens(summary.totalCacheReadTokens)}</div>
+                            <div className="usage-stat-label">Cache Hits</div>
+                        </div>
+                    </div>
+
+                    <div className="usage-breakdown">
+                        <h4>Token Breakdown</h4>
+                        <div className="usage-token-bars">
+                            <TokenBar label="Input" tokens={summary.totalInputTokens} total={summary.totalInputTokens + summary.totalOutputTokens + summary.totalCacheCreationTokens + summary.totalCacheReadTokens} color="var(--usage-input)" />
+                            <TokenBar label="Output" tokens={summary.totalOutputTokens} total={summary.totalInputTokens + summary.totalOutputTokens + summary.totalCacheCreationTokens + summary.totalCacheReadTokens} color="var(--usage-output)" />
+                            <TokenBar label="Cache Write" tokens={summary.totalCacheCreationTokens} total={summary.totalInputTokens + summary.totalOutputTokens + summary.totalCacheCreationTokens + summary.totalCacheReadTokens} color="var(--usage-cache-write)" />
+                            <TokenBar label="Cache Read" tokens={summary.totalCacheReadTokens} total={summary.totalInputTokens + summary.totalOutputTokens + summary.totalCacheCreationTokens + summary.totalCacheReadTokens} color="var(--usage-cache-read)" />
+                        </div>
+                    </div>
+
+                    {Object.keys(summary.byModel).length > 0 && (
+                        <div className="usage-breakdown">
+                            <h4>By Model</h4>
+                            <div className="usage-model-list">
+                                {Object.entries(summary.byModel)
+                                    .sort(([, a], [, b]) => b.cost - a.cost)
+                                    .map(([model, data]) => (
+                                        <div key={model} className="usage-model-row">
+                                            <span className="usage-model-name">{model}</span>
+                                            <span className="usage-model-tokens">{formatTokens(data.inputTokens + data.outputTokens)} tokens</span>
+                                            <span className="usage-model-cost">{formatCost(data.cost)}</span>
+                                        </div>
+                                    ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {Object.keys(summary.byTask).length > 0 && (
+                        <div className="usage-breakdown">
+                            <h4>By Task (Top 10)</h4>
+                            <div className="usage-task-list">
+                                {Object.entries(summary.byTask)
+                                    .sort(([, a], [, b]) => b.cost - a.cost)
+                                    .slice(0, 10)
+                                    .map(([taskId, data]) => (
+                                        <div key={taskId} className="usage-task-row">
+                                            <span className="usage-task-id" title={taskId}>{taskId.slice(0, 12)}...</span>
+                                            <span className="usage-task-tokens">{formatTokens(data.totalTokens)}</span>
+                                            <span className="usage-task-cost">{formatCost(data.cost)}</span>
+                                        </div>
+                                    ))}
+                            </div>
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}
+
+function TokenBar({ label, tokens, total, color }: { label: string; tokens: number; total: number; color: string }) {
+    const pct = total > 0 ? (tokens / total) * 100 : 0;
+    const formatTokens = (t: number) => {
+        if (t >= 1_000_000) return `${(t / 1_000_000).toFixed(1)}M`;
+        if (t >= 1_000) return `${(t / 1_000).toFixed(1)}k`;
+        return t.toString();
+    };
+
+    return (
+        <div className="usage-token-bar-row">
+            <span className="usage-token-bar-label">{label}</span>
+            <div className="usage-token-bar-track">
+                <div className="usage-token-bar-fill" style={{ width: `${Math.max(pct, 1)}%`, backgroundColor: color }} />
+            </div>
+            <span className="usage-token-bar-value">{formatTokens(tokens)}</span>
+        </div>
+    );
+}

--- a/frontend/src/components/WorkspacePanel.css
+++ b/frontend/src/components/WorkspacePanel.css
@@ -1890,3 +1890,56 @@
     color: var(--text-secondary);
 }
 
+/* Workspace Filter */
+.workspace-filter-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    flex: 1;
+    max-width: 160px;
+    min-width: 80px;
+}
+
+.workspace-filter-container:focus-within {
+    border-color: var(--accent-secondary);
+}
+
+.workspace-filter-icon {
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.workspace-filter-input {
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.75rem;
+    width: 100%;
+    outline: none;
+    padding: 2px 0;
+}
+
+.workspace-filter-input::placeholder {
+    color: var(--text-muted);
+}
+
+.workspace-filter-clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.workspace-filter-clear:hover {
+    color: var(--text-primary);
+}
+

--- a/frontend/src/components/WorkspacePanel.css
+++ b/frontend/src/components/WorkspacePanel.css
@@ -8,6 +8,13 @@
     /* Never exceed viewport width — ensures header spans exactly the screen width */
     max-width: 100vw;
     overflow-x: hidden;
+    container-type: inline-size;
+}
+
+@container (max-width: 350px) {
+    .workspace-branch-label {
+        display: none;
+    }
 }
 
 .workspace-panel-header {

--- a/frontend/src/components/WorkspacePanel.tsx
+++ b/frontend/src/components/WorkspacePanel.tsx
@@ -1527,6 +1527,9 @@ export function WorkspacePanel({
     // Workspace manager modal state
     const [showWorkspaceManager, setShowWorkspaceManager] = useState(false);
 
+    // Workspace filter state
+    const [workspaceFilter, setWorkspaceFilter] = useState('');
+
     // Close menu when clicking outside (capture phase so stopPropagation on child elements doesn't block it)
     useEffect(() => {
         if (!openMenuId) return;
@@ -1658,10 +1661,37 @@ export function WorkspacePanel({
         }
     });
 
+    // Filter workspaces by name
+    const filteredWorkspaces = workspaceFilter
+        ? sortedWorkspaces.filter(w => {
+            const name = (w.displayName || w.name).toLowerCase();
+            return name.startsWith(workspaceFilter.toLowerCase());
+        })
+        : sortedWorkspaces;
+
     return (
         <div className="workspace-panel">
             <div className="workspace-panel-header">
                 <h2>Workspaces</h2>
+                <div className="workspace-filter-container">
+                    <Search size={12} className="workspace-filter-icon" />
+                    <input
+                        type="text"
+                        className="workspace-filter-input"
+                        placeholder="Filter..."
+                        value={workspaceFilter}
+                        onChange={(e) => setWorkspaceFilter(e.target.value)}
+                    />
+                    {workspaceFilter && (
+                        <button
+                            className="workspace-filter-clear"
+                            onClick={() => setWorkspaceFilter('')}
+                            title="Clear filter"
+                        >
+                            <X size={12} />
+                        </button>
+                    )}
+                </div>
                 <div className="workspace-panel-header-actions">
                     <button
                         className={`archived-toggle-button ${showArchivedTasks ? 'active' : ''}`}
@@ -1748,18 +1778,24 @@ export function WorkspacePanel({
                 className="workspace-panel-content"
                 style={workspaceColumns > 0 ? { gridTemplateColumns: `repeat(${workspaceColumns}, 1fr)` } : undefined}
             >
-                {sortedWorkspaces.length === 0 ? (
+                {filteredWorkspaces.length === 0 ? (
                     <div className="empty-state">
-                        <p>No workspaces yet.</p>
-                        <button
-                            className="create-first-workspace-btn"
-                            onClick={handleAddWorkspace}
-                        >
-                            <FolderOpen size={14} /> Add Workspace
-                        </button>
+                        {workspaceFilter ? (
+                            <p>No workspaces matching "{workspaceFilter}"</p>
+                        ) : (
+                            <>
+                                <p>No workspaces yet.</p>
+                                <button
+                                    className="create-first-workspace-btn"
+                                    onClick={handleAddWorkspace}
+                                >
+                                    <FolderOpen size={14} /> Add Workspace
+                                </button>
+                            </>
+                        )}
                     </div>
                 ) : (
-                    sortedWorkspaces.map((workspace, index) => (
+                    filteredWorkspaces.map((workspace, index) => (
                         <WorkspaceSection
                             key={workspace.id}
                             workspace={workspace}

--- a/frontend/src/components/WorkspacePanel.tsx
+++ b/frontend/src/components/WorkspacePanel.tsx
@@ -3,7 +3,7 @@ import { useTaskStore } from '../stores/taskStore';
 import { Task, Workspace } from '@claudia/shared';
 import {
     Loader2, Circle, ChevronRight, ChevronDown,
-    Trash2, FolderOpen, Plus, Briefcase, Send, AlertCircle, StopCircle, Undo2, GripVertical, Archive, RotateCcw, Play, MoreVertical, Terminal, Search, GitBranch, ImagePlus, X, FileText, GripHorizontal, Copy, Pencil, Link2, Check, CheckCircle, FolderPlus, Clipboard, Columns2, Clock, Settings, ArrowDownAZ, ArrowDownUp
+    Trash2, FolderOpen, Plus, Briefcase, Send, AlertCircle, StopCircle, Undo2, GripVertical, Archive, RotateCcw, Play, MoreVertical, Terminal, Search, GitBranch, ImagePlus, X, FileText, GripHorizontal, Copy, Pencil, Link2, Check, CheckCircle, FolderPlus, Clipboard, Columns2, Clock, Settings, ArrowDownAZ, ArrowDownUp, Eye
 } from 'lucide-react';
 import { getApiBaseUrl } from '../config/api-config';
 import { SystemPromptModal } from './SystemPromptModal';
@@ -360,6 +360,7 @@ interface WorkspaceSectionProps {
     onOpenFolder: () => void;
     onOpenTerminal: () => void;
     onOpenShell: () => void;
+    onOpenPreview: () => void;
     onPushToGithub: () => void;
     onSystemPrompt: () => void;
     onToggleMenu: () => void;
@@ -406,6 +407,7 @@ function WorkspaceSection({
     onOpenFolder,
     onOpenTerminal,
     onOpenShell,
+    onOpenPreview,
     onPushToGithub,
     onSystemPrompt,
     onToggleMenu,
@@ -931,6 +933,16 @@ function WorkspaceSection({
                         </span>
                     )}
                 </div>
+                <button
+                    className="workspace-action-button preview"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onOpenPreview();
+                    }}
+                    title="Preview app"
+                >
+                    <Eye size={14} />
+                </button>
                 <div className="workspace-menu-container">
                     <button
                         className={`workspace-action-button menu ${isMenuOpen ? 'active' : ''}`}
@@ -1446,6 +1458,7 @@ interface WorkspacePanelProps {
     onOpenFolder: (workspaceId: string) => void;
     onOpenTerminal: (workspaceId: string) => void;
     onOpenShell: (workspaceId: string) => void;
+    onOpenPreview: (workspaceId: string) => void;
     onPushToGithub: (workspaceId: string) => void;
     onSetSystemPrompt: (workspaceId: string, systemPrompt: string) => void;
     onCreateTask: (prompt: string, workspaceId: string, initialCols?: number, initialRows?: number) => void;
@@ -1474,6 +1487,7 @@ export function WorkspacePanel({
     onOpenFolder,
     onOpenTerminal,
     onOpenShell,
+    onOpenPreview,
     onPushToGithub,
     onSetSystemPrompt,
     onCreateTask,
@@ -1819,6 +1833,7 @@ export function WorkspacePanel({
                             onOpenFolder={() => onOpenFolder(workspace.id)}
                             onOpenTerminal={() => onOpenTerminal(workspace.id)}
                             onOpenShell={() => onOpenShell(workspace.id)}
+                            onOpenPreview={() => onOpenPreview(workspace.id)}
                             onPushToGithub={() => onPushToGithub(workspace.id)}
                             onSystemPrompt={() => setSystemPromptWorkspace(workspace)}
                             onToggleMenu={() => setOpenMenuId(openMenuId === workspace.id ? null : workspace.id)}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -695,6 +695,10 @@ export function useWebSocket() {
         sendMessage('workspace:systemPrompt:set', { workspaceId, systemPrompt });
     }, [sendMessage]);
 
+    const setPreviewPort = useCallback((workspaceId: string, port: number | undefined) => {
+        sendMessage('workspace:previewPort:set', { workspaceId, port });
+    }, [sendMessage]);
+
     const requestRecentWorkspaces = useCallback(() => {
         sendMessage('workspace:recent:list', {});
     }, [sendMessage]);
@@ -808,6 +812,7 @@ export function useWebSocket() {
         openFolder,
         openTerminal,
         setSystemPrompt,
+        setPreviewPort,
         requestRecentWorkspaces,
         clearRecentWorkspace,
         executeSupervisorAction,

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -2625,3 +2625,49 @@ body {
     display: none !important;
   }
 }
+
+/* Usage Panel Overlay */
+.usage-panel-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.usage-panel-container {
+  width: 420px;
+  max-height: 80vh;
+  background: var(--bg-primary, #0d1117);
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.usage-panel-close {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 10px 0;
+}
+
+.usage-panel-close button {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.usage-panel-close button:hover {
+  color: var(--text-primary, #fff);
+  background: var(--bg-hover, #2d333b);
+}

--- a/frontend/src/utils/parseToolCalls.ts
+++ b/frontend/src/utils/parseToolCalls.ts
@@ -1,0 +1,370 @@
+/**
+ * parseToolCalls.ts
+ * Parses raw ANSI-stripped terminal output from Claude Code to identify
+ * structured tool call blocks and text segments.
+ *
+ * Claude Code terminal output patterns:
+ * - Tool calls appear with colored markers and structured text
+ * - File paths appear in tool headers
+ * - Bash commands show the command and output
+ * - Edit/Write tools show file content
+ */
+
+export type ToolCallType = 'bash' | 'read' | 'write' | 'edit' | 'search' | 'fetch' | 'thinking' | 'text' | 'result';
+
+export interface ToolCall {
+    id: string;
+    type: ToolCallType;
+    // Common fields
+    filePath?: string;
+    // Bash-specific
+    command?: string;
+    output?: string;
+    exitCode?: number;
+    // Edit-specific
+    oldString?: string;
+    newString?: string;
+    // Write-specific
+    content?: string;
+    // Search-specific
+    query?: string;
+    url?: string;
+    // Text/thinking content
+    text?: string;
+    // Whether this tool call is still streaming (partial)
+    isPartial?: boolean;
+    // Duration if available
+    duration?: string;
+}
+
+export interface ParsedSegment {
+    type: 'tool' | 'text';
+    tool?: ToolCall;
+    text?: string;
+}
+
+// Strip ANSI escape sequences from text
+export function stripAnsi(str: string): string {
+    // eslint-disable-next-line no-control-regex
+    return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+        .replace(/\x1b\][^\x07]*\x07/g, '')   // OSC sequences
+        .replace(/\x1b[()][A-Z0-9]/g, '')       // Character set selection
+        .replace(/\x1b\[\?[0-9;]*[a-zA-Z]/g, '') // Private mode sequences
+        .replace(/\x1b[>=]/g, '')                // Keypad mode
+        .replace(/\r/g, '');                     // Carriage returns
+}
+
+// Generate unique IDs for tool calls
+let idCounter = 0;
+function genId(): string {
+    return `tc-${++idCounter}-${Date.now()}`;
+}
+
+/**
+ * Parse raw terminal output into structured segments.
+ * This handles the typical Claude Code output patterns where tool calls
+ * are displayed with specific formatting.
+ */
+export function parseToolCalls(rawOutput: string): ParsedSegment[] {
+    const stripped = stripAnsi(rawOutput);
+    const lines = stripped.split('\n');
+    const segments: ParsedSegment[] = [];
+
+    let i = 0;
+    let textBuffer = '';
+
+    const flushText = () => {
+        if (textBuffer.trim()) {
+            segments.push({ type: 'text', text: textBuffer.trim() });
+        }
+        textBuffer = '';
+    };
+
+    while (i < lines.length) {
+        const line = lines[i];
+        const trimmed = line.trim();
+
+        // Detect Bash/command tool calls
+        // Patterns: "$ command", "❯ command", "> command" after a tool marker
+        // Or explicit markers like "⏺ Bash(command)" or similar
+        const bashExplicitMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Bash|bash|Run|Execute)\s*[:(]\s*(.+?)\s*\)?$/i);
+        if (bashExplicitMatch) {
+            flushText();
+            const command = bashExplicitMatch[1];
+            // Collect output lines until next tool or end
+            const outputLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextLine = lines[i];
+                const nextTrimmed = nextLine.trim();
+                // Stop at next tool marker or section divider
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                outputLines.push(nextLine);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'bash',
+                    command,
+                    output: outputLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect "$ command" pattern (common in Claude Code output)
+        const shellPromptMatch = trimmed.match(/^\$\s+(.+)$/);
+        if (shellPromptMatch && !trimmed.startsWith('$HOME') && !trimmed.startsWith('${')) {
+            flushText();
+            const command = shellPromptMatch[1];
+            const outputLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextLine = lines[i];
+                const nextTrimmed = nextLine.trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                if (nextTrimmed.match(/^\$\s+/)) break; // Next command
+                outputLines.push(nextLine);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'bash',
+                    command,
+                    output: outputLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect Read tool
+        const readMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Read|read|Reading)\s*[:(]\s*(.+?)\s*\)?$/i);
+        if (readMatch) {
+            flushText();
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'read',
+                    filePath: readMatch[1],
+                }
+            });
+            i++;
+            // Skip content lines until next tool
+            while (i < lines.length && !isToolMarker(lines[i].trim()) && !isSectionDivider(lines[i].trim())) {
+                i++;
+            }
+            continue;
+        }
+
+        // Detect Write tool
+        const writeMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Write|write|Writing|Wrote)\s*[:(]\s*(.+?)\s*\)?$/i);
+        if (writeMatch) {
+            flushText();
+            const filePath = writeMatch[1];
+            const contentLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextTrimmed = lines[i].trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                contentLines.push(lines[i]);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'write',
+                    filePath,
+                    content: contentLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect Edit tool
+        const editMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Edit|edit|Editing|Edited)\s*[:(]\s*(.+?)\s*\)?$/i);
+        if (editMatch) {
+            flushText();
+            const filePath = editMatch[1];
+            const diffLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextTrimmed = lines[i].trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                diffLines.push(lines[i]);
+                i++;
+            }
+            // Parse diff content for old/new strings
+            const { oldString, newString } = parseDiffContent(diffLines);
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'edit',
+                    filePath,
+                    oldString,
+                    newString,
+                    content: diffLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect WebSearch/WebFetch
+        const searchMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:WebSearch|Search|Searching|WebFetch|Fetch|Fetching)\s*[:(]\s*(.+?)\s*\)?$/i);
+        if (searchMatch) {
+            flushText();
+            const queryOrUrl = searchMatch[1];
+            const isUrl = queryOrUrl.startsWith('http');
+            const resultLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextTrimmed = lines[i].trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                resultLines.push(lines[i]);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: isUrl ? 'fetch' : 'search',
+                    query: isUrl ? undefined : queryOrUrl,
+                    url: isUrl ? queryOrUrl : undefined,
+                    output: resultLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect thinking blocks
+        const thinkingMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Thinking|thinking|💭)\s*\.{0,3}$/i);
+        if (thinkingMatch) {
+            flushText();
+            const thinkingLines: string[] = [];
+            i++;
+            while (i < lines.length) {
+                const nextTrimmed = lines[i].trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                thinkingLines.push(lines[i]);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'thinking',
+                    text: thinkingLines.join('\n').trim() || undefined,
+                }
+            });
+            continue;
+        }
+
+        // Detect result/output markers
+        const resultMatch = trimmed.match(/^[⏺●◉○▶►]?\s*(?:Result|Output|✓|✔|⚡)\s*[:(]?\s*(.*)$/i);
+        if (resultMatch && resultMatch[1]) {
+            flushText();
+            const resultLines: string[] = [resultMatch[1]];
+            i++;
+            while (i < lines.length) {
+                const nextTrimmed = lines[i].trim();
+                if (isToolMarker(nextTrimmed) || isSectionDivider(nextTrimmed)) break;
+                resultLines.push(lines[i]);
+                i++;
+            }
+            segments.push({
+                type: 'tool',
+                tool: {
+                    id: genId(),
+                    type: 'result',
+                    text: resultLines.join('\n').trim(),
+                }
+            });
+            continue;
+        }
+
+        // Not a tool call - accumulate as text
+        textBuffer += line + '\n';
+        i++;
+    }
+
+    flushText();
+    return segments;
+}
+
+/**
+ * Check if a line looks like a tool call marker
+ */
+function isToolMarker(line: string): boolean {
+    if (!line) return false;
+    return /^[⏺●◉○▶►]?\s*(?:Bash|Read|Write|Edit|WebSearch|Search|WebFetch|Fetch|Thinking|Result|Output|Run|Execute|Reading|Writing|Editing|Searching|Fetching|Wrote|Edited)\s*[:(]/i.test(line)
+        || /^\$\s+\S/.test(line);
+}
+
+/**
+ * Check if a line is a section divider (horizontal rules, separators)
+ */
+function isSectionDivider(line: string): boolean {
+    if (!line) return false;
+    // Lines of dashes, equals, or unicode box-drawing
+    return /^[-=─━═]{3,}$/.test(line.trim())
+        || /^[╌┄┈]{3,}$/.test(line.trim());
+}
+
+/**
+ * Parse diff-style content to extract old and new strings
+ */
+function parseDiffContent(lines: string[]): { oldString?: string; newString?: string } {
+    const oldLines: string[] = [];
+    const newLines: string[] = [];
+    let inOld = false;
+    let inNew = false;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('---') || trimmed.startsWith('- ') || trimmed.startsWith('-\t')) {
+            inOld = true;
+            inNew = false;
+            oldLines.push(trimmed.startsWith('- ') ? trimmed.slice(2) : trimmed.startsWith('-\t') ? trimmed.slice(2) : '');
+        } else if (trimmed.startsWith('+++') || trimmed.startsWith('+ ') || trimmed.startsWith('+\t')) {
+            inNew = true;
+            inOld = false;
+            newLines.push(trimmed.startsWith('+ ') ? trimmed.slice(2) : trimmed.startsWith('+\t') ? trimmed.slice(2) : '');
+        } else if (trimmed.startsWith('-')) {
+            if (inOld || !inNew) {
+                oldLines.push(trimmed.slice(1));
+                inOld = true;
+            }
+        } else if (trimmed.startsWith('+')) {
+            if (inNew || !inOld) {
+                newLines.push(trimmed.slice(1));
+                inNew = true;
+            }
+        }
+    }
+
+    return {
+        oldString: oldLines.length > 0 ? oldLines.join('\n') : undefined,
+        newString: newLines.length > 0 ? newLines.join('\n') : undefined,
+    };
+}
+
+/**
+ * Incrementally parse output - useful for streaming.
+ * Returns segments from new content appended to existing parsed state.
+ */
+export function parseIncremental(
+    _existingSegments: ParsedSegment[],
+    _newRawChunk: string,
+    fullBuffer: string
+): ParsedSegment[] {
+    // For simplicity, re-parse the full buffer each time.
+    // This is acceptable because we limit the buffer size and
+    // the parsing is fast (string matching, no regex backtracking).
+    return parseToolCalls(fullBuffer);
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -121,6 +121,23 @@ export interface ScheduledTask {
     fireCount: number;             // How many times it has fired
 }
 
+// Checkpoint/Timeline types
+export interface Checkpoint {
+    id: string;                    // Unique identifier
+    taskId: string;                // Which task this checkpoint belongs to
+    workspaceId: string;           // Which workspace
+    name: string;                  // User-provided or auto-generated name
+    description?: string;          // Optional description
+    timestamp: string;             // ISO timestamp when created
+    gitRef?: string;               // Git commit SHA at checkpoint time
+    gitBranch?: string;            // Current branch at checkpoint time
+    gitDiff?: string;              // Uncommitted changes (unified diff) at checkpoint time
+    metadata?: {
+        filesModified?: number;    // Number of uncommitted modified files
+        isCurrent?: boolean;       // Whether this is the "current" position
+    };
+}
+
 // WebSocket message types
 export type WSMessageType =
     // Task lifecycle
@@ -171,6 +188,16 @@ export type WSMessageType =
     | 'cron:fired'
     | 'cron:ran'
     | 'cron:updated'
+    // Checkpoints/Timeline
+    | 'checkpoint:created'
+    | 'checkpoint:list'
+    | 'checkpoint:restored'
+    | 'checkpoint:deleted'
+    | 'checkpoint:forked'
+    | 'checkpoint:error'
+    // Usage/Cost tracking
+    | 'usage:summary'
+    | 'usage:recorded'
     // Server status
     | 'server:reloading'
     | 'server:reconnecting'
@@ -183,6 +210,35 @@ export type WSMessageType =
 export interface WSMessage {
     type: WSMessageType;
     payload: unknown;
+}
+
+// Usage/Cost tracking types
+export interface UsageEntry {
+    id: string;
+    taskId: string;
+    workspaceId: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    cost: number;
+    timestamp: string;
+}
+
+export interface UsageSummary {
+    totalCost: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheCreationTokens: number;
+    totalCacheReadTokens: number;
+    byModel: Record<string, { cost: number; inputTokens: number; outputTokens: number }>;
+    byTask: Record<string, { cost: number; totalTokens: number; taskPrompt?: string }>;
+    byWorkspace: Record<string, { cost: number; totalTokens: number }>;
+    entryCount: number;
+    totalEntryCount: number;      // Total entries across all time (for comparison)
+    oldestEntryDate?: string;     // ISO timestamp of oldest entry in the filtered set
+    newestEntryDate?: string;     // ISO timestamp of newest entry in the filtered set
 }
 
 /**

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -60,6 +60,7 @@ export interface Workspace {
     systemPrompt?: string;   // Custom system prompt for this workspace
     displayName?: string;    // User-editable display name (shown instead of folder name when set)
     references?: WorkspaceReference[];  // Referenced workspaces/folders for cross-workspace context
+    previewPort?: number;    // Dev server port for live preview
 }
 
 export interface RecentWorkspace {

--- a/start.sh
+++ b/start.sh
@@ -78,23 +78,21 @@ for helper in node_modules/node-pty/prebuilds/*/spawn-helper; do
     [ -f "$helper" ] && chmod +x "$helper"
 done
 
-# Check if ports are available
+# Kill any processes on our ports before starting
 echo "🔍 Checking ports..."
-ports_busy=0
 for port in $BACKEND_PORT $FRONTEND_PORT $OPENCODE_PORT; do
-    if lsof -ti:$port >/dev/null 2>&1; then
-        echo "❌ Port $port is already in use:"
-        lsof -i:$port
-        ports_busy=1
+    pids=$(lsof -ti:$port 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "⚠️  Killing process(es) on port $port: $pids"
+        kill $pids 2>/dev/null || true
+        sleep 0.5
+        # Force kill if still running
+        pids=$(lsof -ti:$port 2>/dev/null || true)
+        if [ -n "$pids" ]; then
+            kill -9 $pids 2>/dev/null || true
+        fi
     fi
 done
-
-if [ $ports_busy -eq 1 ]; then
-    echo ""
-    echo "Please free the ports above and try again."
-    echo "You can kill processes on a port with: kill \$(lsof -ti:<port>)"
-    exit 1
-fi
 
 echo "✅ Ports are free"
 echo ""


### PR DESCRIPTION
## Summary
- Add MCP settings tools, voice client support, and workspace browse dialog
- Voice supervisor enhancements, preview panel, and MCP server enabled by default
- Checkpoint timeline, usage tracking dashboard, and tool call widget components
- Extract platform-specific OS commands into testable `platform-commands.ts` module with 57 unit tests covering macOS, Windows, and Linux (folder picker, open folder, open terminal, reveal file, PATH building, app menu)

## Test plan
- [x] All 296 backend tests pass
- [x] All 66 frontend tests pass
- [x] Builds succeed: shared, backend, frontend, electron
- [ ] Manual: verify folder browse dialog on macOS
- [ ] Manual: verify open terminal/finder commands on macOS
- [ ] Manual: verify voice agent page renders correctly