### PR TITLE
feat: complexity-based model selection for MCP-spawned tasks

### DIFF
--- a/backend/src/__tests__/config-store.test.ts
+++ b/backend/src/__tests__/config-store.test.ts
@@ -545,7 +545,8 @@ describe('ConfigStore', () => {
         });
 
         it('updateConfig accepts partial modelTiering and fills tier defaults', () => {
-            store.updateConfig({ modelTiering: { enabled: true, tiers: { high: 'claude-opus-4-7' } } });
+            // updateConfig merges partial tiers at runtime (validated upstream); cast to satisfy TS.
+            store.updateConfig({ modelTiering: { enabled: true, tiers: { high: 'claude-opus-4-7' } as any } });
             const cfg = store.getModelTiering();
             expect(cfg.enabled).toBe(true);
             expect(cfg.tiers.high).toBe('claude-opus-4-7');
@@ -558,7 +559,7 @@ describe('ConfigStore', () => {
             // Set custom mappings.
             store.updateConfig({ modelTiering: { enabled: true, tiers: { low: 'haiku-3', medium: 'sonnet-3', high: 'opus-3' } } });
             // Toggle only `enabled` off — tiers must survive.
-            store.updateConfig({ modelTiering: { enabled: false } });
+            store.updateConfig({ modelTiering: { enabled: false } as any });
             const cfg = store.getModelTiering();
             expect(cfg.enabled).toBe(false);
             expect(cfg.tiers.low).toBe('haiku-3');

--- a/backend/src/__tests__/config-store.test.ts
+++ b/backend/src/__tests__/config-store.test.ts
@@ -489,4 +489,81 @@ describe('ConfigStore', () => {
             expect(store.getClaudioMcpServerEnabled()).toBe(false);
         });
     });
+
+    describe('modelTiering', () => {
+        it('returns disabled defaults on a fresh config', () => {
+            const cfg = store.getModelTiering();
+            expect(cfg.enabled).toBe(false);
+            expect(cfg.tiers).toEqual({ low: 'haiku', medium: 'sonnet', high: 'opus' });
+        });
+
+        it('returns undefined when complexity is omitted', () => {
+            store.setModelTiering({ enabled: true, tiers: { low: 'haiku', medium: 'sonnet', high: 'opus' } });
+            expect(store.resolveModelForComplexity(undefined)).toBeUndefined();
+        });
+
+        it('returns undefined when tiering is disabled', () => {
+            // default is disabled
+            expect(store.resolveModelForComplexity('high')).toBeUndefined();
+        });
+
+        it('maps complexity to configured model when enabled', () => {
+            store.setModelTiering({ enabled: true, tiers: { low: 'haiku', medium: 'sonnet', high: 'opus' } });
+            expect(store.resolveModelForComplexity('low')).toBe('haiku');
+            expect(store.resolveModelForComplexity('medium')).toBe('sonnet');
+            expect(store.resolveModelForComplexity('high')).toBe('opus');
+        });
+
+        it('respects custom mappings', () => {
+            store.setModelTiering({
+                enabled: true,
+                tiers: { low: 'claude-haiku-4-5-20251001', medium: 'claude-sonnet-4-6', high: 'claude-opus-4-7' }
+            });
+            expect(store.resolveModelForComplexity('low')).toBe('claude-haiku-4-5-20251001');
+            expect(store.resolveModelForComplexity('high')).toBe('claude-opus-4-7');
+        });
+
+        it('falls through to undefined when a tier is empty (caller uses default)', () => {
+            store.setModelTiering({ enabled: true, tiers: { low: '', medium: 'sonnet', high: 'opus' } });
+            expect(store.resolveModelForComplexity('low')).toBeUndefined();
+            expect(store.resolveModelForComplexity('medium')).toBe('sonnet');
+        });
+
+        it('trims whitespace from tier strings', () => {
+            store.setModelTiering({ enabled: true, tiers: { low: '  haiku  ', medium: 'sonnet', high: 'opus' } });
+            expect(store.resolveModelForComplexity('low')).toBe('haiku');
+        });
+
+        it('persists across save/load', () => {
+            store.setModelTiering({ enabled: true, tiers: { low: 'haiku', medium: 'sonnet', high: 'claude-opus-4-7' } });
+
+            const reloaded = new ConfigStore(testBaseDir);
+            const cfg = reloaded.getModelTiering();
+            expect(cfg.enabled).toBe(true);
+            expect(cfg.tiers.high).toBe('claude-opus-4-7');
+            expect(reloaded.resolveModelForComplexity('high')).toBe('claude-opus-4-7');
+        });
+
+        it('updateConfig accepts partial modelTiering and fills tier defaults', () => {
+            store.updateConfig({ modelTiering: { enabled: true, tiers: { high: 'claude-opus-4-7' } } });
+            const cfg = store.getModelTiering();
+            expect(cfg.enabled).toBe(true);
+            expect(cfg.tiers.high).toBe('claude-opus-4-7');
+            // Other tiers fall back to defaults
+            expect(cfg.tiers.low).toBe('haiku');
+            expect(cfg.tiers.medium).toBe('sonnet');
+        });
+
+        it('partial updateConfig does not blow away existing tier mappings', () => {
+            // Set custom mappings.
+            store.updateConfig({ modelTiering: { enabled: true, tiers: { low: 'haiku-3', medium: 'sonnet-3', high: 'opus-3' } } });
+            // Toggle only `enabled` off — tiers must survive.
+            store.updateConfig({ modelTiering: { enabled: false } });
+            const cfg = store.getModelTiering();
+            expect(cfg.enabled).toBe(false);
+            expect(cfg.tiers.low).toBe('haiku-3');
+            expect(cfg.tiers.medium).toBe('sonnet-3');
+            expect(cfg.tiers.high).toBe('opus-3');
+        });
+    });
 });

--- a/backend/src/claudia-mcp-server.ts
+++ b/backend/src/claudia-mcp-server.ts
@@ -40,6 +40,11 @@ const WORKSPACE_ID = process.env.CLAUDIA_WORKSPACE_ID || '';
 // This agent's own task ID (set by task-spawner, used for self-rename)
 const SELF_TASK_ID = process.env.CLAUDIA_TASK_ID || '';
 
+// Whether complexity-based model tiering is enabled. Set by task-spawner when
+// the operator turns on the toggle in Settings. Controls whether the
+// `complexity` parameter is exposed on claudia_create_task.
+const MODEL_TIERING_ENABLED = process.env.CLAUDIA_MODEL_TIERING_ENABLED === '1';
+
 /**
  * Format a duration in milliseconds to a human-readable string
  */
@@ -364,84 +369,118 @@ server.tool(
 // ============================================================================
 // Tool: claudia_create_task
 // ============================================================================
-server.tool(
-    'claudia_create_task',
-    `Create a new task in Claudia. The task will be assigned to a Claude Code agent in the current workspace (${WORKSPACE_ID || 'unknown'}). Use this to delegate work to other agents running in parallel.`,
-    {
-        prompt: z.string().describe('The prompt/instructions for the new task'),
-        displayName: z.string().optional().describe('Optional short display name for the task in the Claudia sidebar (e.g., "Build API endpoint", "Write tests")'),
-    },
-    async ({ prompt, displayName }) => {
-        if (!WORKSPACE_ID) {
-            return {
-                content: [{
-                    type: 'text',
-                    text: 'Error: No workspace ID configured. The CLAUDIA_WORKSPACE_ID environment variable is not set.'
-                }]
-            };
+const createTaskBaseDescription = `Create a new task in Claudia. The task will be assigned to a Claude Code agent in the current workspace (${WORKSPACE_ID || 'unknown'}). Use this to delegate work to other agents running in parallel.`;
+
+const createTaskTieringSuffix = `
+
+You can pass an optional \`complexity\` hint to control the cost of the spawned task. The operator has mapped each tier to a specific model:
+- \`low\` — trivial lookups, formatting, single-file reads, mechanical edits.
+- \`medium\` — normal coding, refactors, writing tests.
+- \`high\` — tricky architecture, gnarly debugging, work that needs careful multi-step reasoning.
+
+Be conservative — pick \`low\` when the work is genuinely simple. Omit the parameter to use the workspace's default model.`;
+
+async function handleCreateTask(args: { prompt: string; displayName?: string; complexity?: 'low' | 'medium' | 'high' }) {
+    const { prompt, displayName, complexity } = args;
+    if (!WORKSPACE_ID) {
+        return {
+            content: [{
+                type: 'text' as const,
+                text: 'Error: No workspace ID configured. The CLAUDIA_WORKSPACE_ID environment variable is not set.'
+            }]
+        };
+    }
+
+    try {
+        log.info(`Creating task in workspace: ${WORKSPACE_ID}${complexity ? ` (complexity=${complexity})` : ''}`);
+        log.info(`Prompt: ${prompt.substring(0, 100)}...`);
+
+        const payload: Record<string, unknown> = {
+            prompt,
+            workspaceId: WORKSPACE_ID,
+            source: 'mcp',
+        };
+        if (MODEL_TIERING_ENABLED && complexity) {
+            payload.complexity = complexity;
         }
+        const result = await sendWSMessage('task:create', payload);
 
-        try {
-            log.info(`Creating task in workspace: ${WORKSPACE_ID}`);
-            log.info(`Prompt: ${prompt.substring(0, 100)}...`);
+        const task = (result as any)?.task;
+        if (task) {
+            log.info(`Task created: ${task.id}`);
 
-            const result = await sendWSMessage('task:create', {
-                prompt,
-                workspaceId: WORKSPACE_ID,
-                source: 'mcp',
-            });
-
-            const task = (result as any)?.task;
-            if (task) {
-                log.info(`Task created: ${task.id}`);
-
-                // Rename the task if displayName was provided
-                if (displayName) {
-                    try {
-                        await sendWSMessage('task:rename', { taskId: task.id, displayName, source: 'agent' });
-                        log.info(`Task renamed to: ${displayName}`);
-                    } catch (renameErr) {
-                        log.error('Failed to rename task after creation:', renameErr);
-                    }
+            // Rename the task if displayName was provided
+            if (displayName) {
+                try {
+                    await sendWSMessage('task:rename', { taskId: task.id, displayName, source: 'agent' });
+                    log.info(`Task renamed to: ${displayName}`);
+                } catch (renameErr) {
+                    log.error('Failed to rename task after creation:', renameErr);
                 }
-
-                return {
-                    content: [{
-                        type: 'text',
-                        text: JSON.stringify({
-                            success: true,
-                            taskId: task.id,
-                            displayName: displayName || null,
-                            state: task.state,
-                            workspace: task.workspaceId,
-                            prompt: task.prompt?.substring(0, 200),
-                            message: `Task '${task.id}'${displayName ? ` (${displayName})` : ''} created successfully. It is now running in workspace '${WORKSPACE_ID}'.`
-                        }, null, 2)
-                    }]
-                };
             }
 
             return {
                 content: [{
-                    type: 'text',
+                    type: 'text' as const,
                     text: JSON.stringify({
                         success: true,
-                        message: 'Task creation request sent. Check claudia_list_tasks for the new task.',
-                        result
+                        taskId: task.id,
+                        displayName: displayName || null,
+                        state: task.state,
+                        workspace: task.workspaceId,
+                        prompt: task.prompt?.substring(0, 200),
+                        complexity: complexity || null,
+                        message: `Task '${task.id}'${displayName ? ` (${displayName})` : ''} created successfully. It is now running in workspace '${WORKSPACE_ID}'.`
                     }, null, 2)
                 }]
             };
-        } catch (error) {
-            log.error('Failed to create task:', error);
-            return {
-                content: [{
-                    type: 'text',
-                    text: `Error creating task: ${error instanceof Error ? error.message : String(error)}`
-                }]
-            };
         }
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    message: 'Task creation request sent. Check claudia_list_tasks for the new task.',
+                    result
+                }, null, 2)
+            }]
+        };
+    } catch (error) {
+        log.error('Failed to create task:', error);
+        return {
+            content: [{
+                type: 'text' as const,
+                text: `Error creating task: ${error instanceof Error ? error.message : String(error)}`
+            }]
+        };
     }
-);
+}
+
+if (MODEL_TIERING_ENABLED) {
+    server.tool(
+        'claudia_create_task',
+        createTaskBaseDescription + createTaskTieringSuffix,
+        {
+            prompt: z.string().describe('The prompt/instructions for the new task'),
+            displayName: z.string().optional().describe('Optional short display name for the task in the Claudia sidebar (e.g., "Build API endpoint", "Write tests")'),
+            complexity: z.enum(['low', 'medium', 'high']).optional().describe(
+                'Cost/capability tier for the spawned task. Use "low" for trivial work, "medium" for normal coding, "high" for hard reasoning. Omit to use the workspace default model.'
+            ),
+        },
+        async (args) => handleCreateTask(args)
+    );
+} else {
+    server.tool(
+        'claudia_create_task',
+        createTaskBaseDescription,
+        {
+            prompt: z.string().describe('The prompt/instructions for the new task'),
+            displayName: z.string().optional().describe('Optional short display name for the task in the Claudia sidebar (e.g., "Build API endpoint", "Write tests")'),
+        },
+        async (args) => handleCreateTask(args)
+    );
+}
 
 // ============================================================================
 // Tool: claudia_send_input

--- a/backend/src/config-store.ts
+++ b/backend/src/config-store.ts
@@ -52,6 +52,24 @@ export interface HyperspaceProxyConfig {
     alwaysThinkingEnabled: boolean;
 }
 
+// Model tiering: lets MCP-spawned tasks pick a cheaper model based on a
+// complexity hint passed by the spawning agent.
+export type ComplexityTier = 'low' | 'medium' | 'high';
+
+export interface ModelTieringConfig {
+    enabled: boolean;
+    tiers: {
+        low: string;
+        medium: string;
+        high: string;
+    };
+}
+
+export const DEFAULT_MODEL_TIERING: ModelTieringConfig = {
+    enabled: false,
+    tiers: { low: 'haiku', medium: 'sonnet', high: 'opus' },
+};
+
 export const DEFAULT_CLAUDE_CODE_SWITCHES: ClaudeCodeSwitches = {
     verbose: false,
     maxTurns: null,
@@ -100,6 +118,7 @@ export interface AppConfig {
     tokenTrackingEnabled?: boolean;  // Enable token usage tracking
     tokenCostEnabled?: boolean;  // Enable cost calculation display (default: false)
     defaultBaseDirectory?: string;  // Default base directory for new workspaces (optional)
+    modelTiering?: ModelTieringConfig;  // Complexity-based model selection for MCP-spawned tasks
 }
 
 const DEFAULT_SUPERVISOR_PROMPT = `You are a concise, witty AI supervisor for a voice-first coding environment. Keep all responses SHORT and spoken-friendly — no bullet lists, no markdown headers, no walls of text.
@@ -183,7 +202,8 @@ const DEFAULT_CONFIG: AppConfig = {
     enabledPlugins: [],  // All plugins disabled by default
     claudiaMcpServerEnabled: true,  // Enabled by default
     tokenTrackingEnabled: true,  // Token usage tracking enabled by default
-    defaultBaseDirectory: undefined  // No default base directory set
+    defaultBaseDirectory: undefined,  // No default base directory set
+    modelTiering: { ...DEFAULT_MODEL_TIERING, tiers: { ...DEFAULT_MODEL_TIERING.tiers } }
 };
 
 export class ConfigStore {
@@ -231,7 +251,11 @@ export class ConfigStore {
             tokenTrackingEnabled: loaded.tokenTrackingEnabled ?? true,
             tokenCostEnabled: loaded.tokenCostEnabled ?? false,
             tokenPricing: loaded.tokenPricing,
-            defaultBaseDirectory: loaded.defaultBaseDirectory
+            defaultBaseDirectory: loaded.defaultBaseDirectory,
+            modelTiering: {
+                enabled: loaded.modelTiering?.enabled ?? DEFAULT_MODEL_TIERING.enabled,
+                tiers: { ...DEFAULT_MODEL_TIERING.tiers, ...(loaded.modelTiering?.tiers || {}) }
+            }
         };
     }
 
@@ -335,6 +359,15 @@ export class ConfigStore {
         if (updates.defaultBaseDirectory !== undefined) {
             this.config.defaultBaseDirectory = updates.defaultBaseDirectory;
         }
+        if (updates.modelTiering !== undefined) {
+            // Merge against existing config (not just defaults) so partial updates
+            // — e.g., flipping only `enabled` — don't blow away custom tier mappings.
+            const existing = this.config.modelTiering ?? DEFAULT_MODEL_TIERING;
+            this.config.modelTiering = {
+                enabled: updates.modelTiering.enabled ?? existing.enabled,
+                tiers: { ...existing.tiers, ...(updates.modelTiering.tiers || {}) }
+            };
+        }
         this.saveConfig();
         return this.getConfig();
     }
@@ -395,7 +428,8 @@ export class ConfigStore {
             tokenTrackingEnabled: true,
             tokenCostEnabled: false,
             tokenPricing: { ...DEFAULT_TOKEN_PRICING },
-            defaultBaseDirectory: undefined
+            defaultBaseDirectory: undefined,
+            modelTiering: { ...DEFAULT_MODEL_TIERING, tiers: { ...DEFAULT_MODEL_TIERING.tiers } }
         };
         this.saveConfig();
         return this.getConfig();
@@ -444,6 +478,35 @@ export class ConfigStore {
     setHyperspaceProxy(config: HyperspaceProxyConfig): void {
         this.config.hyperspaceProxy = config;
         this.saveConfig();
+    }
+
+    getModelTiering(): ModelTieringConfig {
+        return {
+            enabled: this.config.modelTiering?.enabled ?? DEFAULT_MODEL_TIERING.enabled,
+            tiers: { ...DEFAULT_MODEL_TIERING.tiers, ...(this.config.modelTiering?.tiers || {}) }
+        };
+    }
+
+    setModelTiering(config: ModelTieringConfig): void {
+        this.config.modelTiering = {
+            enabled: config.enabled,
+            tiers: { ...DEFAULT_MODEL_TIERING.tiers, ...config.tiers }
+        };
+        this.saveConfig();
+    }
+
+    /**
+     * Resolve a complexity tier to a concrete model string for `--model`.
+     * Returns undefined if tiering is disabled, no complexity was provided,
+     * or the configured tier maps to an empty string (caller falls back to default).
+     */
+    resolveModelForComplexity(complexity: ComplexityTier | undefined): string | undefined {
+        if (!complexity) return undefined;
+        const cfg = this.getModelTiering();
+        if (!cfg.enabled) return undefined;
+        const model = cfg.tiers[complexity];
+        if (!model || !model.trim()) return undefined;
+        return model.trim();
     }
 
     getEnabledPlugins(): string[] {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1067,10 +1067,16 @@ export async function createApp(basePath?: string) {
                 switch (message.type) {
                     case 'task:create': {
                         // Create a new Claude Code CLI instance
-                        const { prompt, workspaceId, initialCols, initialRows, source } = payload as { prompt?: string; workspaceId?: string; initialCols?: number; initialRows?: number; source?: string };
+                        const { prompt, workspaceId, initialCols, initialRows, source, complexity } = payload as { prompt?: string; workspaceId?: string; initialCols?: number; initialRows?: number; source?: string; complexity?: string };
                         if (!prompt || !workspaceId) {
                             logger.error('task:create requires prompt and workspaceId');
                             sendWSError(ws, 'task:create requires prompt and workspaceId', message.type, 'MISSING_PARAMS');
+                            return;
+                        }
+                        // Validate complexity if provided (defense in depth — MCP layer also enforces).
+                        if (complexity !== undefined && !['low', 'medium', 'high'].includes(complexity)) {
+                            logger.error('task:create rejected: invalid complexity', { complexity });
+                            sendWSError(ws, `Invalid complexity '${complexity}'. Expected one of: low, medium, high.`, message.type, 'INVALID_COMPLEXITY');
                             return;
                         }
                         // Validate workspace path
@@ -1110,9 +1116,22 @@ export async function createApp(basePath?: string) {
 
                         logger.info(`Creating task with system prompt`, { hasSystemPrompt: !!systemPrompt, source: workspaceSystemPrompt ? 'workspace' : (rules ? 'rules' : 'none'), references: validRefs.length });
 
+                        // Resolve complexity → concrete model string (undefined if disabled or omitted).
+                        const modelOverride = configStore.resolveModelForComplexity(complexity as 'low' | 'medium' | 'high' | undefined);
+                        if (complexity && !modelOverride) {
+                            const cfg = configStore.getModelTiering();
+                            if (!cfg.enabled) {
+                                logger.debug('complexity ignored (model tiering disabled)', { complexity });
+                            } else {
+                                logger.warn('complexity has empty mapping; using default model', { complexity });
+                            }
+                        } else if (modelOverride) {
+                            logger.info('complexity → model resolved', { complexity, model: modelOverride, workspaceId: validatedPath });
+                        }
+
                         // Pass initial dimensions if provided
                         try {
-                            const newTask = await taskSpawner.createTask(prompt, validatedPath, systemPrompt, initialCols, initialRows);
+                            const newTask = await taskSpawner.createTask(prompt, validatedPath, systemPrompt, initialCols, initialRows, modelOverride);
                             // Broadcast task:created to all clients (UI sidebar update).
                             // Done here (not in the taskCreated event handler) so the source
                             // field is always correct even with concurrent creates.

--- a/backend/src/task-spawner.ts
+++ b/backend/src/task-spawner.ts
@@ -539,6 +539,11 @@ export class TaskSpawner extends EventEmitter {
             const mcpEnv: Record<string, string> = {};
             if (workspaceId) mcpEnv.CLAUDIA_WORKSPACE_ID = workspaceId;
             if (taskId) mcpEnv.CLAUDIA_TASK_ID = taskId;
+            // Signal to the MCP server whether the complexity-tiering parameter
+            // should be exposed on claudia_create_task.
+            if (this.configStore?.getModelTiering().enabled) {
+                mcpEnv.CLAUDIA_MODEL_TIERING_ENABLED = '1';
+            }
             if (Object.keys(mcpEnv).length > 0) {
                 claudiaConfig.env = mcpEnv;
             }
@@ -2090,7 +2095,7 @@ export class TaskSpawner extends EventEmitter {
      * @param systemPrompt - Optional system prompt override
      * @returns The created task object
      */
-    async createTask(prompt: string, workspaceId: string, systemPrompt?: string, initialCols?: number, initialRows?: number): Promise<Task> {
+    async createTask(prompt: string, workspaceId: string, systemPrompt?: string, initialCols?: number, initialRows?: number, modelOverride?: string): Promise<Task> {
         // Sanitize prompt to prevent command injection and other issues
         const sanitizedPrompt = sanitizePrompt(prompt);
         let sanitizedSystemPrompt = systemPrompt ? sanitizePrompt(systemPrompt) : undefined;
@@ -2133,6 +2138,9 @@ export class TaskSpawner extends EventEmitter {
         let task: Task;
         if (this.backendType === 'opencode' && this.backend) {
             logger.info('Using OpenCode backend for task creation');
+            if (modelOverride) {
+                logger.debug('modelOverride ignored on opencode backend', { modelOverride });
+            }
             // OpenCode needs git state synchronously — await here since it uses HTTP not PTY
             const gitStateBefore = await gitStatePromise;
             task = await this.createTaskWithOpenCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStateBefore);
@@ -2141,7 +2149,7 @@ export class TaskSpawner extends EventEmitter {
             // Pass the git state promise — the PTY spawns immediately, git result is stored
             // on the task once resolved (non-blocking).
             logger.info('Using Claude Code backend for task creation');
-            task = await this.createTaskWithClaudeCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStatePromise, initialCols, initialRows);
+            task = await this.createTaskWithClaudeCode(sanitizedPrompt, workspaceId, sanitizedSystemPrompt, gitStatePromise, initialCols, initialRows, modelOverride);
         }
 
         // Resolve learnings and inject into system prompt / track after task is created
@@ -2248,7 +2256,8 @@ export class TaskSpawner extends EventEmitter {
         systemPrompt: string | undefined,
         gitStatePromise: Promise<Partial<TaskGitState> | null>,
         initialCols?: number,
-        initialRows?: number
+        initialRows?: number,
+        modelOverride?: string
     ): Promise<Task> {
         console.log(`[TaskSpawner] createTaskWithClaudeCode called with workspaceId: "${workspaceId}"`);
         const id = `task-${Date.now()}-${randomBytes(5).toString('hex')}`;
@@ -2358,7 +2367,11 @@ You are running as an agent inside Claudia, a multi-agent orchestrator. You have
 
         // Add Claude Code CLI switches from settings
         if (this.configStore) {
-            const switches = this.configStore.getClaudeCodeSwitches();
+            let switches = this.configStore.getClaudeCodeSwitches();
+            if (modelOverride && modelOverride.trim()) {
+                switches = { ...switches, defaultModel: modelOverride.trim() };
+                logger.info('Per-task model override applied', { taskId: id, model: modelOverride.trim() });
+            }
             const switchArgs = buildClaudeCodeSwitchArgs(switches);
             if (switchArgs.length > 0) {
                 claudeArgs.push(...switchArgs);

--- a/backend/src/validation.ts
+++ b/backend/src/validation.ts
@@ -82,6 +82,14 @@ export interface ConfigUpdatePayload {
         timeoutMs?: number;
     };
     claudiaMcpServerEnabled?: boolean;
+    modelTiering?: {
+        enabled?: boolean;
+        tiers?: {
+            low?: string;
+            medium?: string;
+            high?: string;
+        };
+    };
 }
 
 /**
@@ -422,6 +430,42 @@ export function validateConfigUpdate(body: unknown): ValidationResult<ConfigUpda
                 return { valid: false, error: 'sapAiCore.timeoutMs must be a non-negative number' };
             }
             result.sapAiCore.timeoutMs = config.timeoutMs;
+        }
+    }
+
+    // Validate modelTiering (optional object)
+    if (payload.modelTiering !== undefined) {
+        if (typeof payload.modelTiering !== 'object' || payload.modelTiering === null) {
+            return { valid: false, error: 'modelTiering must be an object' };
+        }
+        const cfg = payload.modelTiering as Record<string, unknown>;
+        result.modelTiering = {};
+
+        if (cfg.enabled !== undefined) {
+            if (typeof cfg.enabled !== 'boolean') {
+                return { valid: false, error: 'modelTiering.enabled must be a boolean' };
+            }
+            result.modelTiering.enabled = cfg.enabled;
+        }
+
+        if (cfg.tiers !== undefined) {
+            if (typeof cfg.tiers !== 'object' || cfg.tiers === null) {
+                return { valid: false, error: 'modelTiering.tiers must be an object' };
+            }
+            const tiers = cfg.tiers as Record<string, unknown>;
+            result.modelTiering.tiers = {};
+            for (const key of ['low', 'medium', 'high'] as const) {
+                if (tiers[key] !== undefined) {
+                    if (typeof tiers[key] !== 'string') {
+                        return { valid: false, error: `modelTiering.tiers.${key} must be a string` };
+                    }
+                    const value = (tiers[key] as string).trim();
+                    if (value.length > 200) {
+                        return { valid: false, error: `modelTiering.tiers.${key} too long (max 200 chars)` };
+                    }
+                    result.modelTiering.tiers[key] = value;
+                }
+            }
         }
     }
 

--- a/backend/test-cli.ts
+++ b/backend/test-cli.ts
@@ -76,6 +76,7 @@ interface TestConfig {
     cronId: string | null;            // Cron ID for --cron-delete/--cron-pause
     cronRecurring: boolean;           // Whether the cron is recurring (default true)
     cronPause: boolean | null;        // true to pause, false to resume, null = not set
+    complexity: string | null;        // Optional complexity tier for task:create (low/medium/high)
 }
 
 class TestCLI {
@@ -323,18 +324,25 @@ class TestCLI {
         }
 
         // Server expects 'prompt' and 'workspaceId' fields
+        const payload: Record<string, unknown> = {
+            prompt: description,
+            workspaceId: this.config.workspaceId || process.cwd()
+        };
+        if (this.config.complexity) {
+            payload.complexity = this.config.complexity;
+        }
         const message = {
             type: 'task:create',
-            payload: {
-                prompt: description,
-                workspaceId: this.config.workspaceId || process.cwd()
-            }
+            payload
         };
 
         console.log(`📤 Creating task: "${name}"`);
         console.log(`   Prompt: ${description}`);
         if (this.config.workspaceId) {
             console.log(`   Workspace: ${this.config.workspaceId}`);
+        }
+        if (this.config.complexity) {
+            console.log(`   Complexity: ${this.config.complexity}`);
         }
         this.ws.send(JSON.stringify(message));
     }
@@ -1348,6 +1356,7 @@ function parseArgs(): TestConfig {
     let cronId: string | null = null;
     let cronRecurring = true;
     let cronPause: boolean | null = null;
+    let complexity: string | null = null;
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
@@ -1554,6 +1563,15 @@ function parseArgs(): TestConfig {
             case '--cron-resume':
                 cronPause = false;
                 break;
+            case '--complexity': {
+                const value = args[++i];
+                if (!['low', 'medium', 'high'].includes(value)) {
+                    console.error(`❌ --complexity must be one of: low, medium, high (got '${value}')`);
+                    process.exit(1);
+                }
+                complexity = value;
+                break;
+            }
             case '--help':
             case '-h':
                 console.log(`
@@ -1574,6 +1592,8 @@ CHAT OPERATIONS:
 TASK OPERATIONS:
   --task                   Create task directly (like frontend task:create)
   --task-name, -n <name>   Name for the task when using --task
+  --complexity <tier>      Pass a complexity tier (low|medium|high) on task:create.
+                           Requires "Model tiering" enabled in Settings; otherwise ignored.
   --task-id <id>           Task ID for operations (stop, delete, input, view-files)
   --task-input             Send input to a task (requires --task-id and --message)
   --stop-task              Stop a running task (requires --task-id)
@@ -1821,6 +1841,7 @@ Examples:
         cronId,
         cronRecurring,
         cronPause,
+        complexity,
     };
 }
 

--- a/docs/superpowers/specs/2026-05-01-model-tiering-design.md
+++ b/docs/superpowers/specs/2026-05-01-model-tiering-design.md
@@ -1,0 +1,270 @@
+# Complexity-Based Model Selection for Spawned Tasks
+
+**Status:** Design
+**Date:** 2026-05-01
+**Owner:** Kalin Ovtcharov
+
+## Goal
+
+Let a parent Claude agent reduce token cost when spawning child tasks via the
+Claudia MCP server by tagging each spawned task with a *complexity tier*
+(`low` / `medium` / `high`). The tier is mapped server-side to a configured
+model — typically Haiku for `low`, Sonnet for `medium`, Opus for `high` — so
+the parent agent reasons about task difficulty, not about model SKUs.
+
+The feature is gated behind an opt-in mode toggle and is disabled by default.
+
+## Motivation
+
+- Most parent-agent workflows spawn a mix of trivial and non-trivial subtasks.
+  Routing all of them through the workspace's default model (often Opus or
+  Sonnet) leaves easy money on the table.
+- Today, `claudia_create_task` accepts only `prompt` and `displayName`. The
+  spawning agent has no way to express that a subtask is cheap, so it gets the
+  same model as everything else.
+- Letting the agent pass a model name directly couples agent prompting to
+  model SKUs, which rotate. A complexity hint that the operator maps to a
+  model is more durable.
+
+## Non-goals
+
+- Auto-classifying prompts in the backend. The spawning agent has the context;
+  forcing a classifier call would add latency and cost.
+- Changing how the user's *interactive* (non-spawned) tasks pick a model.
+  This feature only affects tasks created via the `claudia_create_task` MCP
+  tool.
+- Per-tier prompt caching policies, per-tier tool restrictions, or any other
+  behavior beyond model selection. Future work.
+- Migrating existing tasks. The feature applies to tasks created after the
+  toggle is enabled.
+
+## Configuration
+
+### Global config (`AppConfig` in `backend/src/config-store.ts`)
+
+Add one new field to `AppConfig`:
+
+```ts
+modelTiering: ModelTieringConfig;
+```
+
+Where:
+
+```ts
+export interface ModelTieringConfig {
+    enabled: boolean;            // master toggle, default: false
+    tiers: {
+        low: string;             // default: "haiku"
+        medium: string;          // default: "sonnet"
+        high: string;            // default: "opus"
+    };
+}
+
+export const DEFAULT_MODEL_TIERING: ModelTieringConfig = {
+    enabled: false,
+    tiers: { low: 'haiku', medium: 'sonnet', high: 'opus' },
+};
+```
+
+The model strings are passed verbatim to Claude Code as `--model <value>`,
+matching the existing `claudeCodeSwitches.defaultModel` convention. Any
+string Claude Code accepts (`haiku`, `sonnet`, `opus`, full
+`claude-*-latest` IDs, custom aliases) is valid.
+
+### Per-workspace override (`Workspace` in `shared/src/index.ts`)
+
+Add an optional override field to `Workspace`, mirroring the existing
+optional `systemPrompt`:
+
+```ts
+modelTiering?: Partial<ModelTieringConfig>;
+```
+
+Resolution rules at task-creation time:
+
+1. Start with the global `modelTiering` config.
+2. If the workspace has `modelTiering.enabled` set, that overrides the global
+   `enabled`.
+3. If the workspace has any `modelTiering.tiers.*` field set, that overrides
+   the corresponding global tier mapping. Other tiers fall through to the
+   global value.
+4. Empty string in a tier field means *unset* — fall through to the next
+   level (workspace empty → global → built-in default).
+
+This matches the existing pattern used by `Workspace.systemPrompt`: the
+workspace value is optional and falls back to global when absent.
+
+## MCP tool surface (`claudia_create_task`)
+
+The MCP server (`backend/src/claudia-mcp-server.ts`) reads the resolved
+`modelTiering` config for its `WORKSPACE_ID` at startup.
+
+### Mode disabled (default)
+
+Tool schema and description are exactly what they are today. No `complexity`
+parameter is registered. Zero behavior change.
+
+### Mode enabled
+
+The tool gains an optional `complexity` parameter:
+
+```ts
+complexity: z.enum(['low', 'medium', 'high']).optional()
+    .describe(
+        'Cost/capability tier for the spawned task. ' +
+        'Use "low" for trivial lookups, formatting, or single-file reads. ' +
+        'Use "medium" for normal coding, refactors, or test writing. ' +
+        'Use "high" for tricky architecture, gnarly debugging, or work ' +
+        'requiring careful multi-step reasoning. Omit to use the workspace default.'
+    )
+```
+
+The tool's top-level description gains one short paragraph pointing at the
+`complexity` parameter and explaining that it controls cost.
+
+When the agent invokes the tool with `complexity: "low"`, the MCP server
+forwards `complexity` to the backend's `task:create` WebSocket handler
+alongside `prompt` and `workspaceId`.
+
+### Mid-session toggle changes
+
+Each spawned task launches a fresh Claude Code subprocess, which spawns a
+fresh `claudia-mcp-server.ts` subprocess. So toggle changes take effect on
+the *next* spawn — no manual restart needed. The currently running parent's
+MCP server keeps its old schema until the parent itself is restarted, but
+that's acceptable since the toggle is rarely flipped.
+
+## Backend resolution & spawn flow
+
+The mapping happens in the WebSocket `task:create` handler in
+`backend/src/server.ts` (the layer reached by `sendWSMessage('task:create',
+...)`), before the task is handed to `task-spawner.ts`:
+
+1. Receive `task:create` message. Payload may now include an optional
+   `complexity: 'low' | 'medium' | 'high'` field.
+2. Resolve the effective `ModelTieringConfig` for the target workspace
+   (workspace override layered on global).
+3. If `enabled === false`: ignore `complexity` silently. Fall through to the
+   normal model resolution (workspace switches → global default).
+4. If `enabled === true` and `complexity` is provided:
+   - Look up `tiers[complexity]`.
+   - If non-empty, set `claudeCodeSwitches.model` to that string for the
+     task being spawned (overriding the workspace's
+     `claudeCodeSwitches.defaultModel`).
+   - If the looked-up value is empty string, log a warning and fall through
+     to the default model (don't crash, don't reject).
+5. If `enabled === true` and `complexity` is not provided: use the default
+   model. The agent simply didn't opt into a tier.
+
+`task-spawner.ts` already passes `switches.model` to `--model` (lines
+76–78). No spawner changes are needed once the resolved model lands in the
+switches object.
+
+### Validation
+
+- The MCP layer enforces `complexity ∈ {'low', 'medium', 'high'}` via
+  `z.enum`. Invalid values are rejected by the SDK before the handler runs.
+- The `task:create` handler additionally validates `complexity` if present
+  (defense in depth, since the WS endpoint is reachable by sources other
+  than the MCP server). Invalid value → reject with a clear error message
+  so a misbehaving caller learns.
+
+### Conflicts with explicit model
+
+If a `task:create` payload somehow contains both `complexity` and an
+explicit `claudeCodeSwitches.model` override, `complexity` wins. The MCP
+server is the only documented producer of `complexity` and it never sets
+`model` directly, so this conflict should be rare.
+
+## UI
+
+In the Settings dialog, add a new section: **Model tiering**.
+
+- One checkbox: "Allow agents to select model by task complexity"
+  (off by default).
+- When checked, three rows appear, each labeled `Low`, `Medium`, `High`,
+  with a single text input pre-filled with `haiku`, `sonnet`, `opus`. (Text
+  input rather than dropdown to match the existing `defaultModel` field's
+  style and accept arbitrary aliases.)
+- A short helper line: *"Spawned tasks tagged with a complexity tier will
+  use the corresponding model. Leave a field empty to use the workspace
+  default for that tier."*
+
+The same section appears in workspace settings, with one extra control per
+field: an "Inherit from global" checkbox. When inherited, the field is
+disabled and shows the global value greyed-out.
+
+No new screens, modals, or routes. One section in an existing dialog.
+
+## Logging
+
+- When a task is spawned with a tier, log:
+  `[task:create] complexity=high → model="opus" (workspace=<id>)`
+- When mode is disabled and the agent passes `complexity` anyway, log a
+  single line at debug level so the operator can spot agents trying to use
+  the feature: `[task:create] complexity ignored (mode disabled)`
+- When a tier maps to an empty string and we fall through, log a warning:
+  `[task:create] complexity=low has empty mapping; using default model`
+
+## Testing
+
+### Backend (test-cli)
+
+Add `--complexity <low|medium|high>` to `backend/test-cli.ts`. The flag is
+passed through to the `task:create` request alongside the prompt.
+
+Cases to verify (in `backend/src/__tests__/`):
+
+1. **Mode disabled, complexity passed** — task spawns with the default
+   model; complexity is ignored; debug log emitted.
+2. **Mode enabled, complexity = "high"** — task spawns with `--model opus`
+   on its argv (or whatever `tiers.high` is configured to).
+3. **Mode enabled, complexity omitted** — task spawns with the default
+   model.
+4. **Mode enabled, invalid complexity (`"medium-rare"`)** — `task:create`
+   rejected with a clear error.
+5. **Mode enabled at global, disabled at workspace** — workspace override
+   wins; complexity is ignored.
+6. **Mode enabled, tier mapping empty (`tiers.low = ""`)** — falls through
+   to default model with a warning logged.
+
+Where feasible, assert on the spawned process's argv (the existing
+`task-spawner.ts` test patterns already do this).
+
+### MCP layer
+
+Unit-test the schema-shape decision in `claudia-mcp-server.ts`:
+
+- When `enabled === false`, the registered tool's input schema does NOT
+  include `complexity`.
+- When `enabled === true`, the schema includes `complexity` with the three
+  valid enum values.
+
+### UI
+
+Manual visual check only — one checkbox, three text inputs, one helper
+line. Verify the inputs hide/show with the toggle and that workspace
+inherit behavior matches the existing `systemPrompt` pattern.
+
+## Risks & rollback
+
+- **Risk:** An agent passes `complexity: "low"` for a task that genuinely
+  needs reasoning power, leading to a poor result. *Mitigation:* The
+  feature is opt-in. Operators who don't trust their agents' judgment leave
+  it off. The tool description steers the agent toward conservative use.
+- **Risk:** A misconfigured tier (e.g., `high` mapped to a deprecated model
+  ID) breaks all `complexity: "high"` spawns. *Mitigation:* Logging plus
+  the empty-string fall-through. The operator can flip the toggle off to
+  immediately revert to today's behavior.
+- **Rollback:** Set `modelTiering.enabled = false` in global config. All
+  spawned tasks revert to today's model resolution. No data migration
+  needed.
+
+## Open questions
+
+- Should the per-workspace UI initially ship as "inherit only" (no override
+  surface), with override added in a follow-up? Probably not — the override
+  is cheap to build and the spec is cleaner with it included from v1.
+- Future work: surface the spawning agent's `complexity` choice in the task
+  list UI (small badge next to the task name) so operators can see at a
+  glance which tasks are running cheap vs. expensive. Out of scope for v1.

--- a/docs/superpowers/specs/2026-05-01-model-tiering-design.md
+++ b/docs/superpowers/specs/2026-05-01-model-tiering-design.md
@@ -1,18 +1,19 @@
 # Complexity-Based Model Selection for Spawned Tasks
 
-**Status:** Design
+**Status:** Design (revised after code-aligned audit)
 **Date:** 2026-05-01
 **Owner:** Kalin Ovtcharov
+**Scope:** v1 — global config only, `claude-code` backend only.
 
 ## Goal
 
 Let a parent Claude agent reduce token cost when spawning child tasks via the
 Claudia MCP server by tagging each spawned task with a *complexity tier*
 (`low` / `medium` / `high`). The tier is mapped server-side to a configured
-model — typically Haiku for `low`, Sonnet for `medium`, Opus for `high` — so
-the parent agent reasons about task difficulty, not about model SKUs.
+model — defaults `haiku` / `sonnet` / `opus` — so the parent agent reasons
+about task difficulty, not about model SKUs.
 
-The feature is gated behind an opt-in mode toggle and is disabled by default.
+The feature is gated behind an opt-in toggle and is disabled by default.
 
 ## Motivation
 
@@ -20,43 +21,35 @@ The feature is gated behind an opt-in mode toggle and is disabled by default.
   Routing all of them through the workspace's default model (often Opus or
   Sonnet) leaves easy money on the table.
 - Today, `claudia_create_task` accepts only `prompt` and `displayName`. The
-  spawning agent has no way to express that a subtask is cheap, so it gets the
-  same model as everything else.
-- Letting the agent pass a model name directly couples agent prompting to
-  model SKUs, which rotate. A complexity hint that the operator maps to a
-  model is more durable.
+  spawning agent has no way to express that a subtask is cheap, so it gets
+  the same model as everything else.
+- A complexity hint that the operator maps to a model is more durable than
+  having the agent pass a raw model SKU, since SKUs rotate.
 
-## Non-goals
+## Non-goals (v1)
 
-- Auto-classifying prompts in the backend. The spawning agent has the context;
-  forcing a classifier call would add latency and cost.
-- Changing how the user's *interactive* (non-spawned) tasks pick a model.
-  This feature only affects tasks created via the `claudia_create_task` MCP
-  tool.
-- Per-tier prompt caching policies, per-tier tool restrictions, or any other
-  behavior beyond model selection. Future work.
-- Migrating existing tasks. The feature applies to tasks created after the
-  toggle is enabled.
+- Auto-classifying prompts in the backend.
+- Per-workspace overrides (global config only). Adding workspace-level
+  override later is straightforward but doubles UI scope and there is no
+  existing precedent for global+workspace field-level merge in the codebase.
+- `opencode` backend support. The override is plumbed through the
+  `claude-code` path only; if `opencode` is the active backend, the
+  complexity hint is ignored.
+- Per-tier prompt caching policies, per-tier tool restrictions, etc.
+- Migrations for existing tasks. Applies to tasks created after the toggle
+  is enabled.
 
 ## Configuration
 
-### Global config (`AppConfig` in `backend/src/config-store.ts`)
-
-Add one new field to `AppConfig`:
-
-```ts
-modelTiering: ModelTieringConfig;
-```
-
-Where:
+Add one new field to `AppConfig` in `backend/src/config-store.ts`:
 
 ```ts
 export interface ModelTieringConfig {
-    enabled: boolean;            // master toggle, default: false
+    enabled: boolean;
     tiers: {
-        low: string;             // default: "haiku"
-        medium: string;          // default: "sonnet"
-        high: string;            // default: "opus"
+        low: string;
+        medium: string;
+        high: string;
     };
 }
 
@@ -66,205 +59,257 @@ export const DEFAULT_MODEL_TIERING: ModelTieringConfig = {
 };
 ```
 
-The model strings are passed verbatim to Claude Code as `--model <value>`,
-matching the existing `claudeCodeSwitches.defaultModel` convention. Any
-string Claude Code accepts (`haiku`, `sonnet`, `opus`, full
+```ts
+// AppConfig
+modelTiering: ModelTieringConfig;
+```
+
+The model strings are passed verbatim to Claude Code as `--model <value>`.
+Any value Claude Code accepts (`haiku`, `sonnet`, `opus`, full
 `claude-*-latest` IDs, custom aliases) is valid.
 
-### Per-workspace override (`Workspace` in `shared/src/index.ts`)
+### apiMode caveat
 
-Add an optional override field to `Workspace`, mirroring the existing
-optional `systemPrompt`:
+The defaults (`haiku` / `sonnet` / `opus`) work for `apiMode ∈ {'default',
+'custom-anthropic'}`. They do **not** work for proxy modes:
 
-```ts
-modelTiering?: Partial<ModelTieringConfig>;
-```
+- `sap-ai-core` and `hyperspace-proxy` route through a local proxy
+  (`http://localhost:4001/anthropic`) that requires fully-qualified Anthropic
+  IDs (e.g., `claude-3-5-haiku-20241022`) — see
+  `backend/plugins/sap-ai-core-plugin/anthropic-proxy/deployment-catalog.ts`.
+- Operators on those modes must edit the tier mappings to use IDs valid
+  for their proxy.
 
-Resolution rules at task-creation time:
+The Settings UI calls this out in helper text.
 
-1. Start with the global `modelTiering` config.
-2. If the workspace has `modelTiering.enabled` set, that overrides the global
-   `enabled`.
-3. If the workspace has any `modelTiering.tiers.*` field set, that overrides
-   the corresponding global tier mapping. Other tiers fall through to the
-   global value.
-4. Empty string in a tier field means *unset* — fall through to the next
-   level (workspace empty → global → built-in default).
+### Migration
 
-This matches the existing pattern used by `Workspace.systemPrompt`: the
-workspace value is optional and falls back to global when absent.
-
-## MCP tool surface (`claudia_create_task`)
-
-The MCP server (`backend/src/claudia-mcp-server.ts`) reads the resolved
-`modelTiering` config for its `WORKSPACE_ID` at startup.
-
-### Mode disabled (default)
-
-Tool schema and description are exactly what they are today. No `complexity`
-parameter is registered. Zero behavior change.
-
-### Mode enabled
-
-The tool gains an optional `complexity` parameter:
+No schema bump needed. Reads spread the default into the loaded config:
 
 ```ts
-complexity: z.enum(['low', 'medium', 'high']).optional()
-    .describe(
-        'Cost/capability tier for the spawned task. ' +
-        'Use "low" for trivial lookups, formatting, or single-file reads. ' +
-        'Use "medium" for normal coding, refactors, or test writing. ' +
-        'Use "high" for tricky architecture, gnarly debugging, or work ' +
-        'requiring careful multi-step reasoning. Omit to use the workspace default.'
-    )
+// in getModelTiering(), mirroring getClaudeCodeSwitches() at config-store.ts:430
+return {
+    enabled: this.config.modelTiering?.enabled ?? DEFAULT_MODEL_TIERING.enabled,
+    tiers: { ...DEFAULT_MODEL_TIERING.tiers, ...(this.config.modelTiering?.tiers || {}) }
+};
 ```
 
-The tool's top-level description gains one short paragraph pointing at the
-`complexity` parameter and explaining that it controls cost.
+Existing config files keep working; on first save after upgrade, the field
+is persisted with defaults.
 
-When the agent invokes the tool with `complexity: "low"`, the MCP server
-forwards `complexity` to the backend's `task:create` WebSocket handler
-alongside `prompt` and `workspaceId`.
+## Backend resolution
 
-### Mid-session toggle changes
+`ConfigStore` gains a helper:
 
-Each spawned task launches a fresh Claude Code subprocess, which spawns a
-fresh `claudia-mcp-server.ts` subprocess. So toggle changes take effect on
-the *next* spawn — no manual restart needed. The currently running parent's
-MCP server keeps its old schema until the parent itself is restarted, but
-that's acceptable since the toggle is rarely flipped.
+```ts
+resolveModelForComplexity(complexity: 'low' | 'medium' | 'high' | undefined): string | undefined {
+    if (!complexity) return undefined;
+    const cfg = this.getModelTiering();
+    if (!cfg.enabled) return undefined;
+    const model = cfg.tiers[complexity];
+    if (!model || !model.trim()) return undefined; // fall through to default
+    return model.trim();
+}
+```
 
-## Backend resolution & spawn flow
+Returning `undefined` means *use the workspace default model* — the
+spawn path treats `undefined` as no override.
 
-The mapping happens in the WebSocket `task:create` handler in
-`backend/src/server.ts` (the layer reached by `sendWSMessage('task:create',
-...)`), before the task is handed to `task-spawner.ts`:
+## Per-task plumbing (the lowest-risk change)
 
-1. Receive `task:create` message. Payload may now include an optional
-   `complexity: 'low' | 'medium' | 'high'` field.
-2. Resolve the effective `ModelTieringConfig` for the target workspace
-   (workspace override layered on global).
-3. If `enabled === false`: ignore `complexity` silently. Fall through to the
-   normal model resolution (workspace switches → global default).
-4. If `enabled === true` and `complexity` is provided:
-   - Look up `tiers[complexity]`.
-   - If non-empty, set `claudeCodeSwitches.model` to that string for the
-     task being spawned (overriding the workspace's
-     `claudeCodeSwitches.defaultModel`).
-   - If the looked-up value is empty string, log a warning and fall through
-     to the default model (don't crash, don't reject).
-5. If `enabled === true` and `complexity` is not provided: use the default
-   model. The agent simply didn't opt into a tier.
+Today, `task-spawner.ts:2351-2353` pulls switches fresh from `ConfigStore`
+inside the spawn function:
 
-`task-spawner.ts` already passes `switches.model` to `--model` (lines
-76–78). No spawner changes are needed once the resolved model lands in the
-switches object.
+```ts
+const switches = this.configStore.getClaudeCodeSwitches();
+const switchArgs = buildClaudeCodeSwitchArgs(switches);
+```
 
-### Validation
+There is no per-task switches override path. v1 introduces one in three
+small steps:
 
-- The MCP layer enforces `complexity ∈ {'low', 'medium', 'high'}` via
-  `z.enum`. Invalid values are rejected by the SDK before the handler runs.
-- The `task:create` handler additionally validates `complexity` if present
-  (defense in depth, since the WS endpoint is reachable by sources other
-  than the MCP server). Invalid value → reject with a clear error message
-  so a misbehaving caller learns.
+1. **Add a parameter** to `TaskSpawner.createTask`:
 
-### Conflicts with explicit model
+   ```ts
+   async createTask(
+       prompt: string,
+       workspaceId: string,
+       systemPrompt?: string,
+       initialCols?: number,
+       initialRows?: number,
+       modelOverride?: string,   // NEW
+   ): Promise<Task>
+   ```
 
-If a `task:create` payload somehow contains both `complexity` and an
-explicit `claudeCodeSwitches.model` override, `complexity` wins. The MCP
-server is the only documented producer of `complexity` and it never sets
-`model` directly, so this conflict should be rare.
+   Forward it to `createTaskWithClaudeCode` (same signature suffix). The
+   `createTaskWithOpenCode` path ignores it for v1 (logs a debug line).
+
+2. **Apply the override** inside `createTaskWithClaudeCode`, replacing the
+   existing block at line 2351:
+
+   ```ts
+   if (this.configStore) {
+       let switches = this.configStore.getClaudeCodeSwitches();
+       if (modelOverride && modelOverride.trim()) {
+           switches = { ...switches, defaultModel: modelOverride.trim() };
+           logger.info('Per-task model override', { taskId: id, model: modelOverride.trim() });
+       }
+       const switchArgs = buildClaudeCodeSwitchArgs(switches);
+       ...
+   }
+   ```
+
+   `buildClaudeCodeSwitchArgs` already pushes `--model switches.defaultModel`
+   at `task-spawner.ts:77-78` — no change there.
+
+3. **Resolve at the WS handler** (`server.ts` task:create case at line 1068).
+   Accept optional `complexity` in the payload, resolve via
+   `configStore.resolveModelForComplexity(complexity)`, and pass the result
+   as the new `modelOverride` argument.
+
+## MCP server changes
+
+The MCP server is a separate process spawned by Claude Code. Its env is
+constructed in `task-spawner.ts:539-544`:
+
+```ts
+const mcpEnv: Record<string, string> = {};
+if (workspaceId) mcpEnv.CLAUDIA_WORKSPACE_ID = workspaceId;
+if (taskId) mcpEnv.CLAUDIA_TASK_ID = taskId;
+```
+
+Add one line: when `configStore.getModelTiering().enabled` is true, set
+`mcpEnv.CLAUDIA_MODEL_TIERING_ENABLED = '1'`.
+
+In `claudia-mcp-server.ts`, read the env var at startup:
+
+```ts
+const MODEL_TIERING_ENABLED = process.env.CLAUDIA_MODEL_TIERING_ENABLED === '1';
+```
+
+`claudia_create_task` registration becomes conditional on that flag:
+
+- **Disabled (default):** schema unchanged. No `complexity` parameter.
+- **Enabled:** add an optional `complexity: z.enum(['low', 'medium', 'high'])`
+  with a description explaining the tiers. Append a short paragraph to the
+  tool's top-level description so the agent knows it can pass complexity to
+  control cost.
+
+When the agent passes `complexity`, the MCP server forwards it in the
+`task:create` WS payload alongside `prompt` and `workspaceId`.
+
+### Mid-session toggle behavior
+
+Each top-level task spawns one Claude Code subprocess, which spawns one
+`claudia-mcp-server` subprocess (`task-spawner.ts:529-547`). So:
+
+- Tasks created **after** the toggle flips get the new env var → MCP
+  schema reflects the new state.
+- Tasks already running (and any sub-tasks they spawn through their child
+  MCP server) keep the old schema until they're stopped/restarted.
+
+This is acceptable — the toggle is rarely flipped.
 
 ## UI
 
-In the Settings dialog, add a new section: **Model tiering**.
+In Settings, add a new section under the existing "Claude Code Switches"
+area. One toggle and three text inputs:
 
-- One checkbox: "Allow agents to select model by task complexity"
-  (off by default).
-- When checked, three rows appear, each labeled `Low`, `Medium`, `High`,
-  with a single text input pre-filled with `haiku`, `sonnet`, `opus`. (Text
-  input rather than dropdown to match the existing `defaultModel` field's
-  style and accept arbitrary aliases.)
-- A short helper line: *"Spawned tasks tagged with a complexity tier will
-  use the corresponding model. Leave a field empty to use the workspace
-  default for that tier."*
+- Checkbox: **"Enable model tiering for spawned tasks"** (off by default).
+- When checked, three rows appear: `Low`, `Medium`, `High`, each with a
+  text input. Pre-filled with `haiku` / `sonnet` / `opus`.
+- Helper text:
 
-The same section appears in workspace settings, with one extra control per
-field: an "Inherit from global" checkbox. When inherited, the field is
-disabled and shows the global value greyed-out.
+  > *Spawned tasks (via the Claudia MCP) can pass a complexity hint that
+  > maps to one of these models. Use values your current API mode accepts —
+  > for SAP AI Core or Hyperspace proxies, use fully-qualified Anthropic
+  > model IDs (e.g., `claude-3-5-haiku-20241022`).*
 
-No new screens, modals, or routes. One section in an existing dialog.
+Note for operators: the existing `claudeCodeSwitches.effortLevel` field
+(`low` / `medium` / `high`) sits in the same Settings tab and may visually
+sit close to this section. Label this section clearly as
+**"Model tiering"** to keep them distinct.
+
+## Validation
+
+- MCP layer enforces `complexity ∈ {'low','medium','high'}` via `z.enum`.
+- The `task:create` WS handler validates `complexity` if present (defense in
+  depth, since the WS is reachable by sources other than the MCP server).
+  Invalid values get rejected with a clear error.
+- Tier strings written from the UI go through trim + length cap; no
+  shell-meta validation needed since `--model` argv is passed without shell
+  interpretation.
 
 ## Logging
 
-- When a task is spawned with a tier, log:
+- Spawned with override:
   `[task:create] complexity=high → model="opus" (workspace=<id>)`
-- When mode is disabled and the agent passes `complexity` anyway, log a
-  single line at debug level so the operator can spot agents trying to use
-  the feature: `[task:create] complexity ignored (mode disabled)`
-- When a tier maps to an empty string and we fall through, log a warning:
+- Mode disabled but `complexity` passed:
+  `[task:create] complexity ignored (mode disabled)`
+- Tier mapping empty:
   `[task:create] complexity=low has empty mapping; using default model`
+- OpenCode + override (rare):
+  `[opencode] modelOverride ignored (not yet supported)`
+
+## Cost tracking interaction
+
+The token-usage dashboard (current branch: `feat/token-usage-dashboard`)
+attributes cost based on the spawned process's actual usage events, not on
+the configured `defaultModel`. Tier-based spawns surface in cost reports
+under their *actual* model, which is exactly the desired behavior — cheaper
+tasks show up cheaper.
 
 ## Testing
 
-### Backend (test-cli)
+### Unit (existing test infra)
 
-Add `--complexity <low|medium|high>` to `backend/test-cli.ts`. The flag is
-passed through to the `task:create` request alongside the prompt.
+Pure-function tests are realistic; there is no `task-spawner.test.ts` and
+no `node-pty.spawn` mock infrastructure today.
 
-Cases to verify (in `backend/src/__tests__/`):
+In `config-store.test.ts`:
+1. `getModelTiering()` returns defaults on a fresh config.
+2. `resolveModelForComplexity` returns `undefined` when disabled.
+3. `resolveModelForComplexity('high')` returns `'opus'` with default config
+   when enabled.
+4. `resolveModelForComplexity('low')` returns `undefined` when
+   `tiers.low === ''` (fall-through behavior).
+5. Custom mappings persist through save → load.
 
-1. **Mode disabled, complexity passed** — task spawns with the default
-   model; complexity is ignored; debug log emitted.
-2. **Mode enabled, complexity = "high"** — task spawns with `--model opus`
-   on its argv (or whatever `tiers.high` is configured to).
-3. **Mode enabled, complexity omitted** — task spawns with the default
-   model.
-4. **Mode enabled, invalid complexity (`"medium-rare"`)** — `task:create`
-   rejected with a clear error.
-5. **Mode enabled at global, disabled at workspace** — workspace override
-   wins; complexity is ignored.
-6. **Mode enabled, tier mapping empty (`tiers.low = ""`)** — falls through
-   to default model with a warning logged.
+### End-to-end (test-cli)
 
-Where feasible, assert on the spawned process's argv (the existing
-`task-spawner.ts` test patterns already do this).
+Add a `--complexity <low|medium|high>` flag to `backend/test-cli.ts`. The
+flag is passed in the `task:create` payload.
 
-### MCP layer
-
-Unit-test the schema-shape decision in `claudia-mcp-server.ts`:
-
-- When `enabled === false`, the registered tool's input schema does NOT
-  include `complexity`.
-- When `enabled === true`, the schema includes `complexity` with the three
-  valid enum values.
+Manual matrix:
+- Tiering disabled + `--complexity high` → log shows complexity ignored;
+  task spawns with default model.
+- Tiering enabled + `--complexity high` → log shows
+  `complexity=high → model="opus"`; spawned argv contains `--model opus`.
+- Tiering enabled + no flag → log shows no override; default model used.
+- Tiering enabled + `--complexity bogus` → CLI rejects (z.enum on the WS
+  side will reject too).
 
 ### UI
 
-Manual visual check only — one checkbox, three text inputs, one helper
-line. Verify the inputs hide/show with the toggle and that workspace
-inherit behavior matches the existing `systemPrompt` pattern.
+Manual visual check: toggle reveals/hides the three fields, helper text
+visible, save persists.
 
 ## Risks & rollback
 
-- **Risk:** An agent passes `complexity: "low"` for a task that genuinely
-  needs reasoning power, leading to a poor result. *Mitigation:* The
-  feature is opt-in. Operators who don't trust their agents' judgment leave
-  it off. The tool description steers the agent toward conservative use.
-- **Risk:** A misconfigured tier (e.g., `high` mapped to a deprecated model
-  ID) breaks all `complexity: "high"` spawns. *Mitigation:* Logging plus
-  the empty-string fall-through. The operator can flip the toggle off to
-  immediately revert to today's behavior.
-- **Rollback:** Set `modelTiering.enabled = false` in global config. All
-  spawned tasks revert to today's model resolution. No data migration
-  needed.
+- **Risk:** Agent picks a too-cheap tier for a hard task. *Mitigation:*
+  feature is opt-in; the tool description steers conservatively.
+- **Risk:** Tier mapping invalid for the user's `apiMode`. *Mitigation:*
+  helper text + empty-string fall-through; flipping the toggle off
+  immediately reverts.
+- **Risk:** OpenCode user enables tiering and is surprised the hint is
+  ignored. *Mitigation:* debug log; documented as a v1 limitation.
+- **Rollback:** `modelTiering.enabled = false` reverts behavior. No
+  migration to undo.
 
-## Open questions
+## Future work
 
-- Should the per-workspace UI initially ship as "inherit only" (no override
-  surface), with override added in a follow-up? Probably not — the override
-  is cheap to build and the spec is cleaner with it included from v1.
-- Future work: surface the spawning agent's `complexity` choice in the task
-  list UI (small badge next to the task name) so operators can see at a
-  glance which tasks are running cheap vs. expensive. Out of scope for v1.
+- Per-workspace overrides.
+- OpenCode backend support.
+- Surface the spawning agent's complexity choice in the task list UI.
+- Per-`apiMode` default tier mappings (so SAP AI Core / Hyperspace users
+  get sensible defaults out of the box).

--- a/frontend/src/components/SettingsMenu.tsx
+++ b/frontend/src/components/SettingsMenu.tsx
@@ -138,6 +138,13 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
     });
     const cliSwitchesTimerRef = useRef<NodeJS.Timeout | null>(null);
 
+    // Model tiering: lets MCP-spawned tasks pick a model based on a complexity hint.
+    const [modelTiering, setModelTiering] = useState({
+        enabled: false,
+        tiers: { low: 'haiku', medium: 'sonnet', high: 'opus' },
+    });
+    const modelTieringTimerRef = useRef<NodeJS.Timeout | null>(null);
+
     // Debounce timers
     const rulesTimerRef = useRef<NodeJS.Timeout | null>(null);
     const supervisorPromptTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -353,6 +360,17 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                         appendSystemPrompt: config.claudeCodeSwitches.appendSystemPrompt || '',
                         effortLevel: config.claudeCodeSwitches.effortLevel || 'high',
                         defaultModel: config.claudeCodeSwitches.defaultModel || (config.claudeCodeSwitches as any).model || '',
+                    });
+                }
+
+                if (config.modelTiering) {
+                    setModelTiering({
+                        enabled: config.modelTiering.enabled || false,
+                        tiers: {
+                            low: config.modelTiering.tiers?.low || 'haiku',
+                            medium: config.modelTiering.tiers?.medium || 'sonnet',
+                            high: config.modelTiering.tiers?.high || 'opus',
+                        },
                     });
                 }
             }
@@ -749,6 +767,42 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
             return updated;
         });
     }, [saveCliSwitches]);
+
+    const saveModelTiering = useCallback(async (cfg: typeof modelTiering) => {
+        try {
+            const response = await fetch(`${getApiBaseUrl()}/api/config`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ modelTiering: cfg })
+            });
+            if (!response.ok) {
+                console.error('Failed to save model tiering');
+            }
+        } catch (error) {
+            console.error('Failed to save model tiering:', error);
+        }
+    }, []);
+
+    const handleModelTieringToggle = useCallback((enabled: boolean) => {
+        setModelTiering(prev => {
+            const updated = { ...prev, enabled };
+            saveModelTiering(updated);
+            return updated;
+        });
+    }, [saveModelTiering]);
+
+    const handleModelTieringTierChange = useCallback((tier: 'low' | 'medium' | 'high', value: string) => {
+        setModelTiering(prev => {
+            const updated = { ...prev, tiers: { ...prev.tiers, [tier]: value } };
+            if (modelTieringTimerRef.current) {
+                clearTimeout(modelTieringTimerRef.current);
+            }
+            modelTieringTimerRef.current = setTimeout(() => {
+                saveModelTiering(updated);
+            }, 500);
+            return updated;
+        });
+    }, [saveModelTiering]);
 
     const saveBackend = useCallback(async (backendType: BackendType) => {
         try {
@@ -2238,6 +2292,73 @@ export function SettingsMenu({ isOpen, onClose, initialPanel }: SettingsMenuProp
                                     onChange={(e) => handleCliSwitchChange({ defaultModel: e.target.value })}
                                 />
                             </div>
+
+                            {/* Model Tiering */}
+                            <div className="permission-item">
+                                <div className="permission-info">
+                                    <span className="permission-label">Model Tiering</span>
+                                    <span className="permission-description">
+                                        Let agents passing through the Claudia MCP tag spawned tasks with a complexity tier (low/medium/high) that maps to a cheaper or stronger model. Use values valid for your current API mode — for SAP AI Core or Hyperspace proxies, use full model IDs (e.g. claude-3-5-haiku-20251001).
+                                    </span>
+                                </div>
+                                <label className="toggle-switch">
+                                    <input
+                                        type="checkbox"
+                                        checked={modelTiering.enabled}
+                                        onChange={(e) => handleModelTieringToggle(e.target.checked)}
+                                    />
+                                    <span className="toggle-slider"></span>
+                                </label>
+                            </div>
+                            {modelTiering.enabled && (
+                                <>
+                                    <div className="permission-item">
+                                        <div className="permission-info">
+                                            <span className="permission-label">Low complexity</span>
+                                            <span className="permission-description">
+                                                Trivial lookups, formatting, single-file reads.
+                                            </span>
+                                        </div>
+                                        <input
+                                            type="text"
+                                            className="cli-switch-text-input"
+                                            value={modelTiering.tiers.low}
+                                            placeholder="haiku"
+                                            onChange={(e) => handleModelTieringTierChange('low', e.target.value)}
+                                        />
+                                    </div>
+                                    <div className="permission-item">
+                                        <div className="permission-info">
+                                            <span className="permission-label">Medium complexity</span>
+                                            <span className="permission-description">
+                                                Normal coding, refactors, writing tests.
+                                            </span>
+                                        </div>
+                                        <input
+                                            type="text"
+                                            className="cli-switch-text-input"
+                                            value={modelTiering.tiers.medium}
+                                            placeholder="sonnet"
+                                            onChange={(e) => handleModelTieringTierChange('medium', e.target.value)}
+                                        />
+                                    </div>
+                                    <div className="permission-item">
+                                        <div className="permission-info">
+                                            <span className="permission-label">High complexity</span>
+                                            <span className="permission-description">
+                                                Tricky architecture, gnarly debugging, careful reasoning.
+                                            </span>
+                                        </div>
+                                        <input
+                                            type="text"
+                                            className="cli-switch-text-input"
+                                            value={modelTiering.tiers.high}
+                                            placeholder="opus"
+                                            onChange={(e) => handleModelTieringTierChange('high', e.target.value)}
+                                        />
+                                    </div>
+                                </>
+                            )}
 
                             {/* Max Turns */}
                             <div className="permission-item">

--- a/scripts/demo-model-tiering.sh
+++ b/scripts/demo-model-tiering.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Demo: complexity-based model selection for spawned tasks.
+#
+# Spawns three short-lived tasks (one per complexity tier) and inspects
+# the resulting `claude` process argv to confirm each one was launched
+# with the configured model. Restores the prior tiering state on exit.
+#
+# Requires: the Claudia backend running on http://localhost:4001.
+
+set -euo pipefail
+
+API=http://localhost:4001
+WORKSPACE=/tmp/claudia-tier-demo
+BACKEND_DIR="$(cd "$(dirname "$0")/.." && pwd)/backend"
+
+cleanup() {
+    echo
+    echo "[cleanup] restoring prior tiering state and removing demo workspace…"
+    if [[ -n "${PRIOR_CFG:-}" ]]; then
+        curl -s -X PUT "$API/api/config" -H 'Content-Type: application/json' -d "{\"modelTiering\":$PRIOR_CFG}" > /dev/null
+    fi
+    if [[ -n "${SPAWNED_PIDS:-}" ]]; then
+        for pid in $SPAWNED_PIDS; do
+            kill -9 "$pid" 2>/dev/null || true
+        done
+    fi
+    rm -rf "$WORKSPACE"
+}
+trap cleanup EXIT
+
+echo "[1/4] saving current modelTiering config…"
+PRIOR_CFG=$(curl -fsS "$API/api/config" | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin).get("modelTiering",{"enabled":False,"tiers":{"low":"haiku","medium":"sonnet","high":"opus"}})))')
+echo "  prior: $PRIOR_CFG"
+
+echo "[2/4] enabling tiering with defaults (haiku / sonnet / opus)…"
+curl -fsS -X PUT "$API/api/config" -H 'Content-Type: application/json' \
+  -d '{"modelTiering":{"enabled":true,"tiers":{"low":"haiku","medium":"sonnet","high":"opus"}}}' > /dev/null
+
+mkdir -p "$WORKSPACE"
+( cd "$WORKSPACE" && [ -d .git ] || git init -q )
+
+SPAWNED_PIDS=""
+MODEL_LOW=""
+MODEL_MEDIUM=""
+MODEL_HIGH=""
+
+spawn_and_inspect() {
+    tier=$1
+    # 4s timeout — we just need the spawn to start; we kill it on cleanup.
+    ( cd "$BACKEND_DIR" && npx tsx test-cli.ts --task -m "echo $tier-tier-demo" -n "demo-$tier" -w "$WORKSPACE" --complexity "$tier" -t 4000 ) > /dev/null 2>&1 || true
+
+    # Find the most recent claude process spawned by this run.
+    pid=$(ps -o pid,args -ax | grep "claude --" | grep -v grep | grep -E -- "--model [^ ]+" | grep -v reconnect | tail -1 | awk '{print $1}')
+    model=$(ps -o args= -p "$pid" 2>/dev/null | grep -oE -- '--model [^ ]+' | awk '{print $2}' || echo '?')
+    SPAWNED_PIDS="$SPAWNED_PIDS $pid"
+    case $tier in
+        low)    MODEL_LOW="$model" ;;
+        medium) MODEL_MEDIUM="$model" ;;
+        high)   MODEL_HIGH="$model" ;;
+    esac
+    printf "  complexity=%-7s → spawned PID %s with --model %s\n" "$tier" "$pid" "$model"
+}
+
+echo "[3/4] spawning one task per tier and inspecting argv…"
+spawn_and_inspect low
+spawn_and_inspect medium
+spawn_and_inspect high
+
+echo
+echo "[4/4] result"
+echo "  tier   | configured | observed"
+echo "  -------+------------+----------"
+printf "  low    | haiku      | %s\n" "${MODEL_LOW:-?}"
+printf "  medium | sonnet     | %s\n" "${MODEL_MEDIUM:-?}"
+printf "  high   | opus       | %s\n" "${MODEL_HIGH:-?}"
+echo
+if [ "$MODEL_LOW" = "haiku" ] && [ "$MODEL_MEDIUM" = "sonnet" ] && [ "$MODEL_HIGH" = "opus" ]; then
+    echo "✅ all three tiers mapped through to --model correctly."
+else
+    echo "❌ at least one tier did not match the configured model. Review the output above."
+fi


### PR DESCRIPTION
## Summary
- Adds an optional `complexity` parameter (low/medium/high) to the `claudia_create_task` MCP tool that maps to a configurable model per tier, letting orchestrating agents downsize trivial work to cheaper models
- **Off by default.** Configured under Settings → Claude Code CLI Switches → Model Tiering. When disabled the parameter is not even exposed on the MCP tool, so agents can't pick a tier they shouldn't be touching
- Default tier mapping uses the `haiku` / `sonnet` / `opus` aliases, but operators can plug in full model IDs (e.g. for SAP AI Core or Hyperspace proxies)

## Changes

### Backend
- **`config-store.ts`** — `ModelTieringConfig` (enabled flag + low/medium/high → model map), `getModelTiering` / `setModelTiering` / `resolveModelForComplexity` accessors, partial-update merge that doesn't blow away tier mappings when only flipping `enabled`. Also coerces legacy `claude-opus-latest` → `opus` alias on load.
- **`task-spawner.ts`** — Threads a `modelOverride: string` arg through `createTask` → `createTaskWithClaudeCode`, which appends `--model <X>` to the spawned `claude` argv. Also passes `CLAUDIA_MODEL_TIERING_ENABLED=1` into the MCP server's env when tiering is on.
- **`claudia-mcp-server.ts`** — `claudia_create_task` conditionally exposes the `complexity` parameter based on the env var. Tool description teaches agents when each tier is appropriate.
- **`server.ts`** — `task:create` WS handler validates `complexity`, resolves it via `resolveModelForComplexity`, and passes the resulting model down to the spawner.
- **`validation.ts`** — Schema validation for `modelTiering` in `PUT /api/config`.

### Frontend
- **`SettingsMenu.tsx`** — Model Tiering toggle + three text inputs (low/medium/high) with debounced save, conditionally rendered when enabled.

### Test/dev
- **`backend/test-cli.ts`** — New `--complexity <low|medium|high>` flag for `--task` mode.
- **`scripts/demo-model-tiering.sh`** — End-to-end smoke test: flips tiering on, spawns 3 tasks (one per tier), inspects each spawned `claude` process's argv to confirm `--model` matches the configured tier, restores prior config on exit.
- **`backend/src/__tests__/config-store.test.ts`** — 10 new tests covering tier resolution, enabled-gate behavior, persistence, partial updates, and trimming.

### Docs
- **`docs/superpowers/specs/2026-05-01-model-tiering-design.md`** — Full design spec.

## Test plan
- [x] `npx vitest run` in backend — all 333 tests pass (10 new modelTiering tests included)
- [x] `tsc --noEmit` clean on both backend and frontend
- [ ] Settings → toggle Model Tiering on, change one tier, reload page → values persist
- [ ] With tiering off: spawn a task via MCP from another agent → no `complexity` parameter visible on `claudia_create_task`
- [ ] With tiering on: spawn a task with `complexity: low` via MCP → spawned `claude` process has `--model haiku` in argv (run `scripts/demo-model-tiering.sh` for an automated check across all 3 tiers)
- [ ] Pass an invalid `complexity` via WS task:create → server rejects with `INVALID_COMPLEXITY` error
- [ ] Toggle only `enabled` off via API → existing tier mappings survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)