### PR TITLE
fix: plus button opens workspace panel instead of file browser

### DIFF
--- a/frontend/src/components/WorkspacePanel.tsx
+++ b/frontend/src/components/WorkspacePanel.tsx
@@ -1641,7 +1641,7 @@ export function WorkspacePanel({
     }, [waitingInputNotifications]);
 
     const handleAddWorkspace = () => {
-        setShowProjectPicker(true);
+        setShowWorkspaceManager(true);
     };
 
     const handleToggleArchivedTasks = () => {


### PR DESCRIPTION
## Summary
- In Electron mode, clicking the + button was immediately launching the native file dialog
- Now it opens the workspace manager panel which provides a richer interface for adding workspaces (browse, manual path input, search)

## Test plan
- [ ] Click the + button in the Electron app sidebar
- [ ] Verify the workspace manager panel opens (not the native file browser)
- [ ] Confirm you can still add workspaces via the panels Add Workspace button