### PR TITLE
test: close coverage gaps + add per-file coverage gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,8 +101,8 @@ jobs:
           }
           Write-Host "All PowerShell scripts are valid"
 
-      - name: Run backend unit tests
-        run: npm test -w backend
+      - name: Run backend unit tests (with coverage gate)
+        run: npm run test:coverage -w backend
 
-      - name: Run frontend unit tests
-        run: npm test -w frontend
+      - name: Run frontend unit tests (with coverage gate)
+        run: npm run test:coverage -w frontend

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 release/
 *.tsbuildinfo
 
+# Coverage reports
+coverage/
+
 # IDE
 .idea/
 .vscode/

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "@types/ws": "^8.5.10",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "@vitest/coverage-v8": "^3.2.4"
   }
 }

--- a/backend/src/__tests__/atomic-write.test.ts
+++ b/backend/src/__tests__/atomic-write.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+describe('atomicWriteFileSync', () => {
+    let testBaseDir: string;
+
+    beforeEach(() => {
+        const uniqueId = Date.now() + '-' + Math.random().toString(36).substring(7);
+        testBaseDir = join(homedir(), '.claudia-atomic-write-test-' + uniqueId);
+        mkdirSync(testBaseDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        try {
+            rmSync(testBaseDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        } catch {
+            // Ignore cleanup errors
+        }
+    });
+
+    describe('basic writes', () => {
+        it('writes string data to a new file', () => {
+            const filePath = join(testBaseDir, 'file.txt');
+            atomicWriteFileSync(filePath, 'hello world');
+            expect(existsSync(filePath)).toBe(true);
+            expect(readFileSync(filePath, 'utf-8')).toBe('hello world');
+        });
+
+        it('writes Buffer data to a new file', () => {
+            const filePath = join(testBaseDir, 'buffer.bin');
+            const buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+            atomicWriteFileSync(filePath, buf);
+            expect(existsSync(filePath)).toBe(true);
+            const read = readFileSync(filePath);
+            expect(Buffer.compare(read, buf)).toBe(0);
+        });
+
+        it('overwrites an existing file with new content', () => {
+            const filePath = join(testBaseDir, 'overwrite.txt');
+            writeFileSync(filePath, 'old content that is longer');
+            atomicWriteFileSync(filePath, 'new');
+            expect(readFileSync(filePath, 'utf-8')).toBe('new');
+        });
+
+        it('respects a custom encoding for string payloads', () => {
+            const filePath = join(testBaseDir, 'encoded.txt');
+            // 'hello' as base64 is 'aGVsbG8='; writing that string with base64
+            // encoding decodes it to the raw bytes 'hello'.
+            atomicWriteFileSync(filePath, 'aGVsbG8=', { encoding: 'base64' });
+            expect(readFileSync(filePath, 'utf-8')).toBe('hello');
+        });
+
+        it('handles empty string content', () => {
+            const filePath = join(testBaseDir, 'empty.txt');
+            atomicWriteFileSync(filePath, '');
+            expect(existsSync(filePath)).toBe(true);
+            expect(readFileSync(filePath, 'utf-8')).toBe('');
+        });
+    });
+
+    describe('directory creation', () => {
+        it('creates missing parent directories', () => {
+            const filePath = join(testBaseDir, 'nested', 'deep', 'file.txt');
+            atomicWriteFileSync(filePath, 'data');
+            expect(existsSync(filePath)).toBe(true);
+            expect(readFileSync(filePath, 'utf-8')).toBe('data');
+        });
+    });
+
+    describe('temp-file cleanup', () => {
+        it('leaves no .tmp file behind after a successful write', () => {
+            const filePath = join(testBaseDir, 'clean.txt');
+            atomicWriteFileSync(filePath, 'content');
+            const leftovers = readdirSync(testBaseDir).filter((f) => f.includes('.tmp'));
+            expect(leftovers).toEqual([]);
+        });
+
+        it('cleans up the temp file and preserves the original on rename failure', () => {
+            // Make the target path a directory so renameSync onto it fails.
+            const filePath = join(testBaseDir, 'target');
+            mkdirSync(filePath);
+
+            expect(() => atomicWriteFileSync(filePath, 'data')).toThrow();
+
+            // No stray .tmp files left in the dir.
+            const leftovers = readdirSync(testBaseDir).filter((f) => f.includes('.tmp'));
+            expect(leftovers).toEqual([]);
+            // The original directory is untouched.
+            expect(existsSync(filePath)).toBe(true);
+        });
+    });
+
+    describe('backup option', () => {
+        it('does not create a .bak file by default', () => {
+            const filePath = join(testBaseDir, 'nobak.txt');
+            writeFileSync(filePath, 'v1');
+            atomicWriteFileSync(filePath, 'v2');
+            expect(existsSync(`${filePath}.bak`)).toBe(false);
+            expect(readFileSync(filePath, 'utf-8')).toBe('v2');
+        });
+
+        it('rolls the previous file to .bak when backup is enabled', () => {
+            const filePath = join(testBaseDir, 'withbak.txt');
+            writeFileSync(filePath, 'previous');
+            atomicWriteFileSync(filePath, 'current', { backup: true });
+
+            expect(readFileSync(filePath, 'utf-8')).toBe('current');
+            expect(existsSync(`${filePath}.bak`)).toBe(true);
+            expect(readFileSync(`${filePath}.bak`, 'utf-8')).toBe('previous');
+        });
+
+        it('does not create a .bak when target does not exist yet, even with backup', () => {
+            const filePath = join(testBaseDir, 'fresh.txt');
+            atomicWriteFileSync(filePath, 'first', { backup: true });
+            expect(readFileSync(filePath, 'utf-8')).toBe('first');
+            expect(existsSync(`${filePath}.bak`)).toBe(false);
+        });
+
+        it('overwrites a stale .bak on a subsequent backup write', () => {
+            const filePath = join(testBaseDir, 'rolling.txt');
+            writeFileSync(filePath, 'gen1');
+            atomicWriteFileSync(filePath, 'gen2', { backup: true });
+            atomicWriteFileSync(filePath, 'gen3', { backup: true });
+
+            expect(readFileSync(filePath, 'utf-8')).toBe('gen3');
+            // .bak should now hold the most recent previous good file (gen2).
+            expect(readFileSync(`${filePath}.bak`, 'utf-8')).toBe('gen2');
+        });
+    });
+
+    describe('error behavior', () => {
+        it('throws when the temp file cannot be written', () => {
+            // Point at a path whose parent is a file, not a directory.
+            const fileAsParent = join(testBaseDir, 'iamafile');
+            writeFileSync(fileAsParent, 'x');
+            const filePath = join(fileAsParent, 'child.txt');
+            expect(() => atomicWriteFileSync(filePath, 'data')).toThrow();
+        });
+    });
+});

--- a/backend/src/__tests__/conversation-parser.test.ts
+++ b/backend/src/__tests__/conversation-parser.test.ts
@@ -7,6 +7,7 @@ import {
     findSessionFile,
     findRecentSessionFiles,
     getWorkspaceSessions,
+    getConversationHistory,
 } from '../conversation-parser.js';
 
 describe('parseConversationFile', () => {
@@ -424,5 +425,407 @@ describe('getWorkspaceSessions', () => {
         expect(result).toHaveLength(1);
         expect(result[0].sessionId).toBe('no-summary-session');
         expect(result[0].summary).toBeUndefined();
+    });
+
+    it('should return claude sessions when backendType is claude-code', async () => {
+        const projectsDir = join(testHome, '.claude', 'projects', '-test-workspace');
+        mkdirSync(projectsDir, { recursive: true });
+
+        const sessionContent = [
+            JSON.stringify({ type: 'summary', summary: 'CC only' }),
+        ].join('\n');
+        writeFileSync(join(projectsDir, 'cc-session.jsonl'), sessionContent);
+
+        const result = await getWorkspaceSessions(testWorkspace, 'claude-code');
+
+        expect(result).toHaveLength(1);
+        expect(result[0].sessionId).toBe('cc-session');
+        expect(result[0].summary).toBe('CC only');
+    });
+});
+
+// ================== Additional parseConversationFile branch coverage ==================
+
+describe('parseConversationFile (additional branches)', () => {
+    const testDir = join(tmpdir(), 'claudia-conv-extra-test-' + Date.now());
+    const testFile = join(testDir, 'extra-session.jsonl');
+
+    beforeEach(() => {
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    });
+
+    it('should default timestamp to empty string when missing', async () => {
+        const content = JSON.stringify({
+            type: 'user',
+            uuid: 'no-ts',
+            message: { role: 'user', content: 'No timestamp here' },
+        });
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0].timestamp).toBe('');
+    });
+
+    it('should ignore user entries missing uuid', async () => {
+        const content = JSON.stringify({
+            type: 'user',
+            message: { role: 'user', content: 'No uuid so skipped' },
+        });
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.messages).toHaveLength(0);
+    });
+
+    it('should ignore assistant entries missing message', async () => {
+        const content = JSON.stringify({
+            type: 'assistant',
+            uuid: 'a-no-msg',
+        });
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.messages).toHaveLength(0);
+    });
+
+    it('should keep first summary when multiple summaries appear', async () => {
+        const content = [
+            JSON.stringify({ type: 'summary', summary: 'First summary' }),
+            JSON.stringify({ type: 'summary', summary: 'Second summary' }),
+        ].join('\n');
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        // Later summaries overwrite earlier ones (assignment, no guard)
+        expect(result.summary).toBe('Second summary');
+    });
+
+    it('should ignore unrecognized array content part types', async () => {
+        const content = JSON.stringify({
+            type: 'assistant',
+            uuid: 'mixed',
+            message: {
+                role: 'assistant',
+                content: [
+                    { type: 'tool_use', text: 'should be ignored' },
+                    { type: 'text', text: 'Visible text' },
+                    { type: 'image' },
+                ],
+            },
+        });
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0].content).toBe('Visible text');
+        expect(result.messages[0].thinking).toBeUndefined();
+    });
+
+    it('should handle CRLF line endings', async () => {
+        const content = [
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'line one' } }),
+            JSON.stringify({ type: 'assistant', uuid: 'a1', message: { role: 'assistant', content: 'line two' } }),
+        ].join('\r\n');
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.messages).toHaveLength(2);
+        expect(result.messages[0].content).toBe('line one');
+        expect(result.messages[1].content).toBe('line two');
+    });
+
+    it('should not capture session id from later entries once set', async () => {
+        const content = [
+            JSON.stringify({ type: 'init', sessionId: 'first-session' }),
+            JSON.stringify({ type: 'init', sessionId: 'second-session' }),
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'hi' } }),
+        ].join('\n');
+
+        writeFileSync(testFile, content);
+        const result = await parseConversationFile(testFile);
+
+        expect(result.sessionId).toBe('first-session');
+    });
+});
+
+// ================== getConversationHistory ==================
+
+describe('getConversationHistory (Claude Code)', () => {
+    const testHome = join(tmpdir(), 'claudia-gch-test-' + Date.now());
+    const testWorkspace = '/test/workspace';
+    let originalHome: string | undefined;
+
+    beforeEach(() => {
+        originalHome = process.env.HOME;
+        process.env.HOME = testHome;
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        rmSync(testHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    });
+
+    it('should return null when claude-code session file is missing', async () => {
+        const result = await getConversationHistory(testWorkspace, 'missing-session', 'claude-code');
+        expect(result).toBeNull();
+    });
+
+    it('should parse a claude-code session when backendType specified', async () => {
+        const projectsDir = join(testHome, '.claude', 'projects', '-test-workspace');
+        mkdirSync(projectsDir, { recursive: true });
+
+        const content = [
+            JSON.stringify({ type: 'summary', summary: 'CC convo' }),
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'Hello CC' } }),
+        ].join('\n');
+        writeFileSync(join(projectsDir, 'cc-1.jsonl'), content);
+
+        const result = await getConversationHistory(testWorkspace, 'cc-1', 'claude-code');
+
+        expect(result).not.toBeNull();
+        expect(result!.summary).toBe('CC convo');
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages[0].content).toBe('Hello CC');
+    });
+
+    it('should auto-detect claude-code when no backendType and file exists', async () => {
+        const projectsDir = join(testHome, '.claude', 'projects', '-test-workspace');
+        mkdirSync(projectsDir, { recursive: true });
+
+        const content = JSON.stringify({
+            type: 'assistant',
+            uuid: 'a1',
+            message: { role: 'assistant', content: 'Auto detected' },
+        });
+        writeFileSync(join(projectsDir, 'auto-1.jsonl'), content);
+
+        const result = await getConversationHistory(testWorkspace, 'auto-1');
+
+        expect(result).not.toBeNull();
+        expect(result!.messages[0].content).toBe('Auto detected');
+    });
+
+    it('should auto-detect OpenCode for ses_ prefixed ids and return null when missing', async () => {
+        // No opencode storage exists under the temp HOME -> null
+        const result = await getConversationHistory(testWorkspace, 'ses_abc123');
+        expect(result).toBeNull();
+    });
+
+    it('should fall back to OpenCode (null) when claude-code lookup fails in auto-detect', async () => {
+        const result = await getConversationHistory(testWorkspace, 'nonexistent-uuid');
+        expect(result).toBeNull();
+    });
+});
+
+// ================== OpenCode backend ==================
+
+describe('OpenCode conversation history & sessions', () => {
+    const testHome = join(tmpdir(), 'claudia-oc-test-' + Date.now());
+    let originalHome: string | undefined;
+
+    const storageDir = () => join(testHome, '.local', 'share', 'opencode', 'storage');
+
+    function writeMessage(sessionId: string, msg: Record<string, unknown>) {
+        const dir = join(storageDir(), 'message', sessionId);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, `${msg.id}.json`), JSON.stringify(msg));
+    }
+
+    function writePart(sessionId: string, part: Record<string, unknown>) {
+        const dir = join(storageDir(), 'part', sessionId);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, `${part.id}.json`), JSON.stringify(part));
+    }
+
+    function writeSession(subdir: string, session: Record<string, unknown>) {
+        const dir = join(storageDir(), 'session', subdir);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, `${session.id}.json`), JSON.stringify(session));
+    }
+
+    beforeEach(() => {
+        originalHome = process.env.HOME;
+        process.env.HOME = testHome;
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        rmSync(testHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    });
+
+    it('should return null when message dir is missing', async () => {
+        const result = await getConversationHistory('/ws', 'ses_missing', 'opencode');
+        expect(result).toBeNull();
+    });
+
+    it('should assemble messages from parts (text + thinking)', async () => {
+        const sessionId = 'ses_oc1';
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'user', time: { created: 1000 } });
+        writeMessage(sessionId, { id: 'm2', sessionID: sessionId, role: 'assistant', time: { created: 2000 } });
+
+        writePart(sessionId, { id: 'p1', messageID: 'm1', sessionID: sessionId, type: 'text', text: 'User question', time: { created: 1000 } });
+        writePart(sessionId, { id: 'p2', messageID: 'm2', sessionID: sessionId, type: 'thinking', thinking: 'pondering', time: { created: 2000 } });
+        writePart(sessionId, { id: 'p3', messageID: 'm2', sessionID: sessionId, type: 'text', text: 'Assistant answer', time: { created: 2001 } });
+
+        writeSession('global', { id: sessionId, title: 'OC Session Title' });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.sessionId).toBe(sessionId);
+        expect(result!.summary).toBe('OC Session Title');
+        expect(result!.messages).toHaveLength(2);
+
+        // sorted by time.created ascending
+        expect(result!.messages[0].role).toBe('user');
+        expect(result!.messages[0].content).toBe('User question');
+        expect(result!.messages[0].timestamp).toBe(new Date(1000).toISOString());
+
+        expect(result!.messages[1].role).toBe('assistant');
+        expect(result!.messages[1].content).toBe('Assistant answer');
+        expect(result!.messages[1].thinking).toBe('pondering');
+    });
+
+    it('should fall back to message summary title when no parts found', async () => {
+        const sessionId = 'ses_oc2';
+        writeMessage(sessionId, {
+            id: 'm1',
+            sessionID: sessionId,
+            role: 'assistant',
+            time: { created: 500 },
+            summary: { title: 'Summary fallback content' },
+        });
+        // create an (empty) part dir so the directory-exists checks pass
+        mkdirSync(join(storageDir(), 'part', sessionId), { recursive: true });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages[0].content).toBe('Summary fallback content');
+    });
+
+    it('should emit "(no content)" for user messages with no parts or summary', async () => {
+        const sessionId = 'ses_oc3';
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'user', time: { created: 100 } });
+        mkdirSync(join(storageDir(), 'part', sessionId), { recursive: true });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages[0].role).toBe('user');
+        expect(result!.messages[0].content).toBe('(no content)');
+    });
+
+    it('should skip assistant messages with no content', async () => {
+        const sessionId = 'ses_oc4';
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'assistant', time: { created: 100 } });
+        mkdirSync(join(storageDir(), 'part', sessionId), { recursive: true });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        // assistant with empty content and no summary -> skipped
+        expect(result!.messages).toHaveLength(0);
+    });
+
+    it('should read parts from the global part dir when session part dir is absent', async () => {
+        const sessionId = 'ses_oc5';
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'assistant', time: { created: 100 } });
+        // Only a global part dir exists, not part/<sessionId>
+        writePart('global', { id: 'p1', messageID: 'm1', sessionID: sessionId, type: 'text', text: 'from global parts', time: { created: 100 } });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages[0].content).toBe('from global parts');
+    });
+
+    it('should skip malformed message files', async () => {
+        const sessionId = 'ses_oc6';
+        const dir = join(storageDir(), 'message', sessionId);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, 'bad.json'), 'not json');
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'user', time: { created: 100 } });
+        mkdirSync(join(storageDir(), 'part', sessionId), { recursive: true });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages[0].uuid).toBe('m1');
+    });
+
+    it('should continue past messages when no part dirs exist for the session', async () => {
+        const sessionId = 'ses_oc_nopart';
+        // Message exists, but neither part/<sessionId> nor part/global exists.
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'user', time: { created: 100 } });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        // The `continue` skips the part-search; user message is still skipped
+        // because it has no content -> 0 messages.
+        expect(result!.messages).toHaveLength(0);
+    });
+
+    it('should use slug as summary when title is absent', async () => {
+        const sessionId = 'ses_oc7';
+        writeMessage(sessionId, { id: 'm1', sessionID: sessionId, role: 'user', time: { created: 100 } });
+        writePart(sessionId, { id: 'p1', messageID: 'm1', sessionID: sessionId, type: 'text', text: 'hi', time: { created: 100 } });
+        writeSession('global', { id: sessionId, slug: 'my-slug' });
+
+        const result = await getConversationHistory('/ws', sessionId, 'opencode');
+
+        expect(result).not.toBeNull();
+        expect(result!.summary).toBe('my-slug');
+    });
+
+    it('getWorkspaceSessions should return OpenCode sessions when backendType is opencode', async () => {
+        writeSession('global', { id: 'ses_a', title: 'Session A' });
+        writeSession('proj1', { id: 'ses_b', title: 'Session B' });
+
+        const result = await getWorkspaceSessions('/ws', 'opencode');
+
+        const ids = result.map(r => r.sessionId).sort();
+        expect(ids).toEqual(['ses_a', 'ses_b']);
+        const a = result.find(r => r.sessionId === 'ses_a');
+        expect(a!.summary).toBe('Session A');
+    });
+
+    it('getWorkspaceSessions should return empty when opencode session dir missing', async () => {
+        const result = await getWorkspaceSessions('/ws', 'opencode');
+        expect(result).toEqual([]);
+    });
+
+    it('getWorkspaceSessions (all backends) should merge claude and opencode sessions', async () => {
+        // Claude session
+        const projectsDir = join(testHome, '.claude', 'projects', '-ws');
+        mkdirSync(projectsDir, { recursive: true });
+        writeFileSync(
+            join(projectsDir, 'cc-session.jsonl'),
+            JSON.stringify({ type: 'summary', summary: 'Claude one' })
+        );
+        // OpenCode session
+        writeSession('global', { id: 'ses_x', title: 'OpenCode one' });
+
+        const result = await getWorkspaceSessions('/ws');
+
+        const ids = result.map(r => r.sessionId);
+        expect(ids).toContain('cc-session');
+        expect(ids).toContain('ses_x');
     });
 });

--- a/backend/src/__tests__/git-utils.test.ts
+++ b/backend/src/__tests__/git-utils.test.ts
@@ -15,6 +15,9 @@ import {
     captureGitStateBefore,
     captureGitStateAfter,
     revertTaskChanges,
+    getDefaultBranch,
+    getCurrentBranch,
+    checkoutBranch,
 } from '../git-utils.js';
 
 const execAsync = promisify(exec);
@@ -375,6 +378,224 @@ describe('git-utils', () => {
             const result = await revertTaskChanges(testDir, gitState);
             expect(result.success).toBe(false);
             expect(result.error).toContain('no longer exists');
+        });
+
+        it('should discard uncommitted changes when commit unchanged', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            const commit = await createCommit('Initial commit');
+
+            // Modify a tracked file (the committed one) so checkout -- . restores it
+            const { stdout: lsFiles } = await execAsync('git ls-files', { cwd: testDir });
+            const trackedFile = lsFiles.trim().split('\n')[0];
+            writeFileSync(join(testDir, trackedFile), 'modified content that should be discarded');
+
+            expect(await hasUncommittedChanges(testDir)).toBe(true);
+
+            const gitState = {
+                commitBefore: commit,
+                uncommittedBefore: false,
+                filesModified: [trackedFile],
+                canRevert: true,
+            };
+
+            const result = await revertTaskChanges(testDir, gitState);
+            expect(result.success).toBe(true);
+            expect(result.filesReverted).toEqual([trackedFile]);
+            // HEAD unchanged, uncommitted changes discarded
+            expect(await getHeadCommit(testDir)).toBe(commit);
+            expect(await hasUncommittedChanges(testDir)).toBe(false);
+        });
+
+        it('should clean untracked files when cleanUntracked is true', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            const commit = await createCommit('Initial commit');
+
+            // Add an untracked file
+            writeFileSync(join(testDir, 'untracked-junk.txt'), 'junk');
+            expect(existsSync(join(testDir, 'untracked-junk.txt'))).toBe(true);
+
+            const gitState = {
+                commitBefore: commit,
+                uncommittedBefore: false,
+                filesModified: [],
+                canRevert: true,
+            };
+
+            const result = await revertTaskChanges(testDir, gitState, true);
+            expect(result.success).toBe(true);
+            // Untracked file should be removed
+            expect(existsSync(join(testDir, 'untracked-junk.txt'))).toBe(false);
+        });
+
+        it('should succeed as no-op for clean repo at commitBefore', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            const commit = await createCommit('Initial commit');
+
+            const gitState = {
+                commitBefore: commit,
+                uncommittedBefore: false,
+                filesModified: [],
+                canRevert: true,
+            };
+
+            const result = await revertTaskChanges(testDir, gitState);
+            expect(result.success).toBe(true);
+            expect(await getHeadCommit(testDir)).toBe(commit);
+        });
+
+        it('should fail when not a git repo (cannot determine HEAD)', async () => {
+            if (!isGitAvailable) return;
+            // testDir is not a git repo
+            const gitState = {
+                commitBefore: 'abc1234',
+                uncommittedBefore: false,
+                filesModified: [],
+                canRevert: true,
+            };
+
+            const result = await revertTaskChanges(testDir, gitState);
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Cannot determine current HEAD');
+        });
+    });
+
+    describe('getCurrentBranch', () => {
+        it('should return null for non-git directory', async () => {
+            if (!isGitAvailable) return;
+            const result = await getCurrentBranch(testDir);
+            expect(result).toBeNull();
+        });
+
+        it('should return the current branch name', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+
+            const { stdout } = await execAsync('git branch --show-current', { cwd: testDir });
+            const expected = stdout.trim();
+
+            const result = await getCurrentBranch(testDir);
+            expect(result).toBe(expected);
+        });
+
+        it('should reflect a newly checked-out branch', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+            await execAsync('git checkout -b feature-xyz', { cwd: testDir });
+
+            const result = await getCurrentBranch(testDir);
+            expect(result).toBe('feature-xyz');
+        });
+    });
+
+    describe('getDefaultBranch', () => {
+        it('should return null for non-git directory', async () => {
+            if (!isGitAvailable) return;
+            const result = await getDefaultBranch(testDir);
+            expect(result).toBeNull();
+        });
+
+        it('should detect the local default branch (main or master)', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+
+            const current = await getCurrentBranch(testDir);
+            const result = await getDefaultBranch(testDir);
+            // No remote configured, so it falls back to checking main/master.
+            // Result must be whichever of main/master exists.
+            if (current === 'main' || current === 'master') {
+                expect(result).toBe(current);
+            } else {
+                // Default branch named something else (e.g. via init.defaultBranch);
+                // neither main nor master exists so it returns null.
+                expect(result).toBeNull();
+            }
+        });
+
+        it('should return main when a main branch exists', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+            // Ensure a 'main' branch exists regardless of init default
+            await execAsync('git branch -f main', { cwd: testDir });
+
+            const result = await getDefaultBranch(testDir);
+            expect(result).toBe('main');
+        });
+    });
+
+    describe('checkoutBranch', () => {
+        it('should reject invalid branch names', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+
+            const result = await checkoutBranch(testDir, 'bad;name');
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Invalid branch name');
+        });
+
+        it('should reject branch names starting with dash', async () => {
+            if (!isGitAvailable) return;
+            const result = await checkoutBranch(testDir, '-foo');
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Invalid branch name');
+        });
+
+        it('should checkout an existing branch', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+            await execAsync('git branch other-branch', { cwd: testDir });
+
+            const result = await checkoutBranch(testDir, 'other-branch');
+            expect(result.success).toBe(true);
+            expect(await getCurrentBranch(testDir)).toBe('other-branch');
+        });
+
+        it('should return error when checking out a non-existent branch', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            await createCommit('Initial commit');
+
+            const result = await checkoutBranch(testDir, 'does-not-exist');
+            expect(result.success).toBe(false);
+            expect(result.error).toBeDefined();
+        });
+    });
+
+    describe('captureGitStateAfter uncommitted path', () => {
+        it('should include currently-uncommitted files in filesModified', async () => {
+            if (!isGitAvailable) return;
+            await initGitRepo();
+            const beforeCommit = await createCommit('Before commit');
+            const beforeState = { commitBefore: beforeCommit, uncommittedBefore: false };
+
+            // No new commit, just an uncommitted (untracked) file
+            writeFileSync(join(testDir, 'dirty.txt'), 'uncommitted work');
+
+            const result = await captureGitStateAfter(testDir, beforeState);
+            expect(result.commitAfter).toBe(beforeCommit);
+            expect(result.filesModified).toContain('dirty.txt');
+            // commit unchanged and no uncommittedBefore -> can revert
+            expect(result.canRevert).toBe(true);
+        });
+    });
+
+    describe('getFilesBetweenCommits / countCommitsBetween invalid input', () => {
+        it('getFilesBetweenCommits returns [] for invalid hashes', async () => {
+            const result = await getFilesBetweenCommits(testDir, 'not!valid', 'also!bad');
+            expect(result).toEqual([]);
+        });
+
+        it('commitExists returns false for invalid hash format', async () => {
+            const result = await commitExists(testDir, 'nope!');
+            expect(result).toBe(false);
         });
     });
 });

--- a/backend/src/__tests__/learnings-store.test.ts
+++ b/backend/src/__tests__/learnings-store.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { LearningsStore } from '../learnings-store.js';
+
+/**
+ * Embedding stub. We map known text -> a fixed embedding so cosine similarity is
+ * deterministic. Anything else falls back to a neutral vector.
+ *
+ * Vectors are chosen so that:
+ *  - "alpha" texts are identical to each other (similarity 1.0)
+ *  - "beta" texts are orthogonal to alpha (similarity 0.0)
+ *  - the query "find-alpha" matches alpha exactly
+ */
+const EMBEDDINGS: Record<string, number[]> = {
+    alpha: [1, 0, 0],
+    beta: [0, 1, 0],
+    gamma: [0, 0, 1],
+};
+
+function embeddingFor(text: string): number[] {
+    for (const key of Object.keys(EMBEDDINGS)) {
+        if (text.includes(key)) return EMBEDDINGS[key];
+    }
+    return [0.5, 0.5, 0.5];
+}
+
+describe('LearningsStore', () => {
+    let testBaseDir: string;
+    let store: LearningsStore;
+    let fetchSpy: any;
+
+    beforeEach(() => {
+        const uniqueId = Date.now() + '-' + Math.random().toString(36).substring(7);
+        testBaseDir = join(homedir(), '.claudia-learnings-test-' + uniqueId);
+        mkdirSync(testBaseDir, { recursive: true });
+
+        // Mock the embeddings endpoint. The store POSTs { input } and expects
+        // { data: [{ embedding }] } back.
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init?: any) => {
+            const parsed = JSON.parse(init.body);
+            const embedding = embeddingFor(parsed.input);
+            return new Response(JSON.stringify({ data: [{ embedding }] }), { status: 200 });
+        });
+
+        store = new LearningsStore(testBaseDir);
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        try {
+            rmSync(testBaseDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        } catch {
+            // ignore
+        }
+    });
+
+    describe('initialization', () => {
+        it('starts empty when no file exists', () => {
+            expect(store.getLearnings()).toEqual([]);
+        });
+
+        it('does not create the file until something is saved', () => {
+            const file = join(testBaseDir, 'learnings.json');
+            expect(existsSync(file)).toBe(false);
+        });
+    });
+
+    describe('addLearning', () => {
+        it('adds a learning with generated embedding and defaults', async () => {
+            const learning = await store.addLearning({
+                workspaceId: 'ws-1',
+                title: 'alpha title',
+                content: 'some alpha content',
+                sourceTaskId: 'task-9',
+            });
+
+            expect(learning.id).toMatch(/^learning-/);
+            expect(learning.workspaceId).toBe('ws-1');
+            expect(learning.title).toBe('alpha title');
+            expect(learning.content).toBe('some alpha content');
+            expect(learning.embedding).toEqual([1, 0, 0]);
+            expect(learning.sourceTaskId).toBe('task-9');
+            expect(learning.utility).toBe(0.5);
+            expect(learning.useCount).toBe(0);
+            expect(learning.successCount).toBe(0);
+            expect(learning.createdAt).toBeTruthy();
+            expect(learning.updatedAt).toBe(learning.createdAt);
+        });
+
+        it('persists the learning to disk', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'x' });
+            const file = join(testBaseDir, 'learnings.json');
+            expect(existsSync(file)).toBe(true);
+
+            const reloaded = new LearningsStore(testBaseDir);
+            expect(reloaded.getLearnings()).toHaveLength(1);
+            expect(reloaded.getLearnings()[0].title).toBe('alpha');
+        });
+
+        it('writes a versioned envelope to disk', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'x' });
+            const raw = JSON.parse(readFileSync(join(testBaseDir, 'learnings.json'), 'utf-8'));
+            expect(raw.schemaVersion).toBe(1);
+            expect(raw.data.learnings).toHaveLength(1);
+        });
+    });
+
+    describe('getLearnings / getLearning', () => {
+        it('filters by workspace', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            await store.addLearning({ workspaceId: 'ws-2', title: 'beta', content: 'b' });
+
+            expect(store.getLearnings('ws-1')).toHaveLength(1);
+            expect(store.getLearnings('ws-1')[0].workspaceId).toBe('ws-1');
+            expect(store.getLearnings('ws-2')).toHaveLength(1);
+            expect(store.getLearnings()).toHaveLength(2);
+        });
+
+        it('getLearnings() returns a copy, not the internal array', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            const list = store.getLearnings();
+            list.pop();
+            expect(store.getLearnings()).toHaveLength(1);
+        });
+
+        it('getLearning returns the matching entry or undefined', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            expect(store.getLearning(l.id)?.id).toBe(l.id);
+            expect(store.getLearning('nope')).toBeUndefined();
+        });
+    });
+
+    describe('deleteLearning', () => {
+        it('removes and persists the deletion', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            expect(store.deleteLearning(l.id)).toBe(true);
+            expect(store.getLearnings()).toHaveLength(0);
+
+            const reloaded = new LearningsStore(testBaseDir);
+            expect(reloaded.getLearnings()).toHaveLength(0);
+        });
+
+        it('returns false for an unknown id', () => {
+            expect(store.deleteLearning('missing')).toBe(false);
+        });
+    });
+
+    describe('updateLearning', () => {
+        it('updates title/content and regenerates the embedding', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            expect(l.embedding).toEqual([1, 0, 0]);
+
+            const updated = await store.updateLearning(l.id, { title: 'beta', content: 'b' });
+            expect(updated).not.toBeNull();
+            expect(updated!.title).toBe('beta');
+            expect(updated!.content).toBe('b');
+            expect(updated!.embedding).toEqual([0, 1, 0]);
+        });
+
+        it('allows partial updates (only content)', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            const updated = await store.updateLearning(l.id, { content: 'beta only' });
+            expect(updated!.title).toBe('alpha');
+            expect(updated!.content).toBe('beta only');
+        });
+
+        it('returns null for an unknown id', async () => {
+            expect(await store.updateLearning('missing', { title: 'x' })).toBeNull();
+        });
+    });
+
+    describe('updateUtility (MemRL)', () => {
+        it('increases utility toward 1 on success', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            store.updateUtility(l.id, true, 0.1);
+            const after = store.getLearning(l.id)!;
+            // 0.5 + 0.1 * (1 - 0.5) = 0.55
+            expect(after.utility).toBeCloseTo(0.55, 5);
+            expect(after.useCount).toBe(1);
+            expect(after.successCount).toBe(1);
+        });
+
+        it('decreases utility toward 0 on failure and does not bump successCount', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            store.updateUtility(l.id, false, 0.1);
+            const after = store.getLearning(l.id)!;
+            // 0.5 + 0.1 * (0 - 0.5) = 0.45
+            expect(after.utility).toBeCloseTo(0.45, 5);
+            expect(after.useCount).toBe(1);
+            expect(after.successCount).toBe(0);
+        });
+
+        it('is a no-op for an unknown id', () => {
+            expect(() => store.updateUtility('missing', true)).not.toThrow();
+        });
+
+        it('persists utility updates', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            store.updateUtility(l.id, true);
+            const reloaded = new LearningsStore(testBaseDir);
+            expect(reloaded.getLearning(l.id)!.useCount).toBe(1);
+        });
+    });
+
+    describe('recordRetrieval', () => {
+        it('bumps useCount for each existing id and ignores missing ones', async () => {
+            const a = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'a' });
+            const b = await store.addLearning({ workspaceId: 'ws-1', title: 'beta', content: 'b' });
+            store.recordRetrieval([a.id, b.id, 'missing']);
+            expect(store.getLearning(a.id)!.useCount).toBe(1);
+            expect(store.getLearning(b.id)!.useCount).toBe(1);
+        });
+    });
+
+    describe('searchLearnings', () => {
+        it('returns matches above minScore ranked by combined score', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'alpha doc' });
+            await store.addLearning({ workspaceId: 'ws-1', title: 'beta', content: 'beta doc' });
+
+            // Query embeds to [1,0,0] (alpha). alpha sim=1, beta sim=0 (below 0.3).
+            const results = await store.searchLearnings({ query: 'alpha' });
+            expect(results).toHaveLength(1);
+            expect(results[0].learning.title).toBe('alpha');
+            expect(results[0].score).toBeCloseTo(1, 5);
+        });
+
+        it('filters by workspaceId', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha', content: 'alpha a' });
+            await store.addLearning({ workspaceId: 'ws-2', title: 'alpha', content: 'alpha b' });
+
+            const results = await store.searchLearnings({ query: 'alpha', workspaceId: 'ws-2' });
+            expect(results).toHaveLength(1);
+            expect(results[0].learning.workspaceId).toBe('ws-2');
+        });
+
+        it('respects topK', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha one', content: 'alpha' });
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha two', content: 'alpha' });
+            await store.addLearning({ workspaceId: 'ws-1', title: 'alpha three', content: 'alpha' });
+
+            const results = await store.searchLearnings({ query: 'alpha', topK: 2 });
+            expect(results).toHaveLength(2);
+        });
+
+        it('drops results below minScore', async () => {
+            await store.addLearning({ workspaceId: 'ws-1', title: 'beta', content: 'beta' });
+            // Query embeds to alpha [1,0,0], beta is orthogonal -> sim 0 < 0.3
+            const results = await store.searchLearnings({ query: 'alpha' });
+            expect(results).toHaveLength(0);
+        });
+
+        it('utility ranking reorders equally-similar results', async () => {
+            const low = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha low', content: 'alpha' });
+            const high = await store.addLearning({ workspaceId: 'ws-1', title: 'alpha high', content: 'alpha' });
+            // Both have identical similarity (1.0). Make `high` more useful.
+            store.updateUtility(high.id, true);
+            store.updateUtility(high.id, true);
+
+            const ranked = await store.searchLearnings({ query: 'alpha', useUtilityRanking: true });
+            expect(ranked[0].learning.id).toBe(high.id);
+
+            const bySimOnly = await store.searchLearnings({ query: 'alpha', useUtilityRanking: false });
+            // Pure similarity tie -> stable original insertion order (low first).
+            expect(bySimOnly.map(r => r.learning.id)).toContain(low.id);
+        });
+    });
+
+    describe('formatForContext', () => {
+        it('returns empty string for no results', () => {
+            expect(store.formatForContext([])).toBe('');
+        });
+
+        it('formats title, content, relevance and utility', async () => {
+            const l = await store.addLearning({ workspaceId: 'ws-1', title: 'My Title', content: 'Body text' });
+            const text = store.formatForContext([{ learning: l, score: 0.8 }]);
+            expect(text).toContain('[RELEVANT LEARNINGS]');
+            expect(text).toContain('## My Title');
+            expect(text).toContain('Body text');
+            expect(text).toContain('Relevance: 80%');
+            expect(text).toContain('Utility: 50%');
+            expect(text).toContain('[/RELEVANT LEARNINGS]');
+        });
+    });
+
+    describe('loadData resilience', () => {
+        it('falls back to empty on malformed JSON', () => {
+            writeFileSync(join(testBaseDir, 'learnings.json'), 'this is not json {{{');
+            const s = new LearningsStore(testBaseDir);
+            expect(s.getLearnings()).toEqual([]);
+        });
+
+        it('reads a legacy (unversioned) file shape', async () => {
+            const legacy = { learnings: [{
+                id: 'legacy-1',
+                workspaceId: 'ws-1',
+                title: 'legacy',
+                content: 'old format',
+                embedding: [1, 0, 0],
+                createdAt: '2020-01-01T00:00:00.000Z',
+                updatedAt: '2020-01-01T00:00:00.000Z',
+                utility: 0.5,
+                useCount: 0,
+                successCount: 0,
+            }], version: 1 };
+            writeFileSync(join(testBaseDir, 'learnings.json'), JSON.stringify(legacy));
+
+            const s = new LearningsStore(testBaseDir);
+            expect(s.getLearnings()).toHaveLength(1);
+            expect(s.getLearning('legacy-1')?.title).toBe('legacy');
+        });
+    });
+
+    describe('generateEmbedding', () => {
+        it('throws when the embedding API returns an error status', async () => {
+            fetchSpy.mockResolvedValueOnce(new Response('boom', { status: 500 }));
+            await expect(store.generateEmbedding('alpha')).rejects.toThrow(/Embedding API error: 500/);
+        });
+
+        it('throws when the response has no embedding', async () => {
+            fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+            await expect(store.generateEmbedding('alpha')).rejects.toThrow(/No embedding in response/);
+        });
+
+        it('returns the embedding from a well-formed response', async () => {
+            const emb = await store.generateEmbedding('alpha');
+            expect(emb).toEqual([1, 0, 0]);
+        });
+    });
+});

--- a/backend/src/__tests__/plugin-registry.test.ts
+++ b/backend/src/__tests__/plugin-registry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { validateManifest, createManifestTemplate } from '../plugin-system/plugin-registry.js';
+
+describe('plugin-registry', () => {
+    describe('validateManifest', () => {
+        it('rejects a missing/null manifest', () => {
+            expect(validateManifest(null)).toEqual({ valid: false, error: 'Manifest is required' });
+            expect(validateManifest(undefined)).toEqual({ valid: false, error: 'Manifest is required' });
+        });
+
+        it('rejects a manifest without a name', () => {
+            const result = validateManifest({ version: '1.0.0', displayName: 'X', type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/name is required/);
+        });
+
+        it('rejects a non-string name', () => {
+            const result = validateManifest({ name: 42, version: '1.0.0', displayName: 'X', type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/name is required/);
+        });
+
+        it('rejects a manifest without a version', () => {
+            const result = validateManifest({ name: 'p', displayName: 'X', type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/version is required/);
+        });
+
+        it('rejects a non-string version', () => {
+            const result = validateManifest({ name: 'p', version: 1, displayName: 'X', type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/version is required/);
+        });
+
+        it('rejects a manifest without a displayName', () => {
+            const result = validateManifest({ name: 'p', version: '1.0.0', type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/displayName is required/);
+        });
+
+        it('rejects a non-string displayName', () => {
+            const result = validateManifest({ name: 'p', version: '1.0.0', displayName: 5, type: 'utility' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/displayName is required/);
+        });
+
+        it('rejects a missing type', () => {
+            const result = validateManifest({ name: 'p', version: '1.0.0', displayName: 'X' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/type must be/);
+        });
+
+        it('rejects an invalid type', () => {
+            const result = validateManifest({ name: 'p', version: '1.0.0', displayName: 'X', type: 'bogus' });
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/type must be/);
+        });
+
+        it('accepts each valid type', () => {
+            for (const type of ['ai-provider', 'utility', 'integration']) {
+                const result = validateManifest({ name: 'p', version: '1.0.0', displayName: 'X', type });
+                expect(result).toEqual({ valid: true });
+            }
+        });
+
+        it('checks name before version before displayName before type', () => {
+            // Only name missing → name error even though others also missing
+            expect(validateManifest({}).error).toMatch(/name is required/);
+            // name present, version missing → version error
+            expect(validateManifest({ name: 'p' }).error).toMatch(/version is required/);
+            // name + version present, displayName missing → displayName error
+            expect(validateManifest({ name: 'p', version: '1.0.0' }).error).toMatch(/displayName is required/);
+        });
+    });
+
+    describe('createManifestTemplate', () => {
+        it('produces a valid manifest', () => {
+            const manifest = createManifestTemplate('my-plugin', 'My Plugin', 'utility');
+            expect(validateManifest(manifest)).toEqual({ valid: true });
+        });
+
+        it('fills in the provided fields', () => {
+            const manifest = createManifestTemplate('my-plugin', 'My Plugin', 'integration');
+            expect(manifest.name).toBe('my-plugin');
+            expect(manifest.displayName).toBe('My Plugin');
+            expect(manifest.type).toBe('integration');
+        });
+
+        it('sets sensible defaults for the rest', () => {
+            const manifest = createManifestTemplate('p', 'P', 'ai-provider');
+            expect(manifest.version).toBe('1.0.0');
+            expect(manifest.description).toBe('');
+            expect(manifest.backend).toEqual({ entry: './index.js', provides: {} });
+        });
+    });
+});

--- a/backend/src/__tests__/task-persistence.test.ts
+++ b/backend/src/__tests__/task-persistence.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import {
+    TaskPersistenceManager,
+    PersistedTask,
+    ArchivedTaskMetadata,
+} from '../task-persistence.js';
+
+const TASKS_SCHEMA_VERSION = 1;
+
+function makeTask(overrides: Partial<PersistedTask> = {}): PersistedTask {
+    return {
+        id: 'task-1',
+        prompt: 'do something',
+        workspaceId: 'ws-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        lastActivity: '2026-01-01T00:01:00.000Z',
+        lastState: 'idle' as PersistedTask['lastState'],
+        sessionId: 'sess-1',
+        ...overrides,
+    };
+}
+
+function makeArchived(overrides: Partial<ArchivedTaskMetadata> = {}): ArchivedTaskMetadata {
+    return {
+        id: 'arch-1',
+        prompt: 'archived prompt',
+        workspaceId: 'ws-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        lastActivity: '2026-01-01T00:01:00.000Z',
+        sessionId: null,
+        ...overrides,
+    };
+}
+
+describe('TaskPersistenceManager', () => {
+    let testBaseDir: string;
+    let persistencePath: string;
+    let manager: TaskPersistenceManager;
+
+    beforeEach(() => {
+        const uniqueId = Date.now() + '-' + Math.random().toString(36).substring(7);
+        testBaseDir = join(homedir(), '.claudia-task-persist-test-' + uniqueId);
+        mkdirSync(testBaseDir, { recursive: true });
+        persistencePath = join(testBaseDir, 'tasks.json');
+        manager = new TaskPersistenceManager(persistencePath);
+    });
+
+    afterEach(() => {
+        try {
+            rmSync(testBaseDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        } catch {
+            // Ignore cleanup errors
+        }
+    });
+
+    describe('path helpers', () => {
+        it('derives history dirs relative to the persistence path', () => {
+            expect(manager.getHistoryDir()).toBe(join(testBaseDir, 'task-histories'));
+            expect(manager.getArchivedHistoryDir()).toBe(join(testBaseDir, 'archived-histories'));
+        });
+
+        it('builds per-task history file paths', () => {
+            expect(manager.getTaskHistoryPath('abc')).toBe(join(testBaseDir, 'task-histories', 'abc.txt'));
+            expect(manager.getArchivedHistoryPath('xyz')).toBe(join(testBaseDir, 'archived-histories', 'xyz.txt'));
+        });
+
+        it('ensureHistoryDir creates the directory', () => {
+            expect(existsSync(manager.getHistoryDir())).toBe(false);
+            manager.ensureHistoryDir();
+            expect(existsSync(manager.getHistoryDir())).toBe(true);
+        });
+
+        it('ensureArchivedHistoryDir creates the directory', () => {
+            expect(existsSync(manager.getArchivedHistoryDir())).toBe(false);
+            manager.ensureArchivedHistoryDir();
+            expect(existsSync(manager.getArchivedHistoryDir())).toBe(true);
+        });
+    });
+
+    describe('saveTasks / loadPersistedTasks round-trip', () => {
+        it('round-trips active and archived tasks', () => {
+            const tasks = [makeTask({ id: 't1' }), makeTask({ id: 't2', prompt: 'second' })];
+            const archived = [makeArchived({ id: 'a1', historySize: 123 })];
+
+            manager.saveTasks(tasks, archived);
+            const loaded = manager.loadPersistedTasks();
+
+            expect(loaded.tasks.map((t) => t.id)).toEqual(['t1', 't2']);
+            expect(loaded.tasks[1].prompt).toBe('second');
+            expect(loaded.archivedTasks).toHaveLength(1);
+            expect(loaded.archivedTasks[0].id).toBe('a1');
+            expect(loaded.archivedTasks[0].historySize).toBe(123);
+            expect(loaded.migratedCount).toBe(0);
+        });
+
+        it('writes a versioned envelope to disk', () => {
+            manager.saveTasks([makeTask()], []);
+            const raw = JSON.parse(readFileSync(persistencePath, 'utf-8'));
+            expect(raw.schemaVersion).toBe(TASKS_SCHEMA_VERSION);
+            expect(raw.data.tasks).toHaveLength(1);
+            expect(raw.data.archivedTasks).toEqual([]);
+        });
+
+        it('creates the persistence parent directory if missing', () => {
+            const nestedPath = join(testBaseDir, 'sub', 'dir', 'tasks.json');
+            const m = new TaskPersistenceManager(nestedPath);
+            m.saveTasks([makeTask()], []);
+            expect(existsSync(nestedPath)).toBe(true);
+        });
+    });
+
+    describe('loadPersistedTasks edge cases', () => {
+        it('returns empty result when file is missing', () => {
+            const loaded = manager.loadPersistedTasks();
+            expect(loaded.tasks).toEqual([]);
+            expect(loaded.archivedTasks).toEqual([]);
+            expect(loaded.migratedCount).toBe(0);
+        });
+
+        it('falls back to defaults on corrupted JSON', () => {
+            writeFileSync(persistencePath, 'not valid json {{{');
+            const loaded = manager.loadPersistedTasks();
+            expect(loaded.tasks).toEqual([]);
+            expect(loaded.archivedTasks).toEqual([]);
+        });
+
+        it('reads a legacy unversioned file via the legacy loader', () => {
+            // Legacy format = raw TaskPersistence object with no schemaVersion.
+            const legacy = {
+                tasks: [makeTask({ id: 'legacy-1' })],
+                archivedTasks: [makeArchived({ id: 'legacy-arch' })],
+            };
+            writeFileSync(persistencePath, JSON.stringify(legacy));
+
+            const loaded = manager.loadPersistedTasks();
+            expect(loaded.tasks.map((t) => t.id)).toEqual(['legacy-1']);
+            expect(loaded.archivedTasks.map((t) => t.id)).toEqual(['legacy-arch']);
+
+            // Loading a legacy file upgrades it to the versioned envelope on disk.
+            const raw = JSON.parse(readFileSync(persistencePath, 'utf-8'));
+            expect(raw.schemaVersion).toBe(TASKS_SCHEMA_VERSION);
+        });
+
+        it('handles a versioned file that omits archivedTasks', () => {
+            const m = new TaskPersistenceManager(persistencePath);
+            // Save with empty archived, then hand-write a file without the key.
+            writeFileSync(
+                persistencePath,
+                JSON.stringify({ schemaVersion: TASKS_SCHEMA_VERSION, data: { tasks: [makeTask({ id: 'only' })] } })
+            );
+            const loaded = m.loadPersistedTasks();
+            expect(loaded.tasks.map((t) => t.id)).toEqual(['only']);
+            expect(loaded.archivedTasks).toEqual([]);
+        });
+    });
+
+    describe('outputHistory migration', () => {
+        it('migrates an embedded active-task outputHistory to a file and strips it', () => {
+            const legacy = {
+                tasks: [makeTask({ id: 'mig-1', outputHistory: 'embedded history content' })],
+                archivedTasks: [],
+            };
+            writeFileSync(persistencePath, JSON.stringify(legacy));
+
+            const loaded = manager.loadPersistedTasks();
+            // outputHistory removed from the in-memory task.
+            expect(loaded.tasks[0].outputHistory).toBeUndefined();
+            // History written to the per-task file (raw, not base64 — this is the
+            // migration path which writes the string directly).
+            const histPath = manager.getTaskHistoryPath('mig-1');
+            expect(existsSync(histPath)).toBe(true);
+            expect(readFileSync(histPath, 'utf-8')).toBe('embedded history content');
+        });
+
+        it('migrates an embedded archived outputHistory and counts it', () => {
+            const legacy = {
+                tasks: [],
+                archivedTasks: [{ ...makeArchived({ id: 'amig-1' }), outputHistory: 'YQ==' }],
+            };
+            writeFileSync(persistencePath, JSON.stringify(legacy));
+
+            const loaded = manager.loadPersistedTasks();
+            expect(loaded.migratedCount).toBe(1);
+            const archPath = manager.getArchivedHistoryPath('amig-1');
+            expect(existsSync(archPath)).toBe(true);
+            expect(readFileSync(archPath, 'utf-8')).toBe('YQ==');
+
+            // historySize derived from embedded length * 0.75.
+            const expectedSize = Math.floor('YQ=='.length * 0.75);
+            expect(loaded.archivedTasks[0].historySize).toBe(expectedSize);
+        });
+
+        it('keeps existing historySize when no embedded archived history', () => {
+            manager.saveTasks([], [makeArchived({ id: 'a', historySize: 999 })]);
+            const loaded = manager.loadPersistedTasks();
+            expect(loaded.migratedCount).toBe(0);
+            expect(loaded.archivedTasks[0].historySize).toBe(999);
+        });
+    });
+
+    describe('task history files (base64)', () => {
+        it('saves and loads a task history round-trip', () => {
+            const data = Buffer.from('terminal output \x1b[0m bytes');
+            manager.saveTaskHistory('h1', [data]);
+
+            expect(manager.hasHistoryFile('h1')).toBe(true);
+            const loaded = manager.loadTaskHistory('h1');
+            expect(loaded.truncated).toBe(false);
+            expect(loaded.buffer).not.toBeNull();
+            expect(Buffer.compare(loaded.buffer!, data)).toBe(0);
+        });
+
+        it('persists history as base64 on disk', () => {
+            const data = Buffer.from('hello');
+            manager.saveTaskHistory('h2', [data]);
+            const onDisk = readFileSync(manager.getTaskHistoryPath('h2'), 'utf-8');
+            expect(onDisk).toBe(data.toString('base64'));
+        });
+
+        it('concatenates previousHistory ahead of new buffers', () => {
+            const prev = Buffer.from('AAA');
+            const next = Buffer.from('BBB');
+            manager.saveTaskHistory('h3', [next], prev);
+            const loaded = manager.loadTaskHistory('h3');
+            expect(loaded.buffer!.toString()).toBe('AAABBB');
+        });
+
+        it('returns null buffer for a missing history file', () => {
+            const loaded = manager.loadTaskHistory('does-not-exist');
+            expect(loaded.buffer).toBeNull();
+            expect(loaded.truncated).toBe(false);
+            expect(manager.hasHistoryFile('does-not-exist')).toBe(false);
+        });
+
+        it('loads only the tail and marks truncated when over maxSize', () => {
+            // Build a base64 payload large enough to exceed our maxSize cap.
+            const raw = Buffer.alloc(4096, 0x41); // 4KB of 'A'
+            manager.saveTaskHistory('h4', [raw]);
+
+            const maxSize = 128; // bytes of the base64 file to read from the tail
+            const loaded = manager.loadTaskHistory('h4', maxSize);
+            expect(loaded.truncated).toBe(true);
+            expect(loaded.buffer).not.toBeNull();
+            // Tail of a base64 string of repeated 'A' decodes to repeated 'A' bytes.
+            expect(loaded.buffer!.every((b) => b === 0x41)).toBe(true);
+        });
+
+        it('reads the whole file when under maxSize (not truncated)', () => {
+            const data = Buffer.from('small');
+            manager.saveTaskHistory('h5', [data]);
+            const loaded = manager.loadTaskHistory('h5', 10_000);
+            expect(loaded.truncated).toBe(false);
+            expect(Buffer.compare(loaded.buffer!, data)).toBe(0);
+        });
+
+        it('writes an empty history file when no buffers and file absent', () => {
+            manager.saveTaskHistory('h6', []);
+            expect(manager.hasHistoryFile('h6')).toBe(true);
+            const loaded = manager.loadTaskHistory('h6');
+            expect(loaded.buffer!.length).toBe(0);
+        });
+    });
+
+    describe('archived history files', () => {
+        it('saves, loads, and deletes archived history', () => {
+            manager.saveArchivedHistory('arch-x', 'base64orwhatever');
+            expect(manager.loadArchivedHistory('arch-x')).toBe('base64orwhatever');
+
+            const deleted = manager.deleteArchivedHistory('arch-x');
+            expect(deleted).toBe(true);
+            expect(manager.loadArchivedHistory('arch-x')).toBeNull();
+        });
+
+        it('returns null when loading a missing archived history', () => {
+            expect(manager.loadArchivedHistory('nope')).toBeNull();
+        });
+
+        it('returns false when deleting a missing archived history', () => {
+            expect(manager.deleteArchivedHistory('nope')).toBe(false);
+        });
+    });
+
+    describe('debounced save', () => {
+        it('invokes the callback after the debounce window', async () => {
+            let calls = 0;
+            manager.scheduleSave(() => {
+                calls++;
+            });
+            await new Promise((r) => setTimeout(r, 700));
+            expect(calls).toBe(1);
+        });
+
+        it('coalesces rapid scheduleSave calls into one', async () => {
+            let calls = 0;
+            const cb = () => {
+                calls++;
+            };
+            manager.scheduleSave(cb);
+            manager.scheduleSave(cb);
+            manager.scheduleSave(cb);
+            await new Promise((r) => setTimeout(r, 700));
+            expect(calls).toBe(1);
+        });
+
+        it('clearDebounceTimer cancels a pending save', async () => {
+            let calls = 0;
+            manager.scheduleSave(() => {
+                calls++;
+            });
+            manager.clearDebounceTimer();
+            await new Promise((r) => setTimeout(r, 700));
+            expect(calls).toBe(0);
+        });
+    });
+
+    describe('persistence survives a fresh manager instance', () => {
+        it('a new manager reads what the previous one saved', () => {
+            manager.saveTasks([makeTask({ id: 'persist-1' })], [makeArchived({ id: 'persist-arch' })]);
+            const fresh = new TaskPersistenceManager(persistencePath);
+            const loaded = fresh.loadPersistedTasks();
+            expect(loaded.tasks.map((t) => t.id)).toEqual(['persist-1']);
+            expect(loaded.archivedTasks.map((t) => t.id)).toEqual(['persist-arch']);
+        });
+    });
+});

--- a/backend/src/__tests__/usage-reporter.test.ts
+++ b/backend/src/__tests__/usage-reporter.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setUserId, getUserId, reportUsage } from '../usage-reporter.js';
+
+// Note: USAGE_DASHBOARD_URL is read at module-load time. In the test environment
+// it is unset, so reportUsage is always a no-op (it never reaches fetch). These
+// tests verify that contract: user-id state management plus the safe no-op path.
+
+describe('usage-reporter', () => {
+    let fetchSpy: any;
+
+    beforeEach(() => {
+        // Spy on fetch so we can assert it is never called when reporting is disabled.
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ ok: true, event_id: 1 }), { status: 200 }),
+        );
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+    });
+
+    describe('user id management', () => {
+        it('starts null until a user id is set in this test ordering', () => {
+            // getUserId reflects module-level state; we set it then read it back.
+            setUserId('user-123');
+            expect(getUserId()).toBe('user-123');
+        });
+
+        it('overwrites a previously set user id', () => {
+            setUserId('first');
+            expect(getUserId()).toBe('first');
+            setUserId('second');
+            expect(getUserId()).toBe('second');
+        });
+    });
+
+    describe('reportUsage (dashboard disabled)', () => {
+        it('resolves without throwing when no user id is set', async () => {
+            // We cannot truly clear the id (no setter to null via public API in a
+            // clean way), but with no dashboard URL it is a no-op regardless.
+            await expect(
+                reportUsage({ tokensInput: 100, tokensOutput: 50, model: 'sonnet' }),
+            ).resolves.toBeUndefined();
+        });
+
+        it('does not call fetch when the dashboard URL is not configured', async () => {
+            setUserId('user-xyz');
+            await reportUsage({ tokensInput: 1000, tokensOutput: 200, model: 'opus' });
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('handles zero usage without throwing', async () => {
+            setUserId('user-zero');
+            await expect(
+                reportUsage({ tokensInput: 0, tokensOutput: 0, model: 'haiku' }),
+            ).resolves.toBeUndefined();
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('handles large token counts without throwing', async () => {
+            setUserId('user-big');
+            await expect(
+                reportUsage({ tokensInput: 9_999_999, tokensOutput: 5_000_000, model: 'opus' }),
+            ).resolves.toBeUndefined();
+        });
+
+        it('is safe to fire-and-forget multiple times', async () => {
+            setUserId('user-multi');
+            await Promise.all([
+                reportUsage({ tokensInput: 1, tokensOutput: 1, model: 'a' }),
+                reportUsage({ tokensInput: 2, tokensOutput: 2, model: 'b' }),
+                reportUsage({ tokensInput: 3, tokensOutput: 3, model: 'c' }),
+            ]);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/backend/src/__tests__/validation.test.ts
+++ b/backend/src/__tests__/validation.test.ts
@@ -216,6 +216,218 @@ describe('validateConfigUpdate', () => {
         }).valid).toBe(false);
     });
 
+    it('should validate http url scheme', () => {
+        // https accepted
+        expect(validateConfigUpdate({
+            mcpServers: [{ name: 'test', type: 'http', url: 'https://example.com', enabled: true }]
+        }).valid).toBe(true);
+
+        // non-http scheme rejected
+        const res = validateConfigUpdate({
+            mcpServers: [{ name: 'test', type: 'http', url: 'ftp://example.com', enabled: true }]
+        });
+        expect(res.valid).toBe(false);
+        expect(res.error).toContain('http or https scheme');
+    });
+
+    it('should reject non-object mcpServers entries', () => {
+        expect(validateConfigUpdate({ mcpServers: [null] }).valid).toBe(false);
+        expect(validateConfigUpdate({ mcpServers: [null] }).error).toContain('must be an object');
+        expect(validateConfigUpdate({ mcpServers: ['string-entry'] }).valid).toBe(false);
+    });
+
+    it('should reject empty server name', () => {
+        const res = validateConfigUpdate({ mcpServers: [{ name: '', command: 'cmd', enabled: true }] });
+        expect(res.valid).toBe(false);
+        expect(res.error).toContain('name is required');
+    });
+
+    it('should reject http server with empty url', () => {
+        const res = validateConfigUpdate({ mcpServers: [{ name: 't', type: 'http', url: '', enabled: true }] });
+        expect(res.valid).toBe(false);
+        expect(res.error).toContain('url is required');
+    });
+
+    it('should validate claudiaMcpServerEnabled boolean', () => {
+        expect(validateConfigUpdate({ claudiaMcpServerEnabled: true }).valid).toBe(true);
+        expect(validateConfigUpdate({ claudiaMcpServerEnabled: 'no' }).valid).toBe(false);
+        expect(validateConfigUpdate({ claudiaMcpServerEnabled: 'no' }).error).toContain('must be a boolean');
+    });
+
+    it('should validate deepgramApiKey', () => {
+        expect(validateConfigUpdate({ deepgramApiKey: 'key123' }).valid).toBe(true);
+        const res = validateConfigUpdate({ deepgramApiKey: 123 });
+        expect(res.valid).toBe(false);
+        expect(res.error).toBe('deepgramApiKey must be a string');
+    });
+
+    it('should validate defaultBaseDirectory', () => {
+        expect(validateConfigUpdate({ defaultBaseDirectory: '/some/path' }).valid).toBe(true);
+        // null is allowed and coerced to undefined
+        const nullRes = validateConfigUpdate({ defaultBaseDirectory: null });
+        expect(nullRes.valid).toBe(true);
+        expect(nullRes.data?.defaultBaseDirectory).toBeUndefined();
+        // non-string non-null rejected
+        const res = validateConfigUpdate({ defaultBaseDirectory: 123 });
+        expect(res.valid).toBe(false);
+        expect(res.error).toBe('defaultBaseDirectory must be a string');
+    });
+
+    describe('claudeCodeSwitches', () => {
+        it('should reject non-object', () => {
+            const res = validateConfigUpdate({ claudeCodeSwitches: 'x' });
+            expect(res.valid).toBe(false);
+            expect(res.error).toBe('claudeCodeSwitches must be an object');
+            expect(validateConfigUpdate({ claudeCodeSwitches: null }).valid).toBe(false);
+        });
+
+        it('should validate verbose', () => {
+            expect(validateConfigUpdate({ claudeCodeSwitches: { verbose: true } }).valid).toBe(true);
+            const res = validateConfigUpdate({ claudeCodeSwitches: { verbose: 'yes' } });
+            expect(res.valid).toBe(false);
+            expect(res.error).toBe('claudeCodeSwitches.verbose must be a boolean');
+        });
+
+        it('should validate maxTurns', () => {
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxTurns: 5 } }).valid).toBe(true);
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxTurns: null } }).valid).toBe(true);
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxTurns: 0 } }).valid).toBe(false);
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxTurns: 1.5 } }).valid).toBe(false);
+            const res = validateConfigUpdate({ claudeCodeSwitches: { maxTurns: -3 } });
+            expect(res.valid).toBe(false);
+            expect(res.error).toContain('maxTurns must be a positive integer');
+        });
+
+        it('should validate maxBudgetUsd', () => {
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxBudgetUsd: 10 } }).valid).toBe(true);
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxBudgetUsd: 0 } }).valid).toBe(true);
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxBudgetUsd: null } }).valid).toBe(true);
+            const res = validateConfigUpdate({ claudeCodeSwitches: { maxBudgetUsd: -1 } });
+            expect(res.valid).toBe(false);
+            expect(res.error).toContain('maxBudgetUsd must be a non-negative');
+            expect(validateConfigUpdate({ claudeCodeSwitches: { maxBudgetUsd: 'x' } }).valid).toBe(false);
+        });
+
+        it('should validate permissionMode', () => {
+            for (const mode of ['plan', 'safe', 'dangerous', 'auto', 'acceptEdits', 'bypassPermissions', 'default', 'dontAsk']) {
+                expect(validateConfigUpdate({ claudeCodeSwitches: { permissionMode: mode } }).valid).toBe(true);
+            }
+            expect(validateConfigUpdate({ claudeCodeSwitches: { permissionMode: null } }).valid).toBe(true);
+            const res = validateConfigUpdate({ claudeCodeSwitches: { permissionMode: 'bogus' } });
+            expect(res.valid).toBe(false);
+            expect(res.error).toContain('permissionMode must be one of');
+            expect(validateConfigUpdate({ claudeCodeSwitches: { permissionMode: 42 } }).valid).toBe(false);
+        });
+
+        it('should validate string switches', () => {
+            const r = validateConfigUpdate({
+                claudeCodeSwitches: {
+                    allowedTools: 'Read,Write',
+                    disallowedTools: 'Bash',
+                    appendSystemPrompt: 'extra',
+                    model: 'opus',
+                }
+            });
+            expect(r.valid).toBe(true);
+            expect(r.data?.claudeCodeSwitches?.allowedTools).toBe('Read,Write');
+            expect(r.data?.claudeCodeSwitches?.model).toBe('opus');
+
+            expect(validateConfigUpdate({ claudeCodeSwitches: { allowedTools: 1 } }).error).toContain('allowedTools must be a string');
+            expect(validateConfigUpdate({ claudeCodeSwitches: { disallowedTools: 1 } }).error).toContain('disallowedTools must be a string');
+            expect(validateConfigUpdate({ claudeCodeSwitches: { appendSystemPrompt: 1 } }).error).toContain('appendSystemPrompt must be a string');
+            expect(validateConfigUpdate({ claudeCodeSwitches: { model: 1 } }).error).toContain('model must be a string');
+        });
+    });
+
+    describe('hyperspaceProxy', () => {
+        it('should reject non-object', () => {
+            expect(validateConfigUpdate({ hyperspaceProxy: 'x' }).error).toBe('hyperspaceProxy must be an object');
+            expect(validateConfigUpdate({ hyperspaceProxy: null }).valid).toBe(false);
+        });
+
+        it('should validate fields', () => {
+            const r = validateConfigUpdate({
+                hyperspaceProxy: { proxyUrl: 'http://p', apiKey: 'k', model: 'm', alwaysThinkingEnabled: true }
+            });
+            expect(r.valid).toBe(true);
+            expect(r.data?.hyperspaceProxy?.proxyUrl).toBe('http://p');
+            expect(r.data?.hyperspaceProxy?.alwaysThinkingEnabled).toBe(true);
+
+            expect(validateConfigUpdate({ hyperspaceProxy: { proxyUrl: 1 } }).error).toContain('proxyUrl must be a string');
+            expect(validateConfigUpdate({ hyperspaceProxy: { apiKey: 1 } }).error).toContain('apiKey must be a string');
+            expect(validateConfigUpdate({ hyperspaceProxy: { model: 1 } }).error).toContain('model must be a string');
+            expect(validateConfigUpdate({ hyperspaceProxy: { alwaysThinkingEnabled: 'x' } }).error).toContain('alwaysThinkingEnabled must be a boolean');
+        });
+    });
+
+    describe('sapAiCore', () => {
+        it('should reject non-object', () => {
+            expect(validateConfigUpdate({ sapAiCore: 'x' }).error).toBe('sapAiCore must be an object');
+            expect(validateConfigUpdate({ sapAiCore: null }).valid).toBe(false);
+        });
+
+        it('should validate all fields', () => {
+            const r = validateConfigUpdate({
+                sapAiCore: {
+                    clientId: 'id', clientSecret: 'secret', authUrl: 'http://auth',
+                    baseUrl: 'http://base', resourceGroup: 'default', model: 'm', timeoutMs: 1000,
+                }
+            });
+            expect(r.valid).toBe(true);
+            expect(r.data?.sapAiCore?.clientId).toBe('id');
+            expect(r.data?.sapAiCore?.timeoutMs).toBe(1000);
+            expect(validateConfigUpdate({ sapAiCore: { timeoutMs: 0 } }).valid).toBe(true);
+        });
+
+        it('should reject invalid field types', () => {
+            expect(validateConfigUpdate({ sapAiCore: { clientId: 1 } }).error).toContain('clientId must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { clientSecret: 1 } }).error).toContain('clientSecret must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { authUrl: 1 } }).error).toContain('authUrl must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { baseUrl: 1 } }).error).toContain('baseUrl must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { resourceGroup: 1 } }).error).toContain('resourceGroup must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { model: 1 } }).error).toContain('model must be a string');
+            expect(validateConfigUpdate({ sapAiCore: { timeoutMs: -5 } }).error).toContain('timeoutMs must be a non-negative');
+            expect(validateConfigUpdate({ sapAiCore: { timeoutMs: 'x' } }).valid).toBe(false);
+        });
+    });
+
+    describe('modelTiering', () => {
+        it('should reject non-object', () => {
+            expect(validateConfigUpdate({ modelTiering: 'x' }).error).toBe('modelTiering must be an object');
+            expect(validateConfigUpdate({ modelTiering: null }).valid).toBe(false);
+        });
+
+        it('should validate enabled', () => {
+            expect(validateConfigUpdate({ modelTiering: { enabled: true } }).valid).toBe(true);
+            expect(validateConfigUpdate({ modelTiering: { enabled: 'x' } }).error).toContain('enabled must be a boolean');
+        });
+
+        it('should validate tiers object', () => {
+            const r = validateConfigUpdate({
+                modelTiering: { enabled: true, tiers: { low: '  haiku  ', medium: 'sonnet', high: 'opus' } }
+            });
+            expect(r.valid).toBe(true);
+            // values are trimmed
+            expect(r.data?.modelTiering?.tiers?.low).toBe('haiku');
+            expect(r.data?.modelTiering?.tiers?.high).toBe('opus');
+        });
+
+        it('should reject non-object tiers', () => {
+            expect(validateConfigUpdate({ modelTiering: { tiers: 'x' } }).error).toContain('tiers must be an object');
+            expect(validateConfigUpdate({ modelTiering: { tiers: null } }).valid).toBe(false);
+        });
+
+        it('should reject non-string tier value', () => {
+            expect(validateConfigUpdate({ modelTiering: { tiers: { low: 123 } } }).error).toContain('low must be a string');
+        });
+
+        it('should reject overly long tier value', () => {
+            const res = validateConfigUpdate({ modelTiering: { tiers: { medium: 'a'.repeat(201) } } });
+            expect(res.valid).toBe(false);
+            expect(res.error).toContain('medium too long');
+        });
+    });
+
     it('should validate multiple config fields at once', () => {
         const result = validateConfigUpdate({
             rules: 'test rules',
@@ -310,6 +522,19 @@ describe('validateWorkspacePath', () => {
             // Either doesn't exist or is blocked
             expect(result.valid).toBe(false);
         }
+    });
+
+    it('should handle relative paths that resolve differently', () => {
+        // A relative path (no `..`) gets resolved against cwd; if it does not
+        // exist this surfaces as a non-existent path rather than passing.
+        const res = validateWorkspacePath('some-relative-nonexistent-dir');
+        expect(res.valid).toBe(false);
+    });
+
+    it('should reject /usr non-local system path', () => {
+        const res = validateWorkspacePath('/usr/bin');
+        expect(res.valid).toBe(false);
+        expect(res.error).toContain('not allowed');
     });
 
     it('should allow /usr/local paths', () => {

--- a/backend/src/__tests__/validation.test.ts
+++ b/backend/src/__tests__/validation.test.ts
@@ -534,7 +534,12 @@ describe('validateWorkspacePath', () => {
     it('should reject /usr non-local system path', () => {
         const res = validateWorkspacePath('/usr/bin');
         expect(res.valid).toBe(false);
-        expect(res.error).toContain('not allowed');
+        // On Unix /usr/bin exists and is blocked as a system path ('not
+        // allowed'). On Windows it does not exist, so it is rejected earlier
+        // with 'Path does not exist' — both are valid rejections.
+        if (existsSync('/usr/bin')) {
+            expect(res.error).toContain('not allowed');
+        }
     });
 
     it('should allow /usr/local paths', () => {

--- a/backend/src/__tests__/workspace-store.test.ts
+++ b/backend/src/__tests__/workspace-store.test.ts
@@ -428,4 +428,196 @@ describe('WorkspaceStore', () => {
             expect(found?.displayName).toBe('Listed Name');
         });
     });
+
+    describe('addWorkspace directory creation', () => {
+        it('should create a directory that does not yet exist', () => {
+            const newDir = join(testBaseDir, 'created-by-store');
+            expect(existsSync(newDir)).toBe(false);
+
+            const workspace = store.addWorkspace(newDir);
+            expect(existsSync(newDir)).toBe(true);
+            expect(workspace.id).toBe(newDir);
+            expect(workspace.name).toBe('created-by-store');
+        });
+    });
+
+    describe('setWorkspaceOrder', () => {
+        it('should apply an explicit order', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addWorkspace(testWorkspace2);
+
+            const result = store.setWorkspaceOrder([testWorkspace2, testWorkspace1]);
+            expect(result).toBe(true);
+
+            const order = store.getWorkspaces().map(w => w.id);
+            expect(order).toEqual([testWorkspace2, testWorkspace1]);
+        });
+
+        it('should append unknown workspaces at the end preserving them', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addWorkspace(testWorkspace2);
+
+            // Client only knows about testWorkspace2; testWorkspace1 should be preserved.
+            const result = store.setWorkspaceOrder([testWorkspace2]);
+            expect(result).toBe(true);
+
+            const order = store.getWorkspaces().map(w => w.id);
+            expect(order[0]).toBe(testWorkspace2);
+            expect(order).toContain(testWorkspace1);
+            expect(order.length).toBe(2);
+        });
+
+        it('should ignore unknown ids and duplicates in input', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addWorkspace(testWorkspace2);
+
+            const result = store.setWorkspaceOrder([
+                testWorkspace2,
+                '/unknown/path',
+                testWorkspace2, // duplicate
+                testWorkspace1,
+            ]);
+            expect(result).toBe(true);
+
+            const order = store.getWorkspaces().map(w => w.id);
+            expect(order).toEqual([testWorkspace2, testWorkspace1]);
+        });
+
+        it('should persist the explicit order', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addWorkspace(testWorkspace2);
+            store.setWorkspaceOrder([testWorkspace2, testWorkspace1]);
+
+            const newStore = new WorkspaceStore(testBaseDir);
+            const order = newStore.getWorkspaces().map(w => w.id);
+            expect(order).toEqual([testWorkspace2, testWorkspace1]);
+        });
+    });
+
+    describe('lastBrowsedPath', () => {
+        it('should return undefined by default', () => {
+            expect(store.getLastBrowsedPath()).toBeUndefined();
+        });
+
+        it('should set and get the last browsed path', () => {
+            store.setLastBrowsedPath('/some/browsed/dir');
+            expect(store.getLastBrowsedPath()).toBe('/some/browsed/dir');
+        });
+
+        it('should persist the last browsed path', () => {
+            store.setLastBrowsedPath('/persisted/dir');
+            const newStore = new WorkspaceStore(testBaseDir);
+            expect(newStore.getLastBrowsedPath()).toBe('/persisted/dir');
+        });
+    });
+
+    describe('references', () => {
+        it('should return empty references for a workspace with none', () => {
+            store.addWorkspace(testWorkspace1);
+            expect(store.getReferences(testWorkspace1)).toEqual([]);
+        });
+
+        it('should return empty references for non-existent workspace', () => {
+            expect(store.getReferences('/non/existent')).toEqual([]);
+        });
+
+        it('should add a reference', () => {
+            store.addWorkspace(testWorkspace1);
+            const ref = store.addReference(testWorkspace1, testWorkspace2, 'shared lib');
+
+            expect(ref.id).toBeDefined();
+            expect(ref.path).toBe(testWorkspace2);
+            expect(ref.name).toBe('workspace2');
+            expect(ref.description).toBe('shared lib');
+
+            const refs = store.getReferences(testWorkspace1);
+            expect(refs.length).toBe(1);
+            expect(refs[0].path).toBe(testWorkspace2);
+        });
+
+        it('should throw when adding reference to non-existent workspace', () => {
+            expect(() => {
+                store.addReference('/non/existent', testWorkspace2);
+            }).toThrow('Workspace not found');
+        });
+
+        it('should throw when referenced directory does not exist', () => {
+            store.addWorkspace(testWorkspace1);
+            expect(() => {
+                store.addReference(testWorkspace1, join(testBaseDir, 'no-such-dir'));
+            }).toThrow('Directory does not exist');
+        });
+
+        it('should throw on duplicate reference', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addReference(testWorkspace1, testWorkspace2);
+            expect(() => {
+                store.addReference(testWorkspace1, testWorkspace2);
+            }).toThrow('Reference already exists');
+        });
+
+        it('should throw when referencing itself', () => {
+            store.addWorkspace(testWorkspace1);
+            expect(() => {
+                store.addReference(testWorkspace1, testWorkspace1);
+            }).toThrow('Cannot reference the same workspace');
+        });
+
+        it('should remove a reference by id', () => {
+            store.addWorkspace(testWorkspace1);
+            const ref = store.addReference(testWorkspace1, testWorkspace2);
+
+            const result = store.removeReference(testWorkspace1, ref.id);
+            expect(result).toBe(true);
+            expect(store.getReferences(testWorkspace1)).toEqual([]);
+        });
+
+        it('should return false removing reference from workspace with none', () => {
+            store.addWorkspace(testWorkspace1);
+            expect(store.removeReference(testWorkspace1, 'no-id')).toBe(false);
+        });
+
+        it('should return false removing reference with unknown id', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addReference(testWorkspace1, testWorkspace2);
+            expect(store.removeReference(testWorkspace1, 'unknown-id')).toBe(false);
+        });
+
+        it('should return false removing reference from non-existent workspace', () => {
+            expect(store.removeReference('/non/existent', 'id')).toBe(false);
+        });
+
+        it('should remove a reference by path', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addReference(testWorkspace1, testWorkspace2);
+
+            const result = store.removeReferenceByPath(testWorkspace1, testWorkspace2);
+            expect(result).toBe(true);
+            expect(store.getReferences(testWorkspace1)).toEqual([]);
+        });
+
+        it('should return false removing by path when not present', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addReference(testWorkspace1, testWorkspace2);
+            const otherDir = join(testBaseDir, 'workspace3');
+            mkdirSync(otherDir, { recursive: true });
+            expect(store.removeReferenceByPath(testWorkspace1, otherDir)).toBe(false);
+        });
+
+        it('should return false removing by path from workspace with no references', () => {
+            store.addWorkspace(testWorkspace1);
+            expect(store.removeReferenceByPath(testWorkspace1, testWorkspace2)).toBe(false);
+        });
+
+        it('should persist references to file', () => {
+            store.addWorkspace(testWorkspace1);
+            store.addReference(testWorkspace1, testWorkspace2, 'desc');
+
+            const newStore = new WorkspaceStore(testBaseDir);
+            const refs = newStore.getReferences(testWorkspace1);
+            expect(refs.length).toBe(1);
+            expect(refs[0].path).toBe(testWorkspace2);
+            expect(refs[0].description).toBe('desc');
+        });
+    });
 });

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -12,9 +12,31 @@ export default defineConfig({
             exclude: [
                 'node_modules/',
                 'dist/',
-                'test-cli.ts',
+                'plugins/**',
+                'test-*.ts',
+                '*.config.ts',
                 '**/*.d.ts',
             ],
+            // Per-file regression gate: floors set just below the coverage
+            // achieved by the suite. Only the modules listed here are gated,
+            // so unrelated feature work that adds new files is not blocked.
+            // Raise these as coverage improves; never lower them.
+            thresholds: {
+                'src/validation.ts': { lines: 95 },
+                'src/conversation-parser.ts': { lines: 95 },
+                'src/git-utils.ts': { lines: 80 },
+                'src/workspace-store.ts': { lines: 90 },
+                'src/task-persistence.ts': { lines: 80 },
+                'src/learnings-store.ts': { lines: 88 },
+                'src/usage-reporter.ts': { lines: 38 },
+                'src/utils/atomic-write.ts': { lines: 88 },
+                'src/utils/schema-version.ts': { lines: 80 },
+                'src/plugin-system/plugin-registry.ts': { lines: 95 },
+                'src/ring-buffer.ts': { lines: 100 },
+                'src/token-parser.ts': { lines: 90 },
+                'src/task-state-detection.ts': { lines: 90 },
+                'src/config-store.ts': { lines: 85 },
+            },
         },
         testTimeout: 10000,
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "jsdom": "^27.4.0",
     "typescript": "^5.3.3",
     "vite": "^8.0.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "@vitest/coverage-v8": "^4.0.17"
   }
 }

--- a/frontend/src/config/__tests__/api-config.test.ts
+++ b/frontend/src/config/__tests__/api-config.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    isTunnelAccess,
+    getMobileToken,
+    getApiBaseUrl,
+    getWebSocketUrl,
+    isElectron,
+} from '../api-config';
+import { PORTS } from '@claudia/shared';
+
+/**
+ * Override window.location with a partial location object.
+ * jsdom's window.location is not directly assignable, so we redefine it.
+ */
+function setLocation(partial: Partial<Location>) {
+    const base: any = {
+        hostname: 'localhost',
+        host: 'localhost:5173',
+        origin: 'http://localhost:5173',
+        protocol: 'http:',
+        search: '',
+    };
+    Object.defineProperty(window, 'location', {
+        value: { ...base, ...partial },
+        configurable: true,
+        writable: true,
+    });
+}
+
+function clearElectron() {
+    delete (window as any).electronAPI;
+}
+
+describe('api-config', () => {
+    beforeEach(() => {
+        clearElectron();
+        setLocation({});
+    });
+
+    afterEach(() => {
+        clearElectron();
+    });
+
+    describe('isTunnelAccess', () => {
+        it('returns false for localhost', () => {
+            setLocation({ hostname: 'localhost' });
+            expect(isTunnelAccess()).toBe(false);
+        });
+
+        it('detects .loca.lt', () => {
+            setLocation({ hostname: 'myapp.loca.lt' });
+            expect(isTunnelAccess()).toBe(true);
+        });
+
+        it('detects ngrok-free.app', () => {
+            setLocation({ hostname: 'abc.ngrok-free.app' });
+            expect(isTunnelAccess()).toBe(true);
+        });
+
+        it('detects ngrok.io', () => {
+            setLocation({ hostname: 'abc.ngrok.io' });
+            expect(isTunnelAccess()).toBe(true);
+        });
+
+        it('detects generic ngrok host', () => {
+            setLocation({ hostname: 'foo.ngrok.example' });
+            expect(isTunnelAccess()).toBe(true);
+        });
+    });
+
+    describe('getMobileToken', () => {
+        it('returns null when no token param', () => {
+            setLocation({ search: '' });
+            expect(getMobileToken()).toBeNull();
+        });
+
+        it('extracts the token param', () => {
+            setLocation({ search: '?token=abc123&mobile=1' });
+            expect(getMobileToken()).toBe('abc123');
+        });
+    });
+
+    describe('isElectron', () => {
+        it('returns false without electronAPI', () => {
+            expect(isElectron()).toBe(false);
+        });
+
+        it('returns true with electronAPI', () => {
+            (window as any).electronAPI = { getBackendUrl: () => 'http://x' };
+            expect(isElectron()).toBe(true);
+        });
+    });
+
+    describe('getApiBaseUrl', () => {
+        it('uses electron backend url when in electron', () => {
+            (window as any).electronAPI = { getBackendUrl: () => 'http://127.0.0.1:9999' };
+            expect(getApiBaseUrl()).toBe('http://127.0.0.1:9999');
+        });
+
+        it('uses origin for tunnel access', () => {
+            setLocation({ hostname: 'app.loca.lt', origin: 'https://app.loca.lt' });
+            expect(getApiBaseUrl()).toBe('https://app.loca.lt');
+        });
+
+        it('uses hostname + backend port for web', () => {
+            setLocation({ hostname: 'myhost' });
+            expect(getApiBaseUrl()).toBe(`http://myhost:${PORTS.BACKEND}`);
+        });
+    });
+
+    describe('getWebSocketUrl', () => {
+        it('converts electron http url to ws', () => {
+            (window as any).electronAPI = { getBackendUrl: () => 'http://127.0.0.1:9999' };
+            expect(getWebSocketUrl()).toBe('ws://127.0.0.1:9999');
+        });
+
+        it('uses wss for https tunnel with token', () => {
+            setLocation({
+                hostname: 'app.loca.lt',
+                host: 'app.loca.lt',
+                protocol: 'https:',
+                search: '?token=tok99',
+            });
+            expect(getWebSocketUrl()).toBe('wss://app.loca.lt?token=tok99&mobile=1');
+        });
+
+        it('uses ws for http tunnel without token', () => {
+            setLocation({
+                hostname: 'app.loca.lt',
+                host: 'app.loca.lt',
+                protocol: 'http:',
+                search: '',
+            });
+            expect(getWebSocketUrl()).toBe('ws://app.loca.lt');
+        });
+
+        it('uses hostname + backend port for web', () => {
+            setLocation({ hostname: 'myhost' });
+            expect(getWebSocketUrl()).toBe(`ws://myhost:${PORTS.BACKEND}`);
+        });
+    });
+});

--- a/frontend/src/hooks/__tests__/useTheme.test.ts
+++ b/frontend/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { useTheme, useEffectiveTheme } from '../useTheme';
+import { useTaskStore } from '../../stores/taskStore';
+
+/**
+ * Minimal renderHook implementation built on react-dom directly.
+ * `@testing-library/react`'s renderHook requires `@testing-library/dom`
+ * which is not installed in this project, so we provide a small equivalent.
+ */
+const activeRoots = new Set<{ root: Root; container: HTMLElement }>();
+
+function renderHook<T>(hook: () => T): { result: { current: T }; rerender: () => void; unmount: () => void } {
+    const result = { current: undefined as unknown as T };
+    let root: Root;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    function TestComponent() {
+        result.current = hook();
+        return null;
+    }
+
+    act(() => {
+        root = createRoot(container);
+        root.render(React.createElement(TestComponent));
+    });
+
+    const entry = { root: root!, container };
+    activeRoots.add(entry);
+
+    const unmount = () => {
+        if (!activeRoots.has(entry)) return;
+        act(() => {
+            entry.root.unmount();
+        });
+        entry.container.remove();
+        activeRoots.delete(entry);
+    };
+
+    return {
+        result,
+        rerender: () => {
+            act(() => {
+                root.render(React.createElement(TestComponent));
+            });
+        },
+        unmount,
+    };
+}
+
+function unmountAll() {
+    for (const entry of Array.from(activeRoots)) {
+        act(() => {
+            entry.root.unmount();
+        });
+        entry.container.remove();
+        activeRoots.delete(entry);
+    }
+}
+
+/**
+ * Controllable matchMedia mock. `matches` corresponds to
+ * '(prefers-color-scheme: light)'. We capture the change handler so tests
+ * can simulate the OS theme changing.
+ */
+function installMatchMedia(initialLight: boolean) {
+    let matches = initialLight;
+    const listeners = new Set<(e: MediaQueryListEvent) => void>();
+    const mql = {
+        get matches() {
+            return matches;
+        },
+        media: '(prefers-color-scheme: light)',
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: (_type: string, cb: (e: MediaQueryListEvent) => void) => {
+            listeners.add(cb);
+        },
+        removeEventListener: (_type: string, cb: (e: MediaQueryListEvent) => void) => {
+            listeners.delete(cb);
+        },
+        dispatchEvent: () => false,
+    };
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: vi.fn(() => mql),
+    });
+    return {
+        setMatches(v: boolean) {
+            matches = v;
+            const evt = { matches: v } as MediaQueryListEvent;
+            act(() => {
+                listeners.forEach(cb => cb(evt));
+            });
+        },
+        listenerCount: () => listeners.size,
+    };
+}
+
+function setPreference(pref: 'light' | 'dark' | 'system') {
+    act(() => {
+        useTaskStore.setState({ themePreference: pref });
+    });
+}
+
+describe('useTheme', () => {
+    beforeEach(() => {
+        useTaskStore.setState({ themePreference: 'system' });
+        document.documentElement.removeAttribute('data-theme');
+    });
+
+    afterEach(() => {
+        unmountAll();
+        document.documentElement.removeAttribute('data-theme');
+    });
+
+    describe('useTheme (with DOM side effects)', () => {
+        it('uses explicit dark preference and sets data-theme', () => {
+            installMatchMedia(true); // system says light, but preference overrides
+            setPreference('dark');
+            const { result } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('dark');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        });
+
+        it('uses explicit light preference and sets data-theme', () => {
+            installMatchMedia(false);
+            setPreference('light');
+            const { result } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('light');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+        });
+
+        it('resolves system preference to light when OS prefers light', () => {
+            installMatchMedia(true);
+            setPreference('system');
+            const { result } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('light');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+        });
+
+        it('resolves system preference to dark when OS prefers dark', () => {
+            installMatchMedia(false);
+            setPreference('system');
+            const { result } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('dark');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        });
+
+        it('reacts to OS theme change while in system mode', () => {
+            const mm = installMatchMedia(false); // start dark
+            setPreference('system');
+            const { result } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('dark');
+
+            mm.setMatches(true); // OS switches to light
+            expect(result.current.effectiveTheme).toBe('light');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+        });
+
+        it('removes the media listener on unmount', () => {
+            const mm = installMatchMedia(true);
+            setPreference('system');
+            const { unmount } = renderHook(() => useTheme());
+            expect(mm.listenerCount()).toBe(1);
+            unmount();
+            expect(mm.listenerCount()).toBe(0);
+        });
+
+        it('does not attach media listener for explicit preference', () => {
+            const mm = installMatchMedia(true);
+            setPreference('dark');
+            renderHook(() => useTheme());
+            expect(mm.listenerCount()).toBe(0);
+        });
+
+        it('updates when preference changes from system to light', () => {
+            installMatchMedia(false); // system => dark
+            setPreference('system');
+            const { result, rerender } = renderHook(() => useTheme());
+            expect(result.current.effectiveTheme).toBe('dark');
+
+            setPreference('light');
+            rerender();
+            expect(result.current.effectiveTheme).toBe('light');
+            expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+        });
+    });
+
+    describe('useEffectiveTheme (no DOM side effects)', () => {
+        it('resolves explicit preference without touching data-theme', () => {
+            installMatchMedia(true);
+            setPreference('dark');
+            const { result } = renderHook(() => useEffectiveTheme());
+            expect(result.current).toBe('dark');
+            expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+        });
+
+        it('resolves system preference based on matchMedia', () => {
+            installMatchMedia(true);
+            setPreference('system');
+            const { result } = renderHook(() => useEffectiveTheme());
+            expect(result.current).toBe('light');
+            expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+        });
+
+        it('reacts to OS theme change in system mode', () => {
+            const mm = installMatchMedia(true); // light
+            setPreference('system');
+            const { result } = renderHook(() => useEffectiveTheme());
+            expect(result.current).toBe('light');
+
+            mm.setMatches(false);
+            expect(result.current).toBe('dark');
+        });
+
+        it('cleans up listener on unmount', () => {
+            const mm = installMatchMedia(false);
+            setPreference('system');
+            const { unmount } = renderHook(() => useEffectiveTheme());
+            expect(mm.listenerCount()).toBe(1);
+            unmount();
+            expect(mm.listenerCount()).toBe(0);
+        });
+    });
+});

--- a/frontend/src/services/__tests__/filePickerService.test.ts
+++ b/frontend/src/services/__tests__/filePickerService.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    selectDirectory,
+    isDirectorySelectionAvailable,
+    getDirectorySelectionInfo,
+} from '../filePickerService';
+
+function clearGlobals() {
+    delete (window as any).electronAPI;
+    delete (window as any).showDirectoryPicker;
+}
+
+describe('filePickerService', () => {
+    beforeEach(() => {
+        clearGlobals();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        clearGlobals();
+        vi.restoreAllMocks();
+    });
+
+    describe('selectDirectory - electron', () => {
+        it('returns success with selected path', async () => {
+            (window as any).electronAPI = { selectDirectory: vi.fn().mockResolvedValue('/Users/me/proj') };
+            const r = await selectDirectory();
+            expect(r).toEqual({ success: true, path: '/Users/me/proj' });
+        });
+
+        it('returns cancelled when no path returned', async () => {
+            (window as any).electronAPI = { selectDirectory: vi.fn().mockResolvedValue(null) };
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('cancelled');
+        });
+
+        it('returns unknown error when selectDirectory throws', async () => {
+            (window as any).electronAPI = { selectDirectory: vi.fn().mockRejectedValue(new Error('boom')) };
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('unknown');
+            expect(r.error?.message).toBe('boom');
+            expect(r.error?.originalError).toBeInstanceOf(Error);
+        });
+
+        it('returns unsupported when electronAPI present at method-detect but missing at call (edge)', async () => {
+            // getDirectorySelectionMethod sees electronAPI; selectDirectoryElectron also checks it.
+            // Define electronAPI with selectDirectory so it routes to electron, then ensure the
+            // guard path is covered by deleting selectDirectory implementation.
+            (window as any).electronAPI = {};
+            // electron branch is selected (electronAPI truthy) but selectDirectory is undefined -> throws -> unknown
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('unknown');
+        });
+    });
+
+    describe('selectDirectory - filesystem-api', () => {
+        it('returns success with directory name', async () => {
+            (window as any).showDirectoryPicker = vi.fn().mockResolvedValue({ name: 'my-folder' });
+            const r = await selectDirectory();
+            expect(r).toEqual({ success: true, path: 'my-folder' });
+        });
+
+        it('returns cancelled when picker resolves falsy', async () => {
+            (window as any).showDirectoryPicker = vi.fn().mockResolvedValue(null);
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('cancelled');
+        });
+
+        it('maps AbortError to cancelled', async () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            (window as any).showDirectoryPicker = vi.fn().mockRejectedValue(err);
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('cancelled');
+        });
+
+        it('maps NotAllowedError to permission-denied', async () => {
+            const err = new Error('denied');
+            err.name = 'NotAllowedError';
+            (window as any).showDirectoryPicker = vi.fn().mockRejectedValue(err);
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('permission-denied');
+        });
+
+        it('maps SecurityError to permission-denied', async () => {
+            const err = new Error('sec');
+            err.name = 'SecurityError';
+            (window as any).showDirectoryPicker = vi.fn().mockRejectedValue(err);
+            const r = await selectDirectory();
+            expect(r.error?.type).toBe('permission-denied');
+        });
+
+        it('maps other errors to unknown', async () => {
+            const err = new Error('weird');
+            err.name = 'WeirdError';
+            (window as any).showDirectoryPicker = vi.fn().mockRejectedValue(err);
+            const r = await selectDirectory();
+            expect(r.error?.type).toBe('unknown');
+            expect(r.error?.message).toBe('weird');
+        });
+    });
+
+    describe('selectDirectory - none', () => {
+        it('returns unsupported when no method available', async () => {
+            const r = await selectDirectory();
+            expect(r.success).toBe(false);
+            expect(r.error?.type).toBe('unsupported');
+            expect(r.error?.message).toContain('Directory selection');
+        });
+    });
+
+    describe('isDirectorySelectionAvailable', () => {
+        it('false when nothing available', () => {
+            expect(isDirectorySelectionAvailable()).toBe(false);
+        });
+
+        it('true in electron', () => {
+            (window as any).electronAPI = {};
+            expect(isDirectorySelectionAvailable()).toBe(true);
+        });
+
+        it('true with filesystem api', () => {
+            (window as any).showDirectoryPicker = () => {};
+            expect(isDirectorySelectionAvailable()).toBe(true);
+        });
+    });
+
+    describe('getDirectorySelectionInfo', () => {
+        it('reports electron', () => {
+            (window as any).electronAPI = {};
+            const info = getDirectorySelectionInfo();
+            expect(info).toEqual({
+                available: true,
+                method: 'electron',
+                message: 'Using Electron native directory picker',
+            });
+        });
+
+        it('reports filesystem-api', () => {
+            (window as any).showDirectoryPicker = () => {};
+            const info = getDirectorySelectionInfo();
+            expect(info.method).toBe('filesystem-api');
+            expect(info.available).toBe(true);
+            expect(info.message).toContain('File System Access API');
+        });
+
+        it('reports none with unsupported message', () => {
+            const info = getDirectorySelectionInfo();
+            expect(info.method).toBe('none');
+            expect(info.available).toBe(false);
+            expect(info.message).toContain('Directory selection');
+        });
+    });
+});

--- a/frontend/src/utils/__tests__/browserCapabilities.test.ts
+++ b/frontend/src/utils/__tests__/browserCapabilities.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    isElectron,
+    hasFileSystemAccess,
+    getDirectorySelectionMethod,
+    hasClipboardAPI,
+    getUnsupportedFeatureMessage,
+    getBrowserCapabilities,
+    hasBrowserNotifications,
+    getNotificationPermission,
+    requestNotificationPermission,
+    sendBrowserNotification,
+    sendTaskCompletionNotification,
+    sendTaskWaitingInputNotification,
+    isSoundEnabled,
+    setSoundEnabled,
+    setupAudioUnlock,
+    playTaskCompletionSound,
+    playTestSound,
+} from '../browserCapabilities';
+
+// Helpers to set / clear globals safely
+function setWindowProp(prop: string, value: unknown) {
+    Object.defineProperty(window, prop, { value, configurable: true, writable: true });
+}
+function deleteWindowProp(prop: string) {
+    // delete works because we defined props as configurable
+    delete (window as any)[prop];
+}
+
+describe('browserCapabilities', () => {
+    beforeEach(() => {
+        deleteWindowProp('electronAPI');
+        deleteWindowProp('showDirectoryPicker');
+        localStorage.clear();
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        deleteWindowProp('electronAPI');
+        deleteWindowProp('showDirectoryPicker');
+        deleteWindowProp('Notification');
+        vi.restoreAllMocks();
+    });
+
+    describe('isElectron', () => {
+        it('returns false when electronAPI is undefined', () => {
+            expect(isElectron()).toBe(false);
+        });
+
+        it('returns true when electronAPI is defined', () => {
+            setWindowProp('electronAPI', { getBackendUrl: () => 'x' });
+            expect(isElectron()).toBe(true);
+        });
+    });
+
+    describe('hasFileSystemAccess', () => {
+        it('returns false when showDirectoryPicker is absent', () => {
+            expect(hasFileSystemAccess()).toBe(false);
+        });
+
+        it('returns true when showDirectoryPicker is a function', () => {
+            setWindowProp('showDirectoryPicker', () => {});
+            expect(hasFileSystemAccess()).toBe(true);
+        });
+
+        it('returns false when showDirectoryPicker exists but is not a function', () => {
+            setWindowProp('showDirectoryPicker', 'not-a-fn');
+            expect(hasFileSystemAccess()).toBe(false);
+        });
+    });
+
+    describe('getDirectorySelectionMethod', () => {
+        it('returns electron when in electron', () => {
+            setWindowProp('electronAPI', {});
+            expect(getDirectorySelectionMethod()).toBe('electron');
+        });
+
+        it('returns filesystem-api when FS access available (no electron)', () => {
+            setWindowProp('showDirectoryPicker', () => {});
+            expect(getDirectorySelectionMethod()).toBe('filesystem-api');
+        });
+
+        it('returns none when nothing available', () => {
+            expect(getDirectorySelectionMethod()).toBe('none');
+        });
+    });
+
+    describe('hasClipboardAPI', () => {
+        it('returns true when clipboard.writeText is a function (jsdom default may vary)', () => {
+            const orig = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+            Object.defineProperty(navigator, 'clipboard', {
+                value: { writeText: () => Promise.resolve() },
+                configurable: true,
+            });
+            expect(hasClipboardAPI()).toBe(true);
+            if (orig) Object.defineProperty(navigator, 'clipboard', orig);
+            else delete (navigator as any).clipboard;
+        });
+
+        it('returns false when clipboard is undefined', () => {
+            const orig = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+            Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+            expect(hasClipboardAPI()).toBe(false);
+            if (orig) Object.defineProperty(navigator, 'clipboard', orig);
+            else delete (navigator as any).clipboard;
+        });
+    });
+
+    describe('getUnsupportedFeatureMessage', () => {
+        it('returns specific message for directory-picker', () => {
+            expect(getUnsupportedFeatureMessage('directory-picker')).toContain('Directory selection');
+        });
+
+        it('returns specific message for clipboard', () => {
+            expect(getUnsupportedFeatureMessage('clipboard')).toContain('Clipboard access');
+        });
+
+        it('returns generic message for unknown feature', () => {
+            expect(getUnsupportedFeatureMessage('foo')).toContain('foo');
+        });
+    });
+
+    describe('getBrowserCapabilities', () => {
+        it('aggregates all capabilities', () => {
+            setWindowProp('electronAPI', {});
+            const caps = getBrowserCapabilities();
+            expect(caps.isElectron).toBe(true);
+            expect(caps.directorySelectionMethod).toBe('electron');
+            expect(typeof caps.hasFileSystemAccess).toBe('boolean');
+            expect(typeof caps.hasClipboardAPI).toBe('boolean');
+        });
+    });
+
+    describe('hasBrowserNotifications', () => {
+        it('returns false when Notification not in window', () => {
+            deleteWindowProp('Notification');
+            expect(hasBrowserNotifications()).toBe(false);
+        });
+
+        it('returns true when Notification in window', () => {
+            setWindowProp('Notification', function () {} as any);
+            expect(hasBrowserNotifications()).toBe(true);
+        });
+    });
+
+    describe('getNotificationPermission', () => {
+        it('returns unsupported when no Notification API', () => {
+            deleteWindowProp('Notification');
+            expect(getNotificationPermission()).toBe('unsupported');
+        });
+
+        it('returns the current permission value', () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+            expect(getNotificationPermission()).toBe('granted');
+        });
+    });
+
+    describe('requestNotificationPermission', () => {
+        it('returns unsupported when no Notification API', async () => {
+            deleteWindowProp('Notification');
+            await expect(requestNotificationPermission()).resolves.toBe('unsupported');
+        });
+
+        it('returns granted immediately when already granted', async () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'granted';
+            NotificationMock.requestPermission = vi.fn();
+            setWindowProp('Notification', NotificationMock);
+            await expect(requestNotificationPermission()).resolves.toBe('granted');
+            expect(NotificationMock.requestPermission).not.toHaveBeenCalled();
+        });
+
+        it('returns denied immediately when already denied', async () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'denied';
+            NotificationMock.requestPermission = vi.fn();
+            setWindowProp('Notification', NotificationMock);
+            await expect(requestNotificationPermission()).resolves.toBe('denied');
+            expect(NotificationMock.requestPermission).not.toHaveBeenCalled();
+        });
+
+        it('requests permission when default and returns result', async () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'default';
+            NotificationMock.requestPermission = vi.fn().mockResolvedValue('granted');
+            setWindowProp('Notification', NotificationMock);
+            await expect(requestNotificationPermission()).resolves.toBe('granted');
+            expect(NotificationMock.requestPermission).toHaveBeenCalled();
+        });
+
+        it('returns denied when requestPermission throws', async () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'default';
+            NotificationMock.requestPermission = vi.fn().mockRejectedValue(new Error('boom'));
+            setWindowProp('Notification', NotificationMock);
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            await expect(requestNotificationPermission()).resolves.toBe('denied');
+        });
+    });
+
+    describe('sendBrowserNotification', () => {
+        it('returns null when notifications unsupported', () => {
+            deleteWindowProp('Notification');
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            expect(sendBrowserNotification('Hi')).toBeNull();
+        });
+
+        it('returns null when permission not granted', () => {
+            const NotificationMock: any = function () {};
+            NotificationMock.permission = 'default';
+            setWindowProp('Notification', NotificationMock);
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            expect(sendBrowserNotification('Hi')).toBeNull();
+        });
+
+        it('creates and returns a Notification when granted', () => {
+            const instances: any[] = [];
+            const NotificationMock: any = function (this: any, title: string, opts: any) {
+                this.title = title;
+                this.options = opts;
+                this.close = vi.fn();
+                instances.push(this);
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+
+            const n = sendBrowserNotification('Hello', { body: 'World' });
+            expect(n).not.toBeNull();
+            expect(instances).toHaveLength(1);
+            expect(instances[0].title).toBe('Hello');
+            expect(typeof (n as any).onclick).toBe('function');
+        });
+
+        it('dispatches taskClick event on click when data.taskId present', () => {
+            const NotificationMock: any = function (this: any) {
+                this.close = vi.fn();
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+            const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {});
+            const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+            const n = sendBrowserNotification('T', { data: { taskId: 'task-9' } });
+            (n as any).onclick();
+
+            expect(focusSpy).toHaveBeenCalled();
+            const evt = dispatchSpy.mock.calls.find(c => (c[0] as CustomEvent).type === 'notification:taskClick');
+            expect(evt).toBeDefined();
+            expect((evt![0] as CustomEvent).detail).toEqual({ taskId: 'task-9' });
+        });
+
+        it('returns null when Notification constructor throws', () => {
+            const NotificationMock: any = function () { throw new Error('nope'); };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            expect(sendBrowserNotification('X')).toBeNull();
+        });
+    });
+
+    describe('sendTaskCompletionNotification', () => {
+        function grantNotifications() {
+            const NotificationMock: any = function (this: any, title: string, opts: any) {
+                this.title = title;
+                this.options = opts;
+                this.close = vi.fn();
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+        }
+
+        it('returns true and uses task name + last message', () => {
+            grantNotifications();
+            expect(sendTaskCompletionNotification({ taskName: 'Build', lastMessage: 'done', taskId: 't1' })).toBe(true);
+        });
+
+        it('returns false when notifications unsupported', () => {
+            deleteWindowProp('Notification');
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            expect(sendTaskCompletionNotification({ taskName: 'Build' })).toBe(false);
+        });
+
+        it('truncates long task name and message', () => {
+            let captured: any;
+            const NotificationMock: any = function (this: any, title: string, opts: any) {
+                captured = { title, opts };
+                this.close = vi.fn();
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+
+            const longName = 'a'.repeat(100);
+            const longMsg = 'b'.repeat(300);
+            sendTaskCompletionNotification({ taskName: longName, lastMessage: longMsg });
+            expect(captured.title.endsWith('...')).toBe(true);
+            expect(captured.title.length).toBe(63); // 60 + '...'
+            expect(captured.opts.body.endsWith('...')).toBe(true);
+            expect(captured.opts.body.length).toBe(203); // 200 + '...'
+        });
+
+        it('falls back to defaults when no name/message', () => {
+            let captured: any;
+            const NotificationMock: any = function (this: any, title: string, opts: any) {
+                captured = { title, opts };
+                this.close = vi.fn();
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+            sendTaskCompletionNotification({});
+            expect(captured.title).toBe('Task Complete');
+            expect(captured.opts.body).toBe('Task finished executing');
+        });
+    });
+
+    describe('sendTaskWaitingInputNotification', () => {
+        function capture(): { get: () => any } {
+            const box: any = {};
+            const NotificationMock: any = function (this: any, title: string, opts: any) {
+                box.title = title;
+                box.opts = opts;
+                this.close = vi.fn();
+            };
+            NotificationMock.permission = 'granted';
+            setWindowProp('Notification', NotificationMock);
+            return { get: () => box };
+        }
+
+        it('labels permission input type', () => {
+            const c = capture();
+            sendTaskWaitingInputNotification({ taskName: 'X', inputType: 'permission' });
+            expect(c.get().title).toContain('Needs Permission');
+        });
+
+        it('labels question input type', () => {
+            const c = capture();
+            sendTaskWaitingInputNotification({ taskName: 'X', inputType: 'question' });
+            expect(c.get().title).toContain('Has a Question');
+        });
+
+        it('labels confirmation input type', () => {
+            const c = capture();
+            sendTaskWaitingInputNotification({ taskName: 'X', inputType: 'confirmation' });
+            expect(c.get().title).toContain('Needs Confirmation');
+        });
+
+        it('defaults to Needs Input and Task prefix without name', () => {
+            const c = capture();
+            const r = sendTaskWaitingInputNotification({});
+            expect(r).toBe(true);
+            expect(c.get().title).toBe('Task Needs Input');
+        });
+
+        it('takes the tail of long recentOutput', () => {
+            const c = capture();
+            const out = 'x'.repeat(100) + 'TAILMARK';
+            sendTaskWaitingInputNotification({ taskName: 'X', recentOutput: out.padEnd(200, 'y') });
+            expect(c.get().opts.body.length).toBe(150);
+        });
+    });
+
+    describe('sound playback', () => {
+        // The module caches a single persistent AudioContext. We install a mock
+        // AudioContext whose `state` we can flip to drive both code paths.
+        function makeOscillator() {
+            return {
+                type: '',
+                frequency: { setValueAtTime: vi.fn() },
+                connect: vi.fn(),
+                start: vi.fn(),
+                stop: vi.fn(),
+            };
+        }
+        function makeGain() {
+            return {
+                connect: vi.fn(),
+                gain: {
+                    setValueAtTime: vi.fn(),
+                    exponentialRampToValueAtTime: vi.fn(),
+                },
+            };
+        }
+
+        // The module caches ONE AudioContext for the whole process. We install a
+        // single shared mock whose `state` we mutate between tests.
+        let ctxState = 'running';
+        const sharedCtx: any = {
+            get state() { return ctxState; },
+            currentTime: 0,
+            destination: {},
+            resume: vi.fn().mockResolvedValue(undefined),
+            createOscillator: vi.fn(makeOscillator),
+            createGain: vi.fn(makeGain),
+        };
+
+        beforeEach(() => {
+            vi.spyOn(console, 'log').mockImplementation(() => {});
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            setSoundEnabled(true);
+            ctxState = 'running';
+            sharedCtx.resume.mockClear();
+            sharedCtx.createOscillator.mockClear();
+            sharedCtx.createGain.mockClear();
+            const AudioCtxMock: any = function () { return sharedCtx; };
+            setWindowProp('AudioContext', AudioCtxMock);
+            // Stub HTML Audio so suspended fallback path is safe
+            (global as any).Audio = vi.fn(() => ({ play: vi.fn().mockResolvedValue(undefined) }));
+            if (!(global as any).URL.createObjectURL) {
+                (global as any).URL.createObjectURL = vi.fn(() => 'blob:chime');
+            }
+        });
+
+        it('does nothing when sound disabled', () => {
+            setSoundEnabled(false);
+            playTaskCompletionSound();
+            expect(sharedCtx.createOscillator).not.toHaveBeenCalled();
+        });
+
+        it('plays via Web Audio when context is running', () => {
+            ctxState = 'running';
+            playTaskCompletionSound();
+            expect(sharedCtx.createOscillator).toHaveBeenCalledTimes(3);
+            expect(sharedCtx.createGain).toHaveBeenCalledTimes(3);
+        });
+
+        it('attempts resume + HTML Audio fallback when suspended', () => {
+            ctxState = 'suspended';
+            playTaskCompletionSound();
+            expect(sharedCtx.resume).toHaveBeenCalled();
+        });
+
+        it('playTestSound forces playback even if disabled', () => {
+            setSoundEnabled(false);
+            ctxState = 'running';
+            playTestSound();
+            expect(sharedCtx.createOscillator).toHaveBeenCalled();
+            expect(isSoundEnabled()).toBe(false);
+        });
+
+        it('setupAudioUnlock registers document listeners without throwing', () => {
+            const addSpy = vi.spyOn(document, 'addEventListener');
+            setupAudioUnlock();
+            const types = addSpy.mock.calls.map(c => c[0]);
+            expect(types).toContain('click');
+            expect(types).toContain('touchstart');
+        });
+    });
+
+    describe('isSoundEnabled / setSoundEnabled', () => {
+        // Note: the module caches sound state in a module-level variable.
+        // setSoundEnabled sets the cache directly so we drive it via that.
+        it('reflects value set via setSoundEnabled', () => {
+            setSoundEnabled(false);
+            expect(isSoundEnabled()).toBe(false);
+            expect(localStorage.getItem('claudia-completion-sound')).toBe('false');
+
+            setSoundEnabled(true);
+            expect(isSoundEnabled()).toBe(true);
+            expect(localStorage.getItem('claudia-completion-sound')).toBe('true');
+        });
+    });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -16,6 +16,16 @@ export default defineConfig({
                 'dist/',
                 '**/*.d.ts',
             ],
+            // Per-file regression gate: floors set just below achieved
+            // coverage. Only listed modules are gated, so new UI work is
+            // not blocked. Raise as coverage improves; never lower.
+            thresholds: {
+                'src/config/api-config.ts': { lines: 95 },
+                'src/hooks/useTheme.ts': { lines: 95 },
+                'src/services/filePickerService.ts': { lines: 85 },
+                'src/utils/browserCapabilities.ts': { lines: 85 },
+                'src/stores/taskStore.ts': { lines: 70 },
+            },
         },
     },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@extropolis/claudia",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@extropolis/claudia",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "bundleDependencies": [
         "@claudia/shared"
       ],
@@ -50,7 +50,7 @@
       }
     },
     "backend": {
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@claudia/shared": "*",
@@ -78,13 +78,14 @@
         "@types/node": "^20.11.0",
         "@types/uuid": "^9.0.7",
         "@types/ws": "^8.5.10",
+        "@vitest/coverage-v8": "^3.2.4",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
         "vitest": "^3.1.4"
       }
     },
     "frontend": {
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@claudia/shared": "*",
         "@types/qrcode": "^1.5.6",
@@ -106,51 +107,83 @@
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",
+        "@vitest/coverage-v8": "^4.0.17",
         "jsdom": "^27.4.0",
         "typescript": "^5.3.3",
         "vite": "^8.0.3",
         "vitest": "^4.0.17"
       }
     },
-    "frontend/node_modules/@vitest/expect": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
-      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
+    "frontend/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "frontend/node_modules/@vitest/pretty-format": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
-      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "frontend/node_modules/@vitest/runner": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
-      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.17",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -158,13 +191,14 @@
       }
     },
     "frontend/node_modules/@vitest/snapshot": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
-      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -173,9 +207,9 @@
       }
     },
     "frontend/node_modules/@vitest/spy": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
-      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -183,14 +217,15 @@
       }
     },
     "frontend/node_modules/@vitest/utils": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
-      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -206,6 +241,20 @@
         "node": ">=18"
       }
     },
+    "frontend/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "frontend/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "frontend/node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -217,9 +266,9 @@
       }
     },
     "frontend/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -305,31 +354,31 @@
       }
     },
     "frontend/node_modules/vitest": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
-      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.17",
-        "@vitest/mocker": "4.0.17",
-        "@vitest/pretty-format": "4.0.17",
-        "@vitest/runner": "4.0.17",
-        "@vitest/snapshot": "4.0.17",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -345,12 +394,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.17",
-        "@vitest/browser-preview": "4.0.17",
-        "@vitest/browser-webdriverio": "4.0.17",
-        "@vitest/ui": "4.0.17",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -371,6 +423,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -379,17 +437,20 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "frontend/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
-      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.17",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -398,88 +459,13 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
           "optional": true
         },
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "frontend/node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }
@@ -497,6 +483,20 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.71.2",
@@ -754,9 +754,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -798,13 +798,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -889,17 +889,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@claudia/shared": {
@@ -1609,6 +1619,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1626,6 +1637,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1643,6 +1655,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1660,6 +1673,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1677,6 +1691,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1694,6 +1709,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1711,6 +1727,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1728,6 +1745,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1745,6 +1763,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1762,6 +1781,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1779,6 +1799,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1796,6 +1817,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1813,6 +1835,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1830,6 +1853,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1847,6 +1871,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1864,6 +1889,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1881,6 +1907,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1898,6 +1925,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1915,6 +1943,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1932,6 +1961,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1949,6 +1979,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1966,6 +1997,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1983,6 +2015,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2000,6 +2033,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2017,6 +2051,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2034,6 +2069,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2192,6 +2228,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3092,9 +3138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3112,9 +3155,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3132,9 +3172,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3152,9 +3189,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3172,9 +3206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3192,9 +3223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,7 +3319,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.1",
@@ -3305,7 +3334,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
@@ -3319,7 +3349,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.1",
@@ -3333,7 +3364,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.1",
@@ -3347,7 +3379,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.1",
@@ -3361,7 +3394,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.1",
@@ -3371,14 +3405,12 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.1",
@@ -3388,14 +3420,12 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.1",
@@ -3405,14 +3435,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.1",
@@ -3422,14 +3450,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.1",
@@ -3439,14 +3465,12 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.1",
@@ -3456,14 +3480,12 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.1",
@@ -3473,14 +3495,12 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.1",
@@ -3490,14 +3510,12 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.1",
@@ -3507,14 +3525,12 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.1",
@@ -3524,14 +3540,12 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.1",
@@ -3541,14 +3555,12 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.1",
@@ -3558,14 +3570,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.1",
@@ -3575,14 +3585,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.1",
@@ -3596,7 +3604,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.1",
@@ -3610,7 +3619,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.1",
@@ -3624,7 +3634,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.1",
@@ -3638,7 +3649,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.1",
@@ -3652,7 +3664,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.1",
@@ -3666,7 +3679,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -4269,6 +4283,71 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -4771,6 +4850,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -7846,6 +7944,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-to-text": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
@@ -8215,6 +8320,73 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jackspeak": {
@@ -8638,9 +8810,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8662,9 +8831,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8686,9 +8852,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8710,9 +8873,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8951,6 +9111,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -12412,6 +12613,76 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -13506,7 +13777,7 @@
     },
     "shared": {
       "name": "@claudia/shared",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "devDependencies": {
         "typescript": "^5.3.3"
       }


### PR DESCRIPTION
## Summary

Fills the biggest test-coverage gaps before we land the other open PRs, and wires a **per-file coverage gate** into CI so the gains can't silently regress.

Suite size: **backend 333 → 516 tests**, **frontend 66 → 154 tests** (all green; full builds pass; `npm ci` verified clean cross-platform).

## Backend coverage

| Module | Before | After |
|--------|-------:|------:|
| `validation.ts` | 49% | 99% |
| `conversation-parser.ts` | 53% | 100% |
| `git-utils.ts` | 64% | 88% |
| `workspace-store.ts` | 64% | 96% |
| `utils/atomic-write.ts` | 57% | 94% |
| `task-persistence.ts` | 0% | 88% |
| `learnings-store.ts` | 4% | 93% |
| `plugin-system/plugin-registry.ts` | 0% | 100% |
| `usage-reporter.ts` | 0% | 40%¹ |

¹ The dashboard-POST path is unreachable from tests: `USAGE_DASHBOARD_URL` is captured into a module-level const at import time and is unset in the test env, so `reportUsage` short-circuits before `fetch`. All reachable code (guards, getters/setters) is exercised.

## Frontend coverage

| Module | Before | After |
|--------|-------:|------:|
| `config/api-config.ts` | 0% | 100% |
| `hooks/useTheme.ts` | 0% | 100% |
| `services/filePickerService.ts` | 0% | 92% |
| `utils/browserCapabilities.ts` | 0% | 91% |

## Tooling / CI gate

- Added `@vitest/coverage-v8` as a saved devDependency in both workspaces, pinned to each workspace's vitest major (backend `^3.2.4`, frontend `^4.0.17`).
- `package-lock.json` regenerated with `--package-lock-only` so Windows-only optional deps are **not** pruned; `npm ci` confirmed green.
- Per-file line thresholds in both `vitest.config.ts` files, set at conservative floors just below achieved coverage. **Only the listed modules are gated**, so unrelated feature PRs that add new files won't be blocked — raise the floors as coverage grows.
- CI **Automated Tests** now runs `test:coverage` for both workspaces, enforcing the thresholds on every PR.
- Excluded compiled plugin `.js` artifacts + root test scripts from the backend coverage report; added `coverage/` to `.gitignore`.

## Scope notes

This targets the high-value, cheaply-testable units. The very large files (`server.ts` ~5.7k lines, `mobile-page.ts`, `mcp-server.ts`, `task-spawner.ts`) aren't meaningfully unit-testable without refactoring seams and are intentionally out of scope here.

> Note: frontend `useTheme` tests use a tiny in-file `renderHook` over `react-dom/client` because the installed `@testing-library/react@16` has an unmet peer on `@testing-library/dom` (not present in `node_modules`). Adding that dep would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)